### PR TITLE
text given to suffix_array must have sentinel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! use bio::data_structures::bwt::bwt;
 //! use bio::data_structures::fmindex::FMIndex;
 //!
-//! let text = b"ACGGATGCTGGATCGGATCGCGCTAGCTA";
+//! let text = b"ACGGATGCTGGATCGGATCGCGCTAGCTA$";
 //! let pattern = b"ACCG";
 //!
 //! // Create an FM-Index for a given text.


### PR DESCRIPTION
example `text` string works without sentinel by coincidence. maybe error message in suffix_array.rs:162 could be more clear that a sentinel is expected on the input text?