### PR TITLE
More serde support for data structures + nightly on .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: rust
 rust:
   - stable
   - beta
+  - nightly
+matrix:
+  allow_failures:
+  - rust: nightly
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Currently, rust-bio provides
 * FMD-Index for finding supermaximal exact matches,
 * a q-gram index,
 * a rank/select data structure,
+* [serde](https://github.com/serde-rs/serde) support for several data structures when built with `nightly` feature,
 * FASTQ and FASTA and BED readers and writers,
 * helper functions for combinatorics and dealing with log probabilities.
 

--- a/src/alphabets/dna.rs
+++ b/src/alphabets/dna.rs
@@ -41,15 +41,17 @@ pub fn iupac_alphabet() -> Alphabet {
 
 
 /// Implementation of transformation into reverse complement.
+#[cfg_attr(feature = "serde_macros", derive(Serialize, Deserialize))]
 pub struct RevComp {
-    comp: [u8; 256]
+    comp: Vec<u8>,
 }
 
 
 impl RevComp {
     /// Create a new instance of reverse complement algorithm.
     pub fn new() -> Self {
-        let mut comp = [0u8; 256];
+        let mut comp = Vec::new();
+        comp.resize(256, 0);
         for (v, mut a) in comp.iter_mut().enumerate() {
             *a = v as u8;
         }

--- a/src/data_structures/bitenc.rs
+++ b/src/data_structures/bitenc.rs
@@ -20,6 +20,7 @@
 
 
 /// A sequence of bitencoded values.
+#[cfg_attr(feature = "serde_macros", derive(Serialize, Deserialize))]
 pub struct BitEnc {
     storage: Vec<u32>,
     width: usize,

--- a/src/data_structures/fmindex.rs
+++ b/src/data_structures/fmindex.rs
@@ -145,6 +145,7 @@ impl BiInterval {
 
 /// The FMD-Index for linear time search of supermaximal exact matches on forward and reverse
 /// strand of DNA texts (Li, 2012).
+#[cfg_attr(feature = "serde_macros", derive(Serialize, Deserialize))]
 pub struct FMDIndex {
     fmindex: FMIndex,
     revcomp: dna::RevComp,

--- a/src/data_structures/rank_select.rs
+++ b/src/data_structures/rank_select.rs
@@ -36,6 +36,7 @@ use bit_vec::BitVec;
 
 
 /// A rank/select data structure.
+#[cfg_attr(feature = "serde_macros", derive(Serialize, Deserialize))]
 pub struct RankSelect {
     n: usize,
     bits: Vec<u8>,

--- a/src/data_structures/smallints.rs
+++ b/src/data_structures/smallints.rs
@@ -34,8 +34,9 @@ use num::traits::cast;
 
 /// Data structure for storing a sequence of small integers with few big ones space efficiently
 /// while supporting classical vector operations.
-pub struct SmallInts<S: Integer + Bounded + NumCast + Copy, B: Integer + NumCast + Copy> {
-    smallints: Vec<S>,
+#[cfg_attr(feature = "serde_macros", derive(Serialize, Deserialize))]
+pub struct SmallInts<F: Integer + Bounded + NumCast + Copy, B: Integer + NumCast + Copy> {
+    smallints: Vec<F>,
     bigints: BTreeMap<usize, B>
 }
 
@@ -112,7 +113,7 @@ impl<S: Integer + Bounded + NumCast + Copy, B: Integer + NumCast + Copy> SmallIn
     pub fn len(&self) -> usize {
         self.smallints.len()
     }
-    
+
     /// is the sequence empty?
     pub fn is_empty(&self) -> bool {
         self.smallints.is_empty()


### PR DESCRIPTION
I added nightly to the travis config, but it's allowed to fail. At the very least it'll provide an item for review if a build fails on nightly, but it won't block PRs coming in. I think that second part is important given the recent rand breakage that lasted for over a week before nightly builds were working again for many crates.

The actual code adds feature-flagged serde support for FMDIndex (and RevComp since it's a member of the FMDIndex), BitEnc, RankSelect, and SmallInts. SuffixArray, LCPArray, etc. are already supported because they're just typedefs for Vec\<T: Serialize, Deserialize\>. A few notes:

* In order to support FMDIndex, I needed to add serde for RevComp. Unfortunately, serde doesn't seem to support stack-allocated arrays greater than length 32. I changed the implementation to a Vec<u8> with a reserved size, and all of the tests are passing. I can see that this would add a small performance overhead from chasing a pointer before indexing into the array. What are your thoughts about this? Is it not worth it to get serde for FMDIndex?
* QGram indices can't have serde_macros enabled because of the VecMap in RankTransform -- VecMap doesn't have serde support
* I had hoped to also add serde for Alphabet (so an index could be saved along with its corresponding alphabet, just in case), but BitSet doesn't support serde