### PR TITLE
Full(ish) serde support + serde coverage on travis + serde compile tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: rust
-rust:
-  - stable
-  - beta
-  - nightly
 matrix:
+  include:
+    - rust: stable
+    - rust: beta
+    - rust: nightly
+    - rust: nightly
+      env: FEATURES="--features nightly"
   allow_failures:
   - rust: nightly
+script:
+  - cargo build $FEATURES
+  - cargo test $FEATURES
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT"
 
 [features]
-nightly = ["serde", "serde_macros"]
+nightly = ["serde", "serde_macros", "vec_map/eders"]
 
 [dependencies]
 csv = "0.14.*"
@@ -17,7 +17,7 @@ rustc-serialize = "0.3.*"
 num = "0.1.*"
 itertools = "0.4.*"
 bit-vec = "0.4.*"
-vec_map = "0.3.*"
+vec_map = "0.6.*"
 bit-set = "0.3.*"
 nalgebra= "0.4.*"
 lazy_static = "0.1.*"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Currently, rust-bio provides
 * FMD-Index for finding supermaximal exact matches,
 * a q-gram index,
 * a rank/select data structure,
-* [serde](https://github.com/serde-rs/serde) support for several data structures when built with `nightly` feature,
+* [serde](https://github.com/serde-rs/serde) support for all data structures when built with `nightly` feature,
 * FASTQ and FASTA and BED readers and writers,
 * helper functions for combinatorics and dealing with log probabilities.
 

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -76,6 +76,7 @@ impl<'a> FromIterator<&'a u8> for Alphabet {
 }
 
 /// Tools based on transforming the alphabet symbols to their lexicographical ranks.
+#[cfg_attr(feature = "serde_macros", derive(Serialize, Deserialize))]
 pub struct RankTransform {
     pub ranks: SymbolRanks
 }
@@ -94,13 +95,13 @@ impl RankTransform {
 
     /// Get the rank of symbol `a`.
     pub fn get(&self, a: u8) -> u8 {
-        *self.ranks.get(&(a as usize)).expect("Unexpected character.")
+        *self.ranks.get(a as usize).expect("Unexpected character.")
     }
 
     /// Transform a given `text`.
     pub fn transform(&self, text: &[u8]) -> Vec<u8> {
         text.iter()
-            .map(|&c| *self.ranks.get(&(c as usize)).expect("Unexpected character in text."))
+            .map(|&c| *self.ranks.get(c as usize).expect("Unexpected character in text."))
             .collect()
     }
 
@@ -167,5 +168,17 @@ impl<'a> Iterator for QGrams<'a> {
             },
             None    => None
         }
+    }
+}
+
+#[cfg(tests)]
+mod tests {
+    #[test]
+    #[cfg(feature = "nightly")]
+    fn test_serde() {
+        use serde::{Serialize, Deserialize};
+        fn impls_serde_traits<S: Serialize + Deserialize>() {}
+
+        impls_serde_traits::<RankTransform>();
     }
 }

--- a/src/data_structures/bitenc.rs
+++ b/src/data_structures/bitenc.rs
@@ -204,4 +204,13 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    #[cfg(feature = "nightly")]
+    fn test_serde() {
+        use serde::{Serialize, Deserialize};
+        fn impls_serde_traits<S: Serialize + Deserialize>() {}
+
+        impls_serde_traits::<BitEnc>();
+    }
 }

--- a/src/data_structures/bwt.rs
+++ b/src/data_structures/bwt.rs
@@ -185,4 +185,13 @@ mod tests {
         assert_eq!(occ.get(&bwt, 4, 2u8), 1);
         assert_eq!(occ.get(&bwt, 4, 3u8), 2);
     }
+
+    #[test]
+    #[cfg(feature = "nightly")]
+    fn test_serde() {
+        use serde::{Serialize, Deserialize};
+        fn impls_serde_traits<S: Serialize + Deserialize>() {}
+
+        impls_serde_traits::<Occ>();
+    }
 }

--- a/src/data_structures/fmindex.rs
+++ b/src/data_structures/fmindex.rs
@@ -367,4 +367,14 @@ mod tests {
         assert_eq!(interval.occ(&pos), [3, 5]);
         assert_eq!(interval.occ_revcomp(&pos), [8, 0]);
     }
+
+    #[test]
+    #[cfg(feature = "nightly")]
+    fn test_serde() {
+        use serde::{Serialize, Deserialize};
+        fn impls_serde_traits<S: Serialize + Deserialize>() {}
+
+        impls_serde_traits::<FMIndex>();
+        impls_serde_traits::<FMDIndex>();
+    }
 }

--- a/src/data_structures/qgram_index.rs
+++ b/src/data_structures/qgram_index.rs
@@ -37,6 +37,7 @@ use utils;
 
 
 /// A classical, flexible, q-gram index implementation.
+#[cfg_attr(feature = "serde_macros", derive(Serialize, Deserialize))]
 pub struct QGramIndex {
     q: u32,
     address: Vec<usize>,
@@ -274,5 +275,14 @@ mod tests {
         for m in exact_matches {
             assert_eq!(m.pattern.get(pattern), m.text.get(text));
         }
+    }
+
+    #[test]
+    #[cfg(feature = "nightly")]
+    fn test_serde() {
+        use serde::{Serialize, Deserialize};
+        fn impls_serde_traits<S: Serialize + Deserialize>() {}
+
+        impls_serde_traits::<QGramIndex>();
     }
 }

--- a/src/data_structures/rank_select.rs
+++ b/src/data_structures/rank_select.rs
@@ -143,3 +143,15 @@ fn superblocks(n: usize, s: usize, raw_bits: &Vec<u8>) -> Vec<u32> {
 
     superblocks
 }
+
+#[cfg(tests)]
+mod tests {
+    #[test]
+    #[cfg(feature = "nightly")]
+    fn test_serde() {
+        use serde::{Serialize, Deserialize};
+        fn impls_serde_traits<S: Serialize + Deserialize>() {}
+
+        impls_serde_traits::<RankSelect>();
+    }
+}

--- a/src/data_structures/smallints.rs
+++ b/src/data_structures/smallints.rs
@@ -157,3 +157,15 @@ impl<'a, S, B> Iterator for Iter<'a, S, B> where
         }
     }
 }
+
+#[cfg(tests)]
+mod tests {
+    #[test]
+    #[cfg(feature = "nightly")]
+    fn test_serde() {
+        use serde::{Serialize, Deserialize};
+        fn impls_serde_traits<S: Serialize + Deserialize>() {}
+
+        impls_serde_traits::<SmallInts<i8, isize>>();
+    }
+}

--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -180,7 +180,7 @@ fn transform_text<T: Integer + Unsigned + NumCast + Copy>(text: &[u8], alphabet:
             s += 1;
         }
         else {
-            transformed.push(cast(*transform.ranks.get(&(a as usize)).unwrap() as usize + offset).unwrap());
+            transformed.push(cast(*(transform.ranks.get(a as usize)).unwrap() as usize + offset).unwrap());
         }
     }
 
@@ -218,10 +218,10 @@ impl SAIS {
         self.bucket_start.clear();
 
         for &c in text.iter() {
-            if !self.bucket_sizes.contains_key(&cast(c).unwrap()) {
+            if !self.bucket_sizes.contains_key(cast(c).unwrap()) {
                 self.bucket_sizes.insert(cast(c).unwrap(), 0);
             }
-            *(self.bucket_sizes.get_mut(&cast(c).unwrap()).unwrap()) += 1;
+            *(self.bucket_sizes.get_mut(cast(c).unwrap()).unwrap()) += 1;
         }
 
         let mut sum = 0;

--- a/src/pattern_matching/bom.rs
+++ b/src/pattern_matching/bom.rs
@@ -54,7 +54,7 @@ impl BOM {
             // for this iterate over the known suffixes until
             // reaching an edge labelled with a or the start
             while let Some(k_) = k {
-                if table[k_].contains_key(&a) {
+                if table[k_].contains_key(a) {
                     break;
                 }
                 table[k_].insert(a, i);
@@ -64,7 +64,7 @@ impl BOM {
             // the longest suffix is either 0 or the state
             // reached by the edge labelled with a
             suff[i] = Some(match k {
-                Some(k) => *table[k].get(&a).unwrap(),
+                Some(k) => *table[k].get(a).unwrap(),
                 None => 0
             });
 
@@ -79,7 +79,7 @@ impl BOM {
             None
         }
         else {
-            match self.table[q].get(&(a as usize)) {
+            match self.table[q].get(a as usize) {
                 Some(&q) => Some(q),
                 None => None
             }


### PR DESCRIPTION
The serde support that I PR'd for vec_map has landed in 0.6.0 (https://github.com/contain-rs/vec-map/pull/15).

This PR updates the vec_map dependency to 0.6.0 so that QGramIndex can now have serde on nightly too. I also added the nightly feature flag to the TravisCI config so it'll run tests against both a vanilla nightly and against the nightly feature flag. The vec_map maintainer had a nice suggestion on how to include tests for the serde traits, so I've also added those to all of the data structures.

I think this is probably as much serde support as I'll be able to achieve -- unfortunately serde_macros seems unable to handle some of the type-system-jiggery-pokery that is used in bit_set/bit_vec. Without serde support there, I won't be able to get the alphabet implementations serializable using the macros. If serializing the alphabet associated with an index is important enough, we could always implement a wrapper enum to at least record which type was used. That said, all of the actual data structures and indices should now be supported by serde, it's just the alphabets that I'm missing.