### PR TITLE
Refactor to text iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 - Reverse complement API has been refactored into plain functions.
 - Reverse complement now supports the whole IUPAC alphabet.
+- Various algorithms take now IntoTextIterator instead of only slices.
+- Fasta reader and writer treat sequence names as strings.
 
 ## [0.6.0] - 2016-05-09
 - Type aliases for various text representations.

--- a/src/alignment/distance.rs
+++ b/src/alignment/distance.rs
@@ -36,6 +36,8 @@ use itertools::Zip;
 use std::cmp::min;
 use std::result::Result;
 
+use utils::TextSlice;
+
 
 /// Compute the Hamming distance between two strings with `hamming`. If returns the `Result<u32, &str>` type
 /// with the first element corresponding to the distance between two strings (a number of mismatches) and the second one to the error message
@@ -72,7 +74,7 @@ use std::result::Result;
 /// }
 /// assert!(hamming(x, y).is_err());
 /// ```
-pub fn hamming(alpha: &[u8], beta: &[u8]) -> Result<u32, &'static str> {
+pub fn hamming(alpha: TextSlice, beta: TextSlice) -> Result<u32, &'static str> {
     if alpha.len() == beta.len() {
         let mut score: u32 = 0;
         for (a, b) in Zip::new((alpha, beta)) {
@@ -104,7 +106,7 @@ pub fn hamming(alpha: &[u8], beta: &[u8]) -> Result<u32, &'static str> {
 /// assert_eq!(l_score, 5);
 /// ```
 #[allow(unused_assignments)]
-pub fn levenshtein(alpha: &[u8], beta: &[u8]) -> u32 {
+pub fn levenshtein(alpha: TextSlice, beta: TextSlice) -> u32 {
     let mut columns = [vec!(0u32; alpha.len() + 1), vec!(0u32; alpha.len() + 1)];
     let mut i_prev = 0;
     let mut i_cur = 1;

--- a/src/alignment/mod.rs
+++ b/src/alignment/mod.rs
@@ -5,6 +5,7 @@
 
 //! Various alignment and distance computing algorithms.
 
+use utils::TextSlice;
 
 pub mod pairwise;
 pub mod distance;
@@ -120,7 +121,7 @@ impl Alignment {
     /// let alignment = aligner.global(x, y);
     /// println!("Global: \n{}\n", alignment.pretty(x, y));
     /// ```
-    pub fn pretty(&self, x: &[u8], y: &[u8]) -> String {
+    pub fn pretty(&self, x: TextSlice, y: TextSlice) -> String {
         let mut x_pretty = String::new();
         let mut y_pretty = String::new();
         let mut inb_pretty = String::new();

--- a/src/alignment/pairwise.rs
+++ b/src/alignment/pairwise.rs
@@ -42,6 +42,7 @@ use std::cmp::max;
 
 use alignment::{Alignment, AlignmentOperation};
 use data_structures::bitenc::BitEnc;
+use utils::TextSlice;
 
 
 enum AlignmentType {
@@ -241,7 +242,7 @@ impl<'a, F> Aligner<'a, F>
     }
 
     /// Calculate global alignment of x against y.
-    pub fn global(&mut self, x: &[u8], y: &[u8]) -> Alignment {
+    pub fn global(&mut self, x: TextSlice, y: TextSlice) -> Alignment {
         let (m, n) = (x.len(), y.len());
         self.init(m, AlignmentType::Global);
         self.traceback.init(m, n, AlignmentType::Global);
@@ -262,7 +263,7 @@ impl<'a, F> Aligner<'a, F>
     }
 
     /// Calculate semiglobal alignment of x against y (x is global, y is local).
-    pub fn semiglobal(&mut self, x: &[u8], y: &[u8]) -> Alignment {
+    pub fn semiglobal(&mut self, x: TextSlice, y: TextSlice) -> Alignment {
         let (m, n) = (x.len(), y.len());
         self.init(m, AlignmentType::Semiglobal);
         self.traceback.init(m, n, AlignmentType::Semiglobal);
@@ -290,7 +291,7 @@ impl<'a, F> Aligner<'a, F>
     }
 
     /// Calculate local alignment of x against y.
-    pub fn local(&mut self, x: &[u8], y: &[u8]) -> Alignment {
+    pub fn local(&mut self, x: TextSlice, y: TextSlice) -> Alignment {
         let (m, n) = (x.len(), y.len());
         self.init(m, AlignmentType::Local);
         self.traceback.init(m, n, AlignmentType::Local);
@@ -389,7 +390,7 @@ impl Traceback {
         self.matrix[i].get(j).unwrap()
     }
 
-    fn alignment(&self, mut i: usize, mut j: usize, x: &[u8], y: &[u8], score: i32) -> Alignment {
+    fn alignment(&self, mut i: usize, mut j: usize, x: TextSlice, y: TextSlice, score: i32) -> Alignment {
         let mut ops = Vec::with_capacity(x.len());
 
         loop {

--- a/src/alphabets/dna.rs
+++ b/src/alphabets/dna.rs
@@ -17,7 +17,7 @@
 //! ```
 
 use alphabets::Alphabet;
-use utils::TextSlice;
+use utils::IntoTextIterator;
 
 
 /// The DNA alphabet (uppercase and lowercase).
@@ -61,6 +61,7 @@ pub fn complement(a: u8) -> u8 {
 
 
 /// Calculate reverse complement of given text (IUPAC alphabet supported).
-pub fn revcomp(text: TextSlice) -> Vec<u8> {
-    text.iter().rev().map(|&a| complement(a)).collect()
+pub fn revcomp<'a, T: IntoTextIterator<'a>>(text: T) -> Vec<u8> where
+    T::IntoIter: DoubleEndedIterator {
+    text.into_iter().rev().map(|&a| complement(a)).collect()
 }

--- a/src/alphabets/protein.rs
+++ b/src/alphabets/protein.rs
@@ -20,7 +20,7 @@ use alphabets::Alphabet;
 
 /// Returns the standard protein alphabet, containing the 20 common amino acids.
 pub fn alphabet() -> Alphabet {
-    Alphabet::new(b"ARNDCEQGHILKMFPSTWYVarndceqghilkmfpstwyv")
+    Alphabet::new(&b"ARNDCEQGHILKMFPSTWYVarndceqghilkmfpstwyv"[..])
 }
 
 

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -406,7 +406,7 @@ ATTGTTGTTTTA
                              .ok()
                              .expect("Error reading index");
         let mut seq = Vec::new();
-        reader.read(b"id", 1, 5, &mut seq).ok().expect("Error reading sequence.");
+        reader.read("id", 1, 5, &mut seq).ok().expect("Error reading sequence.");
         assert_eq!(seq, b"CCGT");
     }
 

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -86,8 +86,8 @@ impl<R: io::Read> Reader<R> {
 
 /// A FASTA index as created by SAMtools (.fai).
 pub struct Index {
-    inner: collections::HashMap<Vec<u8>, IndexRecord>,
-    seqs: Vec<Vec<u8>>,
+    inner: collections::HashMap<String, IndexRecord>,
+    seqs: Vec<String>,
 }
 
 
@@ -99,8 +99,8 @@ impl Index {
         let mut fai_reader = csv::Reader::from_reader(fai).delimiter(b'\t').has_headers(false);
         for row in fai_reader.decode() {
             let (name, record): (String, IndexRecord) = try!(row);
-            seqs.push(name.clone().into_bytes());
-            inner.insert(name.into_bytes(), record);
+            seqs.push(name.clone());
+            inner.insert(name, record);
         }
         Ok(Index {
             inner: inner,
@@ -179,7 +179,7 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
     }
 
     /// For a given seqname, read the whole sequence into the given vector.
-    pub fn read_all(&mut self, seqname: TextSlice, seq: &mut Text) -> io::Result<()> {
+    pub fn read_all(&mut self, seqname: &str, seq: &mut Text) -> io::Result<()> {
         match self.index.inner.get(seqname) {
             Some(&idx) => self.read(seqname, 0, idx.len, seq),
             None => Err(io::Error::new(io::ErrorKind::Other, "Unknown sequence name.")),
@@ -188,7 +188,7 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
 
     /// Read the given interval of the given seqname into the given vector (stop position is exclusive).
     pub fn read(&mut self,
-                seqname: TextSlice,
+                seqname: &str,
                 start: u64,
                 stop: u64,
                 seq: &mut Text)
@@ -240,7 +240,7 @@ struct IndexRecord {
 
 /// A sequence record returned by the FASTA index.
 pub struct Sequence {
-    pub name: Text,
+    pub name: String,
     pub len: u64,
 }
 

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -25,6 +25,7 @@ use std::convert::AsRef;
 
 use csv;
 
+use utils::{TextSlice, Text};
 
 /// A FASTA reader.
 pub struct Reader<R: io::Read> {
@@ -178,7 +179,7 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
     }
 
     /// For a given seqname, read the whole sequence into the given vector.
-    pub fn read_all(&mut self, seqname: &[u8], seq: &mut Vec<u8>) -> io::Result<()> {
+    pub fn read_all(&mut self, seqname: TextSlice, seq: &mut Text) -> io::Result<()> {
         match self.index.inner.get(seqname) {
             Some(&idx) => self.read(seqname, 0, idx.len, seq),
             None => Err(io::Error::new(io::ErrorKind::Other, "Unknown sequence name.")),
@@ -187,10 +188,10 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
 
     /// Read the given interval of the given seqname into the given vector (stop position is exclusive).
     pub fn read(&mut self,
-                seqname: &[u8],
+                seqname: TextSlice,
                 start: u64,
                 stop: u64,
-                seq: &mut Vec<u8>)
+                seq: &mut Text)
                 -> io::Result<()> {
         match self.index.inner.get(seqname) {
             Some(idx) => {
@@ -239,7 +240,7 @@ struct IndexRecord {
 
 /// A sequence record returned by the FASTA index.
 pub struct Sequence {
-    pub name: Vec<u8>,
+    pub name: Text,
     pub len: u64,
 }
 
@@ -270,7 +271,7 @@ impl<W: io::Write> Writer<W> {
     }
 
     /// Write a Fasta record with given id, optional description and sequence.
-    pub fn write(&mut self, id: &str, desc: Option<&str>, seq: &[u8]) -> io::Result<()> {
+    pub fn write(&mut self, id: &str, desc: Option<&str>, seq: TextSlice) -> io::Result<()> {
         try!(self.writer.write(b">"));
         try!(self.writer.write(id.as_bytes()));
         if desc.is_some() {
@@ -335,7 +336,7 @@ impl Record {
     }
 
     /// Return the sequence of the record.
-    pub fn seq(&self) -> &[u8] {
+    pub fn seq(&self) -> TextSlice {
         self.seq.as_bytes()
     }
 

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -21,7 +21,7 @@ use std::fmt;
 use std::path::Path;
 use std::convert::AsRef;
 
-use utils::{Text, TextSlice};
+use utils::TextSlice;
 
 /// A FastQ reader.
 pub struct Reader<R: io::Read> {

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -21,6 +21,7 @@ use std::fmt;
 use std::path::Path;
 use std::convert::AsRef;
 
+use utils::{Text, TextSlice};
 
 /// A FastQ reader.
 pub struct Reader<R: io::Read> {
@@ -131,7 +132,7 @@ impl Record {
     }
 
     /// Return the sequence of the record.
-    pub fn seq(&self) -> &[u8] {
+    pub fn seq(&self) -> TextSlice {
         self.seq.trim_right().as_bytes()
     }
 
@@ -208,7 +209,7 @@ impl<W: io::Write> Writer<W> {
     pub fn write(&mut self,
                  id: &str,
                  desc: Option<&str>,
-                 seq: &[u8],
+                 seq: TextSlice,
                  qual: &[u8])
                  -> io::Result<()> {
         try!(self.writer.write(b"@"));

--- a/src/pattern_matching/bndm.rs
+++ b/src/pattern_matching/bndm.rs
@@ -20,7 +20,7 @@
 
 
 use pattern_matching::shift_and::masks;
-use utils::TextSlice;
+use utils::{TextSlice, IntoTextIterator};
 
 
 /// BNDM algorithm.
@@ -33,15 +33,15 @@ pub struct BNDM {
 
 impl BNDM {
     /// Create a new instance for a given pattern.
-    pub fn new(pattern: TextSlice) -> Self {
+    pub fn new<'a, P: IntoTextIterator<'a>>(pattern: P) -> Self where
+        P::IntoIter: DoubleEndedIterator + ExactSizeIterator {
+
+        let pattern = pattern.into_iter();
         let m = pattern.len();
         assert!(m <= 64, "Expecting a pattern of at most 64 symbols.");
         // take the reverse pattern and build nondeterministic
         // suffix automaton
-        let mut rev = pattern.to_vec();
-        rev.reverse();
-
-        let (masks, accept) = masks(&rev);
+        let (masks, accept) = masks(pattern.rev());
 
         BNDM {
             m: m,

--- a/src/pattern_matching/bom.rs
+++ b/src/pattern_matching/bom.rs
@@ -20,7 +20,7 @@
 
 
 use std::iter::repeat;
-use utils::TextSlice;
+use utils::{TextSlice, IntoTextIterator};
 
 use vec_map::VecMap;
 
@@ -34,16 +34,18 @@ pub struct BOM {
 
 impl BOM {
     /// Create a new instance for a given pattern.
-    pub fn new(pattern: TextSlice) -> Self {
+    pub fn new<'a, P: IntoTextIterator<'a>>(pattern: P) -> Self where
+        P::IntoIter: DoubleEndedIterator + ExactSizeIterator + Clone {
+        let pattern = pattern.into_iter();
         let m = pattern.len();
-        let maxsym = *pattern.iter().max().expect("Expecting non-empty pattern.") as usize;
+        let maxsym = *pattern.clone().max().expect("Expecting non-empty pattern.") as usize;
         let mut table: Vec<VecMap<usize>> = Vec::with_capacity(m);
         // init suffix table, initially all values unknown
         // suff[i] is the state in which the longest suffix of
         // pattern[..i+1] ends that does not end in i
         let mut suff: Vec<Option<usize>> = repeat(None).take(m + 1).collect();
 
-        for (j, &b) in pattern.iter().rev().enumerate() {
+        for (j, &b) in pattern.rev().enumerate() {
             let i = j + 1;
             let a = b as usize;
             let mut delta = VecMap::with_capacity(maxsym);

--- a/src/pattern_matching/myers.rs
+++ b/src/pattern_matching/myers.rs
@@ -44,18 +44,21 @@ pub struct Myers {
 
 impl Myers {
     /// Create a new instance of Myers algorithm for a given pattern.
-    pub fn new(pattern: TextSlice) -> Self {
-        assert!(pattern.len() <= 64 && pattern.len() > 0);
+    pub fn new<'a, P: IntoTextIterator<'a>>(pattern: P) -> Self where
+        P::IntoIter: ExactSizeIterator {
+        let pattern = pattern.into_iter();
+        let m = pattern.len();
+        assert!(m <= 64 && m > 0);
 
         let mut peq = [0; 256];
-        for (i, &a) in pattern.iter().enumerate() {
+        for (i, &a) in pattern.enumerate() {
             peq[a as usize] |= 1 << i;
         }
 
         Myers {
             peq: peq,
-            bound: 1 << (pattern.len() - 1),
-            m: pattern.len() as u8,
+            bound: 1 << (m - 1),
+            m: m as u8,
         }
     }
 

--- a/src/pattern_matching/shift_and.rs
+++ b/src/pattern_matching/shift_and.rs
@@ -20,7 +20,7 @@
 
 use std::iter::Enumerate;
 
-use utils::{TextSlice, IntoTextIterator, TextIterator};
+use utils::{IntoTextIterator, TextIterator};
 
 /// ShiftAnd algorithm.
 pub struct ShiftAnd {
@@ -32,13 +32,16 @@ pub struct ShiftAnd {
 
 impl ShiftAnd {
     /// Create new ShiftAnd instance from a given pattern.
-    pub fn new(pattern: TextSlice) -> ShiftAnd {
-        assert!(pattern.len() <= 64,
+    pub fn new<'a, P: IntoTextIterator<'a>>(pattern: P) -> Self where
+        P::IntoIter: ExactSizeIterator {
+        let pattern = pattern.into_iter();
+        let m = pattern.len();
+        assert!(m <= 64,
                 "Expecting a pattern of at most 64 symbols.");
         let (masks, accept) = masks(pattern);
 
         ShiftAnd {
-            m: pattern.len(),
+            m: m,
             masks: masks,
             accept: accept,
         }
@@ -59,11 +62,11 @@ impl ShiftAnd {
 
 /// Calculate ShiftAnd masks. This function is called automatically when instantiating
 /// a new ShiftAnd for a given pattern.
-pub fn masks(pattern: &[u8]) -> ([u64; 256], u64) {
+pub fn masks<'a, I: IntoTextIterator<'a>>(pattern: I) -> ([u64; 256], u64) {
     let mut masks = [0; 256];
 
     let mut bit = 1;
-    for &c in pattern.iter() {
+    for &c in pattern {
         masks[c as usize] |= bit;
         bit *= 2;
     }


### PR DESCRIPTION
Refactors various parts of the API to use IntoTextIterator instead of slices. Missing is BWT and SuffixArray related stuff, because this is currently refactored in pull request #47.