### PR TITLE
Fixing nightly travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,14 @@ matrix:
     - rust: stable
     - rust: beta
     - rust: nightly
+      env: TRAVIS_CARGO_NIGHTLY_FEATURE=""
     - rust: nightly
-      env: FEATURES="--features nightly"
+      env: TRAVIS_CARGO_NIGHTLY_FEATURE="nightly"
   allow_failures:
   - rust: nightly
 script:
-  - travis-cargo build $FEATURES
-  - travis-cargo test $FEATURES
+  - travis-cargo build
+  - travis-cargo test
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&


### PR DESCRIPTION
Updating travis-cargo invocation to avoid spurious nightly build failures.

Note that the CI build will fail until the io::bed test case is resolved, see #66 for a quick fix there.