### PR TITLE
make Entry fields public so that clients can read data

### DIFF
--- a/src/data_structures/interval_tree.rs
+++ b/src/data_structures/interval_tree.rs
@@ -14,9 +14,22 @@ pub struct IntervalTree<N, D> {
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Entry<'a, N: 'a, D: 'a> {
-    pub data: &'a D,
-    pub interval: &'a Range<N>,
+    data: &'a D,
+    interval: &'a Range<N>,
 }
+
+impl<'a, N: 'a, D: 'a> Entry<'a, N, D> {
+    /// Get a reference to the data for this entry
+    pub fn data(&self) -> &'a D {
+        self.data
+    }
+
+    /// Get a reference to the interval for this entry
+    pub fn interval(&self) -> &'a Range<N> {
+        self.interval
+    }
+}
+
 
 pub struct IntervalTreeIterator<'a, N: 'a, D: 'a> {
     nodes: Vec<&'a Node<N, D>>,

--- a/src/data_structures/interval_tree.rs
+++ b/src/data_structures/interval_tree.rs
@@ -14,8 +14,8 @@ pub struct IntervalTree<N, D> {
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Entry<'a, N: 'a, D: 'a> {
-    data: &'a D,
-    interval: &'a Range<N>,
+    pub data: &'a D,
+    pub interval: &'a Range<N>,
 }
 
 pub struct IntervalTreeIterator<'a, N: 'a, D: 'a> {


### PR DESCRIPTION
Currently we can't actually access the results of IntervalTree::find because the fields on Entry are not public.