### PR TITLE
Use newtype Interval<N>(Range<N>)

### DIFF
--- a/src/data_structures/interval_tree.rs
+++ b/src/data_structures/interval_tree.rs
@@ -8,32 +8,62 @@ use std::fmt::Debug;
 use std::ops::Range;
 
 #[derive(Debug, Clone)]
-pub struct IntervalTree<N, D> {
+pub struct IntervalTree<N: Ord + Clone + Debug, D> {
     root: Option<Node<N, D>>,
 }
 
-#[derive(PartialEq, Eq, Debug, Clone)]
-pub struct Entry<'a, N: 'a, D: 'a> {
+#[derive(Debug, Clone)]
+pub struct Entry<'a, N: 'a + Ord + Clone + Debug,  D: 'a + Debug> {
     data: &'a D,
-    interval: &'a Range<N>,
+    interval: &'a Interval<N>,
 }
 
-impl<'a, N: 'a, D: 'a> Entry<'a, N, D> {
+impl<'a, N: 'a + Ord + Clone + Debug, D: 'a+ Debug> Entry<'a, N, D> {
     /// Get a reference to the data for this entry
     pub fn data(&self) -> &'a D {
         self.data
     }
 
     /// Get a reference to the interval for this entry
-    pub fn interval(&self) -> &'a Range<N> {
-        self.interval
+    pub fn interval(&self) -> &'a Interval<N> {
+        &self.interval
     }
 }
 
 
-pub struct IntervalTreeIterator<'a, N: 'a, D: 'a> {
+pub struct IntervalTreeIterator<'a, N: 'a + Ord + Debug + Clone, D: 'a> {
     nodes: Vec<&'a Node<N, D>>,
-    interval: Range<N>,
+    interval: Interval<N>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Interval<N: Ord + Clone + Debug>(Range<N>);
+
+impl<N: Ord + Clone + Debug> Interval<N> {
+    pub fn new(r: Range<N>) -> Result<Interval<N>, IntervalTreeError> {
+        if r.end >= r.start {
+            Ok(Interval(r))
+        } else {
+            Err(IntervalTreeError::InvalidRange)
+        }
+    }
+
+    pub fn start(&self) -> &N {
+        &self.0.start
+    }
+
+    pub fn end(&self) -> &N {
+        &self.0.end
+    }
+}
+
+impl<N: Ord + Clone + Debug> From<Range<N>> for Interval<N> {
+    fn from(r: Range<N>) -> Self {
+        match Interval::new(r) {
+            Ok(interval) => interval,
+            Err(_) => panic!("Cannot convert negative width range to interval")
+        }
+    }
 }
 
 impl<'a, N: Debug + Num + Clone + Ord + 'a, D: Debug + 'a> Iterator for IntervalTreeIterator<'a,
@@ -49,19 +79,19 @@ impl<'a, N: Debug + Num + Clone + Ord + 'a, D: Debug + 'a> Iterator for Interval
             };
 
             // stop traversal if the query interval is beyond the current node and all children
-            if self.interval.start < candidate.max {
+            if self.interval.0.start < candidate.max {
                 if let Some(ref left) = candidate.left {
                     self.nodes.push(left);
                 }
 
                 // don't traverse right if the query interval is completely before the current interval
-                if self.interval.end > candidate.interval.start {
+                if self.interval.0.end > candidate.interval.0.start {
                     if let Some(ref right) = candidate.right {
                         self.nodes.push(right);
                     }
 
                     // overlap is only possible if both tests pass
-                    if intersect(&self.interval, &candidate.interval) {
+                    if intersect(&self.interval.0, &candidate.interval.0) {
                         return Some(Entry {
                             data: &candidate.value,
                             interval: &candidate.interval,
@@ -78,18 +108,17 @@ impl<N: Debug + Num + Clone + Ord, D: Debug> IntervalTree<N, D> {
         IntervalTree { root: None }
     }
 
-    pub fn insert(&mut self, interval: Range<N>, data: D) -> Result<(), IntervalTreeError> {
-        try!(validate(&interval));
+    pub fn insert<I: Into<Interval<N>>>(&mut self, irange: I, data: D) {
+        let interval = irange.into();
         match self.root {
             Some(ref mut n) => n.insert(interval, data),
             None => self.root = Some(Node::new(interval, data)),
         };
-        Ok(())
     }
 
-    pub fn find(&self, interval: &Range<N>) -> Result<IntervalTreeIterator<N, D>, IntervalTreeError> {
-        try!(validate(&interval));
-        Ok(match self.root {
+    pub fn find<I: Into<Interval<N>>>(&self, irange: I) -> IntervalTreeIterator<N, D> {
+        let interval = irange.into();
+        match self.root {
             Some(ref n) => n.find_iter(interval.clone()),
             None => {
                 let empty_nodes = vec![];
@@ -98,22 +127,14 @@ impl<N: Debug + Num + Clone + Ord, D: Debug> IntervalTree<N, D> {
                     interval: interval.clone(),
                 }
             }
-        })
-    }
-}
-
-fn validate<N: Ord + Debug>(interval: &Range<N>) -> Result<(), IntervalTreeError> {
-    if interval.start > interval.end {
-        Err(IntervalTreeError::InvalidRange)
-    } else {
-        Ok(())
+        }
     }
 }
 
 #[derive(Debug, Clone)]
-struct Node<N, D> {
+struct Node<N: Ord + Clone + Debug, D> {
     // actual interval data
-    interval: Range<N>,
+    interval: Interval<N>,
     value: D,
     // tree metadata
     max: N,
@@ -123,8 +144,8 @@ struct Node<N, D> {
 }
 
 impl<N: Debug + Num + Clone + Ord, D: Debug> Node<N, D> {
-    fn new(interval: Range<N>, data: D) -> Self {
-        let max = interval.end.clone();
+    fn new(interval: Interval<N>, data: D) -> Self {
+        let max = interval.0.end.clone();
         Node {
             interval: interval,
             max: max,
@@ -135,8 +156,8 @@ impl<N: Debug + Num + Clone + Ord, D: Debug> Node<N, D> {
         }
     }
 
-    fn insert(&mut self, interval: Range<N>, data: D) {
-        if interval.start <= self.interval.start {
+    fn insert(&mut self, interval: Interval<N>, data: D) {
+        if interval.0.start <= self.interval.0.start {
             if let Some(ref mut son) = self.left {
                 son.insert(interval, data);
             } else {
@@ -152,7 +173,7 @@ impl<N: Debug + Num + Clone + Ord, D: Debug> Node<N, D> {
         self.repair();
     }
 
-    pub fn find_iter<'a>(&'a self, interval: Range<N>) -> IntervalTreeIterator<'a, N, D> {
+    pub fn find_iter<'a>(&'a self, interval: Interval<N>) -> IntervalTreeIterator<'a, N, D> {
         let nodes = vec![self];
         IntervalTreeIterator {
             nodes: nodes,
@@ -167,7 +188,7 @@ impl<N: Debug + Num + Clone + Ord, D: Debug> Node<N, D> {
     }
 
     fn update_max(&mut self) {
-        self.max = self.interval.end.clone();
+        self.max = self.interval.0.end.clone();
         if let Some(ref n) = self.left {
             if self.max < n.max {
                 self.max = n.max.clone();
@@ -249,12 +270,12 @@ impl<N: Debug + Num + Clone + Ord, D: Debug> Node<N, D> {
     }
 }
 
-fn swap_interval_data<N, D>(node_1: &mut Node<N, D>, node_2: &mut Node<N, D>) {
+fn swap_interval_data<N: Ord + Clone + Debug, D>(node_1: &mut Node<N, D>, node_2: &mut Node<N, D>) {
     mem::swap(&mut node_1.value, &mut node_2.value);
     mem::swap(&mut node_1.interval, &mut node_2.interval);
 }
 
-fn intersect<N: Ord>(range_1: &Range<N>, range_2: &Range<N>) -> bool {
+fn intersect<N: Ord + Clone + Debug>(range_1: &Range<N>, range_2: &Range<N>) -> bool {
     range_1.start < range_1.end && range_2.start < range_2.end &&
         range_1.end > range_2.start && range_1.start < range_2.end
 }
@@ -272,7 +293,7 @@ quick_error! {
 
 #[cfg(test)]
 mod tests {
-    use super::{Node, IntervalTree, Entry};
+    use super::{Interval, Node, IntervalTree, Entry};
     use std::cmp;
     use std::cmp::{min, max};
     use std::ops::Range;
@@ -294,14 +315,14 @@ mod tests {
 
     fn validate_intervals(node: &Node<i64, String>) {
         let mut reached_maximum: bool = false;
-        if node.interval.end == node.max {
+        if node.interval.0.end == node.max {
             reached_maximum = true;
         }
         if let Some(ref son) = node.left {
             if !(son.max <= node.max) {
                 panic!("left max invariant violated:\n{:?} -> {:?}", node, son);
             }
-            if !(son.interval.start <= node.interval.start) {
+            if !(son.interval.0.start <= node.interval.0.start) {
                 panic!("left ord invariant violated\n{:?} -> {:?}", node, son);
             }
             if node.max == son.max {
@@ -313,7 +334,7 @@ mod tests {
                 panic!("right max invariant violated\n{:?} -> {:?}", node, son);
             }
 
-            if !(son.interval.start >= node.interval.start) {
+            if !(son.interval.0.start >= node.interval.0.start) {
                 panic!("right ord invariant violated\n{:?} -> {:?}", node, son);
             }
             if node.max == son.max {
@@ -327,9 +348,9 @@ mod tests {
 
     fn validate_string_metadata(node: &Node<i64, String>) {
         let mut name: String = "".to_string();
-        name.push_str(&node.interval.start.to_string());
+        name.push_str(&node.interval.0.start.to_string());
         name.push_str(":");
-        name.push_str(&node.interval.end.to_string());
+        name.push_str(&node.interval.0.end.to_string());
         if name != node.value {
             panic!("Invalid metadata for node {:?}", node);
         }
@@ -340,7 +361,7 @@ mod tests {
         name.push_str(&start.to_string());
         name.push_str(":");
         name.push_str(&end.to_string());
-        tree.insert((start..end), name).unwrap();
+        tree.insert((start..end), name);
         if let Some(ref n) = tree.root {
             validate(n);
         }
@@ -362,13 +383,13 @@ mod tests {
     fn assert_intersections(tree: &IntervalTree<i64, String>,
                             target: Range<i64>,
                             expected_results: Vec<Range<i64>>) {
-        let mut actual_entries: Vec<Entry<i64, String>> = tree.find(&target).unwrap().collect();
+        let mut actual_entries: Vec<Entry<i64, String>> = tree.find(target).collect();
         println!("{:?}", actual_entries);
         actual_entries.sort_by(|x1, x2| x1.data.cmp(&x2.data));
         let expected_entries = make_entry_tuples(expected_results);
         assert_eq!(actual_entries.len(), expected_entries.len());
         for (actual, expected) in actual_entries.iter().zip(expected_entries.iter()) {
-            assert_eq!(actual.interval, &expected.0);
+            assert_eq!(&actual.interval.0, &expected.0);
             assert_eq!(actual.data, &expected.1);
         }
     }
@@ -380,7 +401,7 @@ mod tests {
     #[test]
     fn test_insertion_and_intersection() {
         let mut tree: IntervalTree<i64, String> = IntervalTree::new();
-        tree.insert((50..51), "50:51".to_string()).unwrap();
+        tree.insert((50..51), "50:51".to_string());
         assert_not_found(&tree, (49..50));
         assert_intersections(&tree, (49..55), vec![(50..51)]);
         assert_not_found(&tree, (51..55));
@@ -467,12 +488,19 @@ mod tests {
     #[test]
     fn zero_width_ranges() {
         let mut tree: IntervalTree<i64, String> = IntervalTree::new();
-        tree.insert((10..10), "10:10".to_string()).unwrap();
+        tree.insert(Interval::new(10..10).unwrap(), "10:10".to_string());
 
         assert_not_found(&tree, (5..15));
         assert_not_found(&tree, (10..10));
 
         insert_and_validate(&mut tree, 50, 60);
         assert_not_found(&tree, (55..55));
+    }
+
+    #[test]
+    #[should_panic]
+    fn negative_width_range() {
+        let mut tree: IntervalTree<i64, ()> = IntervalTree::new();
+        tree.insert((10..5), ());
     }
 }


### PR DESCRIPTION
This is a first attempt at replacing Range<N> with a newtype. In order to keep inserting / querying convenient I changed the insert/find signature to `I: Into<Interval<N>>` and implemented the `From` trait for `Range<N>` to `Interval<N>`. This conversion can now panic. The interval constructor returns the Result type. So if you create Intervals through `Interval::new` you can catch the error. If you rely on the `into` function the code might panic, but as you mentioned negative width ranges can be considered a programming error....

Thoughts?