### PR TITLE
inline critical traceback functions which rust was declining to inlin…

### DIFF
--- a/src/alignment/pairwise.rs
+++ b/src/alignment/pairwise.rs
@@ -454,7 +454,7 @@ impl TracebackCell {
 
     #[inline(always)]
     pub fn set_d(&mut self, value: u8) {
-        self.v = self.v & !DPOS | (value)
+        self.v = (self.v & !DPOS) | (value)
     }
 
     pub fn get_d(&self) -> u8 {
@@ -463,7 +463,7 @@ impl TracebackCell {
 
     #[inline(always)]
     pub fn set_s(&mut self, value: u8) {
-        self.v = self.v & !SPOS | (value << 2)
+        self.v = (self.v & !SPOS) | (value << 2)
     }
 
     pub fn get_s(&self) -> u8 {
@@ -472,7 +472,7 @@ impl TracebackCell {
 
     #[inline(always)]
     pub fn set_i(&mut self, value: u8) {
-        self.v = self.v & !IPOS | (value << 4)
+        self.v = (self.v & !IPOS) | (value << 4)
     }
 
     pub fn get_i(&self) -> u8 {

--- a/src/alignment/pairwise.rs
+++ b/src/alignment/pairwise.rs
@@ -452,6 +452,7 @@ impl TracebackCell {
         TracebackCell { v: 0 }
     }
 
+    #[inline(always)]
     pub fn set_d(&mut self, value: u8) {
         self.v = self.v & !DPOS | (value)
     }
@@ -460,6 +461,7 @@ impl TracebackCell {
         self.v & 0x3
     }
 
+    #[inline(always)]
     pub fn set_s(&mut self, value: u8) {
         self.v = self.v & !SPOS | (value << 2)
     }
@@ -468,6 +470,7 @@ impl TracebackCell {
         (self.v >> 2) & 0x3
     }
 
+    #[inline(always)]
     pub fn set_i(&mut self, value: u8) {
         self.v = self.v & !IPOS | (value << 4)
     }


### PR DESCRIPTION
…e ~ 25% speed-up

(note this benchmark was done on a small strings than the current alignment benchmarks, since the current strings take an annoyingly long time to profile)

Current code:
running 1 test
test bench_aligner_wc_local      ... bench:  79,464,207 ns/iter (+/- 23,503,581)

New code:
running 1 test
test bench_aligner_wc_local      ... bench:  60,518,534 ns/iter (+/- 9,249,962)