### PR TITLE
Refactor strand enum. Two unknown strands are no longer equal.

### DIFF
--- a/src/io/bed.rs
+++ b/src/io/bed.rs
@@ -28,7 +28,7 @@ use std::convert::AsRef;
 
 use csv;
 
-use io::Strand;
+use utils::Strand;
 
 /// A BED reader.
 pub struct Reader<R: io::Read> {

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -28,7 +28,7 @@ use regex::Regex;
 
 use csv;
 
-use io::Strand;
+use utils::Strand;
 
 /// `GffType`
 ///
@@ -328,7 +328,7 @@ impl Record {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use io::Strand;
+    use utils::Strand;
     use std::collections::HashMap;
 
     const GFF_FILE: &'static [u8] = b"P0A7B8\tUniProtKB\tInitiator methionine\t1\t1\t.\t.\t.\tNote=Removed,ID=test

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -5,11 +5,3 @@ pub mod fastq;
 pub mod fasta;
 pub mod bed;
 pub mod gff;
-
-/// Strand information.
-#[derive(Debug, PartialEq)]
-pub enum Strand {
-    Forward,
-    Reverse,
-    Unknown,
-}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -15,6 +15,27 @@ mod interval;
 pub use self::interval::{Interval, IntervalError};
 
 
+/// Strand information.
+#[derive(Debug, Clone, Copy)]
+pub enum Strand {
+    Forward,
+    Reverse,
+    Unknown,
+}
+
+
+impl PartialEq for Strand {
+    /// Returns true if both are `Forward` or both are `Reverse`, otherwise returns false.
+    fn eq(&self, other: &Strand) -> bool {
+        match (self, other) {
+            (&Strand::Forward, &Strand::Forward) => true,
+            (&Strand::Reverse, &Strand::Reverse) => true,
+            _ => false
+        }
+    }
+}
+
+
 /// In place implementation of scan over a slice.
 pub fn scan<T: Copy, F: Fn(T, T) -> T>(a: &mut [T], op: F) {
     let mut s = a[0];


### PR DESCRIPTION
xref: #122.