### PR TITLE
Iterator for fasta::IndexedReader

### DIFF
--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -304,6 +304,11 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
                  -> io::Result<u64> {
         let (bytes_to_read, bytes_to_keep) = {
             let src = self.reader.fill_buf()?;
+            if src.is_empty() {
+                return Err(io::Error::new(io::ErrorKind::UnexpectedEof,
+                                          "FASTA file is truncated."));
+            }
+
             let bases_on_line = idx.line_bases - min(idx.line_bases, *line_offset);
             let bases_in_buffer = min(src.len() as u64, bases_on_line);
 

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -201,8 +201,7 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
 
 
     /// For a given seqname, return an iterator yielding that sequence.
-    pub fn read_iter_all(&mut self, seqname: &str)
-                -> io::Result<IndexedReaderIterator<R>> {
+    pub fn read_all_iter(&mut self, seqname: &str) -> io::Result<IndexedReaderIterator<R>> {
         let idx = self.idx(seqname)?;
 
        self.read_into_iter(idx, 0, idx.len)

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -588,16 +588,12 @@ ATTGTTGTTTTA
             assert_eq!(record.desc(), descs[i]);
             assert_eq!(record.seq(), seqs[i]);
         }
-
-
-        // let record = records.ok().nth(1).unwrap();
     }
 
     #[test]
     fn test_indexed_reader() {
         let mut reader = IndexedReader::new(io::Cursor::new(FASTA_FILE), FAI_FILE)
-            .ok()
-            .expect("Error reading index");
+            .unwrap();
 
         _test_indexed_reader(&mut reader)
     }
@@ -605,8 +601,7 @@ ATTGTTGTTTTA
     #[test]
     fn test_indexed_reader_crlf() {
         let mut reader = IndexedReader::new(io::Cursor::new(FASTA_FILE_CRLF), FAI_FILE_CRLF)
-            .ok()
-            .expect("Error reading index");
+            .unwrap();
 
         _test_indexed_reader(&mut reader)
     }
@@ -615,79 +610,49 @@ ATTGTTGTTTTA
         let mut seq = Vec::new();
 
         // Test reading various substrings of the sequence
-        reader
-            .read("id", 1, 5, &mut seq)
-            .ok()
-            .expect("Error reading sequence.");
+        reader.read("id", 1, 5, &mut seq).unwrap();
         assert_eq!(seq, b"CCGT");
 
-        reader
-            .read("id", 1, 31, &mut seq)
-            .ok()
-            .expect("Error reading sequence.");
+        reader.read("id", 1, 31, &mut seq).unwrap();
         assert_eq!(seq, b"CCGTAGGCTGACCGTAGGCTGAACGTAGGC");
 
-        reader
-            .read("id", 13, 23, &mut seq)
-            .ok()
-            .expect("Error reading sequence.");
+        reader.read("id", 13, 23, &mut seq).unwrap();
         assert_eq!(seq, b"CGTAGGCTGA");
 
-        reader
-            .read("id", 36, 52, &mut seq)
-            .ok()
-            .expect("Error reading sequence.");
+        reader.read("id", 36, 52, &mut seq).unwrap();
         assert_eq!(seq, b"GTAGGCTGAAAACCCC");
 
-        reader
-            .read("id2", 12, 40, &mut seq)
-            .ok()
-            .expect("Error reading sequence.");
+        reader.read("id2", 12, 40, &mut seq).unwrap();
         assert_eq!(seq, b"ATTGTTGTTTTAATTGTTGTTTTAGGGG");
 
-        reader
-            .read("id2", 12, 12, &mut seq)
-            .ok()
-            .expect("Error reading sequence.");
+        reader.read("id2", 12, 12, &mut seq).unwrap();
         assert_eq!(seq, b"");
 
-        reader
-            .read("id2", 12, 13, &mut seq)
-            .ok()
-            .expect("Error reading sequence.");
+        reader.read("id2", 12, 13, &mut seq).unwrap();
         assert_eq!(seq, b"A");
 
         assert!(reader.read("id2", 12, 11, &mut seq).is_err());
         assert!(reader.read("id2", 12, 1000, &mut seq).is_err());
+        assert!(reader.read("id3", 0, 1, &mut seq).is_err());
     }
 
     #[test]
     fn test_indexed_reader_no_trailing_lf() {
         let mut reader = IndexedReader::new(io::Cursor::new(FASTA_FILE_NO_TRAILING_LF),
                                             FAI_FILE_NO_TRAILING_LF)
-                .ok()
-                .expect("Error reading index");
+                .unwrap();
         let mut seq = Vec::new();
 
-        reader
-            .read("id", 0, 16, &mut seq)
-            .ok()
-            .expect("Error reading sequence.");
+        reader.read("id", 0, 16, &mut seq).unwrap();
         assert_eq!(seq, b"GTAGGCTGAAAACCCC");
     }
 
     #[test]
     fn test_writer() {
         let mut writer = Writer::new(Vec::new());
-        writer
-            .write("id", Some("desc"), b"ACCGTAGGCTGA")
-            .ok()
-            .expect("Expected successful write");
-        writer
-            .write("id2", None, b"ATTGTTGTTTTA")
-            .ok()
-            .expect("Expected successful write");
-        writer.flush().ok().expect("Expected successful write");
+        writer.write("id", Some("desc"), b"ACCGTAGGCTGA").unwrap();
+        writer.write("id2", None, b"ATTGTTGTTTTA").unwrap();
+        writer.flush().unwrap();
         assert_eq!(writer.writer.get_ref(), &WRITE_FASTA_FILE);
     }
 }

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -120,15 +120,8 @@ impl Index {
 
     /// Open a FASTA index given the corresponding FASTA file path (e.g. for ref.fasta we expect ref.fasta.fai).
     pub fn with_fasta_file<P: AsRef<Path>>(fasta_path: &P) -> csv::Result<Self> {
-        let mut ext = fasta_path
-            .as_ref()
-            .extension()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_owned();
-        ext.push_str(".fai");
-        let fai_path = fasta_path.as_ref().with_extension(ext);
+        let mut fai_path = fasta_path.as_ref().as_os_str().to_owned();
+        fai_path.push(".fai");
 
         Self::from_file(&fai_path)
     }


### PR DESCRIPTION
This pull-request not entirely done, but I wanted your take on it.

This pull-request includes fixing a couple of possible panics when opening .fai files, refactoring IndexedReader, and adding support for reading indexed FASTA sequences using iterators (my original goal). In addition, I noticed some pathological behavior when reading files with long lines, so I capped the size of the internal buffer to 512 bytes for all indexed reads.

I ran into some issues trying to write minimal benchmarks, so instead I wrote some simple tests based on reading through versions of the reference genome used by the 1000 Genomes Project: The vanilla genome, a genome where each chromosome spans one line, and a version where 60 bp lines are bookended by 60 spaces. The code itself can be found here:

https://gist.github.com/MikkelSchubert/ac7634f79d4bb25b7a5a41d48e23d9ae

As you can see, I compared reading the full chromosomes in one go, reading chromosomes in blocks of 1MB, and reading using the new iterators. In the two former cases, I also iterated over all bases so that the actual work done was comparable.

Results for 20 runs of each test are reported here (in seconds):

Old version:

    Benchmarking command './target/release/fasta_iter full Human_g1k_v37.fasta'
    Run 20 of 20:  2.09 +/- 0.05
    Benchmarking command './target/release/fasta_iter block Human_g1k_v37.fasta'
    Run 20 of 20:  1.55 +/- 0.07
    Benchmarking command './target/release/fasta_iter full Human_g1k_v37_single_lines.fasta'
    Run 20 of 20:  2.74 +/- 0.04
    Benchmarking command './target/release/fasta_iter block Human_g1k_v37_single_lines.fasta'
    Run 20 of 20:  43.03 +/- 22.16
    Benchmarking command './target/release/fasta_iter full Human_g1k_v37_whitespace.fasta'
    Run 20 of 20:  2.01 +/- 0.03
    Benchmarking command './target/release/fasta_iter block Human_g1k_v37_whitespace.fasta'
    Run 20 of 20:  1.87 +/- 0.04


New version:

    Benchmarking command './target/release/fasta_iter full Human_g1k_v37.fasta'
    Run 20 of 20:  1.81 +/- 0.05
    Benchmarking command './target/release/fasta_iter block Human_g1k_v37.fasta'
    Run 20 of 20:  1.69 +/- 0.02
    Benchmarking command './target/release/fasta_iter iter Human_g1k_v37.fasta'
    Run 20 of 20:  2.86 +/- 0.10
    Benchmarking command './target/release/fasta_iter full Human_g1k_v37_single_lines.fasta'
    Run 20 of 20:  1.39 +/- 0.04
    Benchmarking command './target/release/fasta_iter block Human_g1k_v37_single_lines.fasta'
    Run 20 of 20:  1.22 +/- 0.05
    Benchmarking command './target/release/fasta_iter iter Human_g1k_v37_single_lines.fasta'
    Run 20 of 20:  2.17 +/- 0.06
    Benchmarking command './target/release/fasta_iter full Human_g1k_v37_whitespace.fasta'
    Run 20 of 20:  2.14 +/- 0.06
    Benchmarking command './target/release/fasta_iter block Human_g1k_v37_whitespace.fasta'
    Run 20 of 20:  2.03 +/- 0.07
    Benchmarking command './target/release/fasta_iter iter Human_g1k_v37_whitespace.fasta'
    Run 20 of 20:  3.12 +/- 0.05


Assuming that you don't have any suggestions or objections to these changes, then all I need to finish is cleaning up my current unit tests (and adding more) for the iterator, and committing them.

I may also have undone some of the rustfmt cleanup, since I seem to be getting different formatting results on two different PCs. So I also need to figure out what is going on there.
