### PR TITLE
Add 'from_char' and 'is_unknown' static functions for Strand enum

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -43,13 +43,13 @@ impl Strand {
     ///     * '+', 'f', or 'F' becomes `Strand::Forward`
     ///     * '-', 'r', or 'R' becomes `Strand::Reverse`
     ///     * '.', '?' becomes `Strand::Unknown`
-    ///     * Any other inputs will return an `Err(Error::InvalidStrandChar)`
-    pub fn from_char(strand_char: &char) -> Result<Strand, Error> {
+    ///     * Any other inputs will return an `Err(StrandError::InvalidChar)`
+    pub fn from_char(strand_char: &char) -> Result<Strand, StrandError> {
         match *strand_char {
             '+' | 'f' | 'F' => Ok(Strand::Forward),
             '-' | 'r' | 'R' => Ok(Strand::Reverse),
             '.' | '?'  => Ok(Strand::Unknown),
-            invalid => Err(Error::InvalidStrandChar(invalid)),
+            invalid => Err(StrandError::InvalidChar(invalid)),
         }
     }
 
@@ -63,8 +63,8 @@ impl Strand {
 
 quick_error! {
     #[derive(Debug)]
-    pub enum Error {
-        InvalidStrandChar(invalid_char: char) {
+    pub enum StrandError {
+        InvalidChar(invalid_char: char) {
             description("invalid character for strand conversion")
             display("character {:?} can not be converted to a Strand", invalid_char)
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -41,8 +41,8 @@ impl Strand {
     ///
     /// The mapping is as follows:
     ///     * '+', 'f', or 'F' becomes `Strand::Forward`
-    ///     * '-', 'r', or 'R' becomes `Strand::Forward`
-    ///     * '.', '?' becomes `Strand::Forward`
+    ///     * '-', 'r', or 'R' becomes `Strand::Reverse`
+    ///     * '.', '?' becomes `Strand::Unknown`
     ///     * Any other inputs will return an `Err(Error::InvalidStrandChar)`
     pub fn from_char(strand_char: &char) -> Result<Strand, Error> {
         match *strand_char {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -35,6 +35,41 @@ impl PartialEq for Strand {
     }
 }
 
+impl Strand {
+
+    /// Returns a `Strand` enum representing the given char.
+    ///
+    /// The mapping is as follows:
+    ///     * '+', 'f', or 'F' becomes `Strand::Forward`
+    ///     * '-', 'r', or 'R' becomes `Strand::Forward`
+    ///     * '.', '?' becomes `Strand::Forward`
+    ///     * Any other inputs will return an `Err(Error::InvalidStrandChar)`
+    pub fn from_char(strand_char: &char) -> Result<Strand, Error> {
+        match *strand_char {
+            '+' | 'f' | 'F' => Ok(Strand::Forward),
+            '-' | 'r' | 'R' => Ok(Strand::Reverse),
+            '.' | '?'  => Ok(Strand::Unknown),
+            invalid => Err(Error::InvalidStrandChar(invalid)),
+        }
+    }
+
+    pub fn is_unknown(&self) -> bool {
+        match self {
+            &Strand::Unknown => true,
+            _ => false,
+        }
+    }
+}
+
+quick_error! {
+    #[derive(Debug)]
+    pub enum Error {
+        InvalidStrandChar(invalid_char: char) {
+            description("invalid character for strand conversion")
+            display("character {:?} can not be converted to a Strand", invalid_char)
+        }
+    }
+}
 
 /// In place implementation of scan over a slice.
 pub fn scan<T: Copy, F: Fn(T, T) -> T>(a: &mut [T], op: F) {
@@ -72,5 +107,13 @@ mod tests {
         let mut a = vec![1, 0, 0, 1];
         prescan(&mut a[..], 0, |a, b| a + b);
         assert_eq!(a, vec![0, 1, 1, 1]);
+    }
+
+    #[test]
+    fn test_strand() {
+        assert_eq!(Strand::from_char(&'+').unwrap(), Strand::Forward);
+        assert_eq!(Strand::from_char(&'-').unwrap(), Strand::Reverse);
+        assert!(Strand::from_char(&'.').unwrap().is_unknown());
+        assert!(Strand::from_char(&'o').is_err());
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -54,9 +54,10 @@ impl Strand {
     }
 
     pub fn is_unknown(&self) -> bool {
-        match self {
-            &Strand::Unknown => true,
-            _ => false,
+        if let &Strand::Unknown = self {
+            true
+        } else {
+            false
         }
     }
 }


### PR DESCRIPTION
This PR adds two new method for the Strand enum:

* `Strand::is_unknown` is used for a quick check since `Strand::Unknown` behaves like a Rust's NaN floats.
* `from_char` is for conversions from strand characters used in common formats like BED or GTF.

I also added a new `utils::Error` enum for a failed strand conversion.

Some notes:

* I'm not sure if this is the best place to put the error enum, but there needs to be a way to represent a failed conversion (and I have the impression that there is no generic error types like `ValueError` in Python?). It probably should go somewhere else ...

* I ended up using a `from_char` static method on the enum, but I did consider using a `From` trait or `FromStr`. I didn't end up using `From` since a conversion may fail, and `FromStr` is not used since the commonly used strand information are single characters and I thought using a `String` type is a bit too much. The ideal trait seems to be [TryFrom](https://doc.rust-lang.org/beta/std/convert/trait.TryFrom.html), but I thought it would be better to wait until it lands on stable.

Thanks in advance for checking this out!