### PR TITLE
Fix compilation of benches/distance.rs

### DIFF
--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -272,14 +272,14 @@ GCCGCGCGCGCGGGGCCGGGCCGCGCGCGCGCCGGGCCGCCGGCGGGGCGCGGCC";
 #[bench]
 fn bench_hamming_dist_equal_str_1000iter(b: &mut Bencher) {
     b.iter(|| for _ in 0..1000 {
-               hamming(STR_1, STR_1).unwrap();
+               hamming(STR_1, STR_1);
            });
 }
 
 #[bench]
 fn bench_hamming_dist_diverse_str_1000iter(b: &mut Bencher) {
     b.iter(|| for _ in 0..1000 {
-               hamming(STR_1, STR_2).unwrap();
+               hamming(STR_1, STR_2);
            });
 }
 


### PR DESCRIPTION
The 'hamming' distance function was changed return a u64 in https://github.com/rust-bio/rust-bio/commit/4d1854680e1ad54a45d8d7ad8fe997b39894559d, but the benchmarks still try to unwrap a Result.