### PR TITLE
Small fixes to io::fasta

### DIFF
--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -83,9 +83,12 @@ impl<R: io::Read> Reader<R> {
         Ok(())
     }
 
-    /// Return an iterator over the records of this FastQ file.
+    /// Return an iterator over the records of this Fasta file.
     pub fn records(self) -> Records<R> {
-        Records { reader: self }
+        Records {
+            reader: self,
+            error_has_occured: false,
+        }
     }
 }
 
@@ -278,7 +281,7 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
     /// Return the IndexRecord for the given sequence name or io::Result::Err
     fn idx(&self, seqname: &str) -> io::Result<IndexRecord> {
         match self.index.inner.get(seqname) {
-            Some(idx) => Ok(idx.clone()),
+            Some(idx) => Ok(*idx),
             None => Err(io::Error::new(io::ErrorKind::Other, "Unknown sequence name.")),
         }
     }
@@ -402,6 +405,9 @@ impl<'a, R: io::Read + io::Seek + 'a> Iterator for IndexedReaderIterator<'a, R> 
             item
         } else if self.bases_left > 0 {
             if let Err(e) = self.fill_buffer() {
+                self.bases_left = 0;
+                self.buf_idx = self.buf.len();
+
                 return Some(Err(e));
             }
 
@@ -492,7 +498,7 @@ impl Record {
     /// Check validity of Fasta record.
     pub fn check(&self) -> Result<(), &str> {
         if self.id().is_none() {
-            return Err("Expecting id for FastQ record.");
+            return Err("Expecting id for Fasta record.");
         }
         if !self.seq.is_ascii() {
             return Err("Non-ascii character found in sequence.");
@@ -503,7 +509,10 @@ impl Record {
 
     /// Return the id of the record.
     pub fn id(&self) -> Option<&str> {
-        self.header[1..].trim_right().splitn(2, ' ').nth(0)
+        match self.header[1..].trim_right().splitn(2, ' ').nth(0) {
+            Some("") => None,
+            value => value,
+        }
     }
 
     /// Return descriptions if present.
@@ -527,6 +536,7 @@ impl Record {
 /// An iterator over the records of a Fasta file.
 pub struct Records<R: io::Read> {
     reader: Reader<R>,
+    error_has_occured: bool,
 }
 
 
@@ -534,11 +544,18 @@ impl<R: io::Read> Iterator for Records<R> {
     type Item = io::Result<Record>;
 
     fn next(&mut self) -> Option<io::Result<Record>> {
-        let mut record = Record::new();
-        match self.reader.read(&mut record) {
-            Ok(()) if record.is_empty() => None,
-            Ok(()) => Some(Ok(record)),
-            Err(err) => Some(Err(err)),
+        if self.error_has_occured {
+            None
+        } else {
+            let mut record = Record::new();
+            match self.reader.read(&mut record) {
+                Ok(()) if record.is_empty() => None,
+                Ok(()) => Some(Ok(record)),
+                Err(err) => {
+                    self.error_has_occured = true;
+                    Some(Err(err))
+                }
+            }
         }
     }
 }
@@ -639,6 +656,57 @@ ATTGTTGTTTTA
             assert_eq!(record.desc(), descs[i]);
             assert_eq!(record.seq(), seqs[i]);
         }
+    }
+
+    #[test]
+    fn test_reader_wrong_header() {
+        let mut reader = Reader::new(&b"!test\nACGTA\n"[..]);
+        let mut record = Record::new();
+        assert!(reader.read(&mut record).is_err(),
+                "read() should return Err if FASTA header is malformed");
+    }
+
+    #[test]
+    fn test_reader_no_id() {
+        let mut reader = Reader::new(&b">\nACGTA\n"[..]);
+        let mut record = Record::new();
+        reader.read(&mut record).unwrap();
+        assert!(record.check().is_err(),
+                "check() should return Err if FASTA header is empty");
+    }
+
+    #[test]
+    fn test_reader_non_ascii_sequence() {
+        let mut reader = Reader::new(&b">id\nACGTA\xE2\x98\xB9AT\n"[..]);
+        let mut record = Record::new();
+        reader.read(&mut record).unwrap();
+        assert!(record.check().is_err(),
+                "check() should return Err if FASTA sequence is not ASCII");
+    }
+
+    #[test]
+    fn test_reader_read_fails() {
+        let mut reader = Reader::new(ReaderMock {
+                                         seek_fails: false,
+                                         read_fails: true,
+                                     });
+        let mut record = Record::new();
+        assert!(reader.read(&mut record).is_err(),
+                "read() should return Err if Read::read fails");
+    }
+
+    #[test]
+    fn test_reader_read_fails_iter() {
+        let reader = Reader::new(ReaderMock {
+                                     seek_fails: false,
+                                     read_fails: true,
+                                 });
+        let mut records = reader.records();
+
+        assert!(records.next().unwrap().is_err(),
+                "next() should return Err if Read::read fails");
+        assert!(records.next().is_none(),
+                "next() should return None after error has occurred");
     }
 
     #[test]
@@ -904,6 +972,8 @@ ATTGTTGTTTTA
         let mut reader = IndexedReader::new(bad_reader, FAI_FILE).unwrap();
         let mut iterator = reader.read_iter("id", 0, 10).unwrap();
         assert!(iterator.next().unwrap().is_err());
+        assert!(iterator.next().is_none(),
+                "next() should return none after error has occurred");
     }
 
     #[test]


### PR DESCRIPTION
This pull request is for a few small issues I noticed in io::fasta.

More specifically, the current implementation of Record::id() returns Some("") if the header is empty, instead of a None. Additionally, the two iterators in io::fasta can potentially return an infinite stream of Err values if an error occurs during iteration. This has been changed so that iteration terminates after the first error, similar to . Finally, the patch adds additional tests, including for the issues described above, and fixes some cosmetic stuff (comments referring to FastQ instead of Fasta and a minor clippy lint).

Cheers