### PR TITLE
Fasta/q parser refactoring

### DIFF
--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -502,7 +502,7 @@ impl Record {
     }
 
     /// Create a new Fasta record from given attributes.
-    pub fn from_attrs(id: &str, desc: Option<&str>, seq: TextSlice) -> Self {
+    pub fn with_attrs(id: &str, desc: Option<&str>, seq: TextSlice) -> Self {
         let desc = match desc {
             Some(desc) => Some(desc.to_owned()),
             _ => None,
@@ -738,8 +738,8 @@ ATTGTTGTTTTA
     }
 
     #[test]
-    fn test_record_from_attrs() {
-        let record = Record::from_attrs("id_str", Some("desc"), b"ATGCGGG");
+    fn test_record_with_attrs() {
+        let record = Record::with_attrs("id_str", Some("desc"), b"ATGCGGG");
         assert_eq!(record.id(), Some("id_str"));
         assert_eq!(record.desc(), Some("desc"));
         assert_eq!(record.seq(), b"ATGCGGG");

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -497,6 +497,19 @@ impl Record {
         }
     }
 
+    /// Create a new Fasta record from given attributes.
+    pub fn from_attrs(id: &str, desc: Option<&str>, seq: TextSlice) -> Self {
+        let desc = match desc {
+            Some(desc) => desc.to_owned(),
+            _ => String::new(),
+        };
+        Record {
+            id: id.to_owned(),
+            desc: desc,
+            seq: String::from_utf8(seq.to_vec()).unwrap(),
+        }
+    }
+
     /// Check if record is empty.
     pub fn is_empty(&self) -> bool {
         self.id.is_empty() && self.desc.is_empty() && self.seq.is_empty()

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -70,15 +70,8 @@ impl<R: io::Read> Reader<R> {
         if !self.line.starts_with('>') {
             return Err(io::Error::new(io::ErrorKind::Other, "Expected > at record start."));
         }
-        record.id = match self.line[1..].trim_right().splitn(2, ' ').nth(0) {
-            None => "".to_owned(),
-            Some(id) => id.to_owned()
-        };
-        record.desc = match self.line[1..].trim_right().splitn(2, ' ').nth(1) {
-            Some("") => None,
-            None => None,
-            Some(id) => Some(id.to_owned())
-        };
+        record.id = self.line[1..].trim_right().splitn(2, ' ').nth(0).map(|s| s.to_owned()).unwrap();
+        record.desc = self.line[1..].trim_right().splitn(2, ' ').nth(1).map(|s| s.to_owned());
         loop {
             self.line.clear();
             try!(self.reader.read_line(&mut self.line));

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -740,6 +740,15 @@ ATTGTTGTTTTA
     }
 
     #[test]
+    fn test_record_from_attrs() {
+        let record = Record::from_attrs("id_str", Some("desc"), b"ATGCGGG");
+        assert_eq!(record.id(), Some("id_str"));
+        assert_eq!(record.desc(), Some("desc"));
+        assert_eq!(record.seq(), b"ATGCGGG");
+
+    }
+
+    #[test]
     fn test_index_sequences() {
         let reader = IndexedReader::new(io::Cursor::new(FASTA_FILE), FAI_FILE).unwrap();
 

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -71,7 +71,6 @@ impl<R: io::Read> Reader<R> {
             return Err(io::Error::new(io::ErrorKind::Other, "Expected > at record start."));
         }
         record.id = match self.line[1..].trim_right().splitn(2, ' ').nth(0) {
-            Some("") => "".to_owned(),
             None => "".to_owned(),
             Some(id) => id.to_owned()
         };
@@ -457,7 +456,7 @@ impl<W: io::Write> Writer<W> {
 
     /// Directly write a Fasta record.
     pub fn write_record(&mut self, record: &Record) -> io::Result<()> {
-        self.write(record.id().unwrap_or(""), record.desc(), record.seq())
+        self.write(record.id(), record.desc(), record.seq())
     }
 
     /// Write a Fasta record with given id, optional description and sequence.
@@ -521,7 +520,7 @@ impl Record {
 
     /// Check validity of Fasta record.
     pub fn check(&self) -> Result<(), &str> {
-        if self.id().is_none() {
+        if self.id().is_empty() {
             return Err("Expecting id for Fasta record.");
         }
         if !self.seq.is_ascii() {
@@ -532,11 +531,8 @@ impl Record {
     }
 
     /// Return the id of the record.
-    pub fn id(&self) -> Option<&str> {
-        match self.id.as_ref() {
-            "" => None,
-            value => Some(value)
-        }
+    pub fn id(&self) -> &str {
+        self.id.as_ref()
     }
 
     /// Return descriptions if present.
@@ -672,7 +668,7 @@ ATTGTTGTTTTA
     #[test]
     fn test_reader() {
         let reader = Reader::new(FASTA_FILE);
-        let ids = [Some("id"), Some("id2")];
+        let ids = ["id", "id2"];
         let descs = [Some("desc"), None];
         let seqs: [&[u8]; 2] = [b"ACCGTAGGCTGACCGTAGGCTGAACGTAGGCTGAAAGTAGGCTGAAAACCCC",
                                 b"ATTGTTGTTTTAATTGTTGTTTTAATTGTTGTTTTAGGGG"];
@@ -740,7 +736,7 @@ ATTGTTGTTTTA
     #[test]
     fn test_record_with_attrs() {
         let record = Record::with_attrs("id_str", Some("desc"), b"ATGCGGG");
-        assert_eq!(record.id(), Some("id_str"));
+        assert_eq!(record.id(), "id_str");
         assert_eq!(record.desc(), Some("desc"));
         assert_eq!(record.seq(), b"ATGCGGG");
 

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -134,7 +134,7 @@ impl Record {
 
     /// Check validity of FastQ record.
     pub fn check(&self) -> Result<(), &str> {
-        if self.id().is_none() {
+        if self.id().is_empty() {
             return Err("Expecting id for FastQ record.");
         }
         if !self.seq.is_ascii() {
@@ -151,9 +151,8 @@ impl Record {
     }
 
     /// Return the id of the record.
-    pub fn id(&self) -> Option<&str> {
-        Some(&self.id)
-        // self.header[1..].trim_right().splitn(2, ' ').nth(0)
+    pub fn id(&self) -> &str {
+        self.id.as_ref()
     }
 
     /// Return descriptions if present.
@@ -238,7 +237,7 @@ impl<W: io::Write> Writer<W> {
 
     /// Directly write a FastQ record.
     pub fn write_record(&mut self, record: &Record) -> io::Result<()> {
-        self.write(record.id().unwrap_or(""),
+        self.write(record.id(),
                    record.desc(),
                    record.seq(),
                    record.qual())
@@ -292,7 +291,7 @@ IIIIIIJJJJJJ
         for res in records {
             let record = res.ok().unwrap();
             assert_eq!(record.check(), Ok(()));
-            assert_eq!(record.id(), Some("id"));
+            assert_eq!(record.id(), "id");
             assert_eq!(record.desc(), Some("desc"));
             assert_eq!(record.seq(), b"ACCGTAGGCTGA");
             assert_eq!(record.qual(), b"IIIIIIJJJJJJ");
@@ -302,7 +301,7 @@ IIIIIIJJJJJJ
     #[test]
     fn test_record_with_attrs() {
         let record = Record::with_attrs("id_str", Some("desc"), b"ATGCGGG", b"QQQQQQQ");
-        assert_eq!(record.id(), Some("id_str"));
+        assert_eq!(record.id(), "id_str");
         assert_eq!(record.desc(), Some("desc"));
         assert_eq!(record.seq(), b"ATGCGGG");
         assert_eq!(record.qual(), b"QQQQQQQ");

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -66,11 +66,7 @@ impl<R: io::Read> Reader<R> {
                 .nth(0)
                 .unwrap_or_default()
                 .to_owned();
-            record.desc = match header[1..].trim_right().splitn(2, ' ').nth(1) {
-                Some("") => None,
-                None => None,
-                Some(desc) => Some(desc.to_owned())
-            };
+            record.desc = header[1..].trim_right().splitn(2, ' ').nth(1).map(|s| s.to_owned());
             try!(self.reader.read_line(&mut record.seq));
             try!(self.reader.read_line(&mut self.sep_line));
             try!(self.reader.read_line(&mut record.qual));

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -299,6 +299,16 @@ IIIIIIJJJJJJ
     }
 
     #[test]
+    fn test_record_from_attrs() {
+        let record = Record::from_attrs("id_str", Some("desc"), b"ATGCGGG", b"QQQQQQQ");
+        assert_eq!(record.id(), Some("id_str"));
+        assert_eq!(record.desc(), Some("desc"));
+        assert_eq!(record.seq(), b"ATGCGGG");
+        assert_eq!(record.qual(), b"QQQQQQQ");
+
+    }
+
+    #[test]
     fn test_writer() {
         let mut writer = Writer::new(Vec::new());
         writer

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -114,7 +114,7 @@ impl Record {
     }
 
     /// Create a new FastQ record from given attributes.
-    pub fn from_attrs(id: &str, desc: Option<&str>, seq: TextSlice, qual: &[u8]) -> Self {
+    pub fn with_attrs(id: &str, desc: Option<&str>, seq: TextSlice, qual: &[u8]) -> Self {
         let desc = match desc {
             Some(desc) => Some(desc.to_owned()),
             _ => None,
@@ -300,8 +300,8 @@ IIIIIIJJJJJJ
     }
 
     #[test]
-    fn test_record_from_attrs() {
-        let record = Record::from_attrs("id_str", Some("desc"), b"ATGCGGG", b"QQQQQQQ");
+    fn test_record_with_attrs() {
+        let record = Record::with_attrs("id_str", Some("desc"), b"ATGCGGG", b"QQQQQQQ");
         assert_eq!(record.id(), Some("id_str"));
         assert_eq!(record.desc(), Some("desc"));
         assert_eq!(record.seq(), b"ATGCGGG");


### PR DESCRIPTION
Hi @johanneskoester, this is my take on a limited refactoring of the fasta and fastq parsers based on issue #133. I'm still new to Rust so I'm very open to critiques here. There are no breaking changes to the API.

What's changed:

1. Record structs lose `header` field: `id` and `desc` are now parsed during read. I know in #52 you mentioned this was done so that you could skip a record without parsing. In my informal tests it looks like there is an extremely small performance penalty to just doing the parsing anyway (on a 900k record Fastq file, there was a 0.01s slowdown on my laptop).
2. Record fields are now public (this is the only API change).
3. There is a new constructor for records: `Record::from_attrs(...)` that builds a record using the same argument signatures as the `Writer::write(...)` method. I'm not in love with the constructor name but I don't really know the conventions in Rust.