### PR TITLE
Add missing `frame_mut` method to gff::Record

### DIFF
--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -319,6 +319,11 @@ impl Record {
         &mut self.strand
     }
 
+    /// Get mutable reference on frame of feature.
+    pub fn frame_mut(&mut self) -> &mut String {
+        &mut self.frame
+    }
+
     /// Get mutable reference on attributes of feature.
     pub fn attributes_mut(&mut self) -> &mut HashMap<String, String> {
         &mut self.attributes


### PR DESCRIPTION
Hello everyone,

This is to continue the initial #132 issue. Many of the things I mentioned there are debatable, but I thought I'd start with the less-debatable ones first :). The current `gff::Record` does not have any `frame_mut` method, which makes its `frame` value unchangeable. This simple fix adds the method so that the value can be changed post-creation.

If this is ok, I'd like to implement the following changes (ordered from less opinionated first):

* Use `char` instead of `String` for the underlying strand type.
* Update gff::Record::new() to accept a tuple of the required values (as the current `new()` method seems practically the same as the derived `default()`).
* Convert the coordinate of `gff::Record` to use `bio::utils::Interval`.
* Use setters for changing the record values and only `_mut` for the containers (in this case, only the HashMap. This may need to wait until #128 is resolved first, though).