### PR TITLE
Changed terminator from ',' to ';' for GFF3.

### DIFF
--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -51,7 +51,7 @@ impl GffType {
     #[inline]
     fn separator(&self) -> (u8, u8) {
         match *self {
-            GffType::GFF3 => (b'=', b','),
+            GffType::GFF3 => (b'=', b';'),
             GffType::GFF2 => (b' ', b';'),
             GffType::GTF2 => (b' ', b';'),
             GffType::Any(x, y) => (x, y),
@@ -336,8 +336,8 @@ mod tests {
     use utils::Strand;
     use multimap::MultiMap;
 
-    const GFF_FILE: &'static [u8] = b"P0A7B8\tUniProtKB\tInitiator methionine\t1\t1\t.\t.\t.\tNote=Removed,ID=test
-P0A7B8\tUniProtKB\tChain\t2\t176\t50\t+\t.\tNote=ATP-dependent protease subunit HslV,ID=PRO_0000148105
+    const GFF_FILE: &'static [u8] = b"P0A7B8\tUniProtKB\tInitiator methionine\t1\t1\t.\t.\t.\tNote=Removed;ID=test
+P0A7B8\tUniProtKB\tChain\t2\t176\t50\t+\t.\tNote=ATP-dependent protease subunit HslV;ID=PRO_0000148105
 ";
     //required because MultiMap iter on element randomly
     const GFF_FILE_ONE_ATTRIB: &'static [u8] = b"P0A7B8\tUniProtKB\tInitiator methionine\t1\t1\t.\t.\t.\tNote=Removed

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -37,7 +37,7 @@ use utils::Strand;
 /// For each type we have key value separator and field separator
 #[derive(Clone, Copy)]
 pub enum GffType {
-    /// Attribute format is key1=value, key2=value
+    /// Attribute format is key1=value; key2=value
     GFF3,
     /// Attribute format is key1 value; key2 value
     GFF2,


### PR DESCRIPTION
According to http://gmod.org/wiki/GFF3#GFF3_Format
"multiple tag=value pairs are separated by semicolons" in the attributes
field.

To be compliant with the specification, the terminator has been changed from `,` to `;` and the test examples have been updated.

Additionally, "multiple attributes of the same type are indicated by
separating the values with the comma." In other words, if an attribute
has multiple values, these values are separated by commas. This feature
is yet not supported...