### PR TITLE
use bytecount for Occ::get

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,12 @@ documentation = "https://docs.rs/bio"
 readme = "README.md"
 license = "MIT"
 
+[features]
+avx-accel = ["bytecount/avx-accel"]
+simd-accel = ["bytecount/simd-accel"]
+
 [dependencies]
+bytecount = "0.1.7"
 csv = "0.15"
 rustc-serialize = "0.3.*"
 num-traits = "0.1.*"

--- a/src/data_structures/bwt.rs
+++ b/src/data_structures/bwt.rs
@@ -13,6 +13,7 @@ use utils::prescan;
 use alphabets::Alphabet;
 use data_structures::suffix_array::RawSuffixArray;
 use std::ops::Deref;
+use bytecount;
 
 pub type BWT = Vec<u8>;
 pub type BWTSlice = [u8];
@@ -152,12 +153,7 @@ impl Occ {
         let end = r + 1;
 
         // count all the matching bytes b/t the closest checkpoint and our desired lookup
-        let mut count: u32 = 0;
-        for &x in &bwt[start..end] {
-            if x == a {
-                count += 1;
-            }
-        }
+        let count = bytecount::count(&bwt[start..end], a);
 
         // return the sampled checkpoint for this character + the manual count we just did
         checkpoint + (count as usize)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ extern crate ordered_float;
 extern crate quick_error;
 extern crate regex;
 extern crate multimap;
+extern crate bytecount;
 
 pub mod utils;
 pub mod alphabets;


### PR DESCRIPTION
This should give a modest speedup, even more with `simd-accel` or even `avx-accel` feature enabled.