### PR TITLE
Make it easier to use Strand in hashed structs

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -16,7 +16,7 @@ pub use self::interval::{Interval, IntervalError};
 
 
 /// Strand information.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash)]
 pub enum Strand {
     Forward,
     Reverse,


### PR DESCRIPTION
I'd like to use `Strand` in data types that I use with `HashSet` containers and as `HashMap` keys. Deriving a `Hash` implementation would make this easier.

I definitely see the motivation for the `PartialEq`-only equality operator on `Strand`, and of course these data structures using `Strand` would need custom equality implementations, but a derived `Hash` on `Strand` would avoid the need for an additional, non-derived `Hash` implementation.