### PR TITLE
Remove rustc-serialize dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ simd-accel = ["bytecount/simd-accel"]
 
 [dependencies]
 bytecount = "0.1.7"
-csv = "0.15"
-rustc-serialize = "0.3.*"
+csv = "1.0.0-beta.5"
 num-traits = "0.1.*"
 num-integer = "0.1.*"
 itertools = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,6 @@
 #[macro_use]
 extern crate serde_derive;
 extern crate serde;
-extern crate rustc_serialize;
 extern crate csv;
 extern crate num_traits;
 extern crate num_integer;

--- a/src/stats/probs/mod.rs
+++ b/src/stats/probs/mod.rs
@@ -66,9 +66,7 @@ custom_derive! {
         Copy,
         Clone,
         Debug,
-        Default,
-        RustcDecodable,
-        RustcEncodable
+        Default
     )]
     #[derive(Serialize, Deserialize)]
     pub struct Prob(pub f64);
@@ -117,9 +115,7 @@ custom_derive! {
         PartialOrd,
         Copy,
         Clone,
-        Debug,
-        RustcDecodable,
-        RustcEncodable
+        Debug
     )]
     #[derive(Serialize, Deserialize)]
     pub struct LogProb(pub f64);
@@ -152,9 +148,7 @@ custom_derive! {
         PartialOrd,
         Copy,
         Clone,
-        Debug,
-        RustcDecodable,
-        RustcEncodable
+        Debug
     )]
     #[derive(Serialize, Deserialize)]
     pub struct PHREDProb(pub f64);


### PR DESCRIPTION
fixes #130

@johanneskoester The `csv` crate is still in beta, but everything works with some minor tweaks (and I'm tempted to remove this dep). Will you be okay with this?