### PR TITLE
add LogProb::cap_numerical_overshoot() with tests

### DIFF
--- a/src/stats/probs/mod.rs
+++ b/src/stats/probs/mod.rs
@@ -186,10 +186,10 @@ impl LogProb {
             return *self
         } else {
             let capped = **self - epsilon;
-        if capped <= 0.0 {
+            if capped <= 0.0 {
                 return LogProb::ln_one()
             } else {
-                panic!("Cannot correct LogProb {:} -- not within given epsilon of 0.0 ({})", **self, epsilon);
+                panic!("Cannot correct LogProb {:?} -- not within given epsilon of 0.0 ({})", **self, epsilon);
             }
         }
     }


### PR DESCRIPTION
* add function to cap LogProb values to probability range
  boundary of 1 (which is ln_one() for LogProb) if they
  are above 1, but only less then a specified epsilon

This is based on a discussion in the `libprosic` library that depends on `rust-bio`, you can check out [the respective issue](https://github.com/PROSIC/libprosic/pull/20).

@johanneskoester Do you think `cap_numerical_overshoot` is descriptive of what the function does? Are you OK with the implementation and the documentation?