### PR TITLE
distance: hamming: Use zip from stdlib rather than itertools' multizip.

### DIFF
--- a/src/alignment/distance.rs
+++ b/src/alignment/distance.rs
@@ -7,7 +7,6 @@
 //! Various subroutines for computing a distance between sequences.
 
 
-use itertools::multizip;
 use std::cmp::min;
 
 use utils::TextSlice;
@@ -34,7 +33,7 @@ pub fn hamming(alpha: TextSlice, beta: TextSlice) -> u64 {
                alpha.len(),
                beta.len());
     let mut dist = 0;
-    for (a, b) in multizip((alpha, beta)) {
+    for (a, b) in alpha.iter().zip(beta) {
         if a != b {
             dist += 1;
         }


### PR DESCRIPTION
This change produces a minor performance increase.

From https://docs.rs/itertools/0.7.4/itertools/fn.multizip.html

>Prefer izip!() over multizip for the performance benefits of using the standard library .zip(). Prefer multizip if a nameable type is needed.

But since there's only two iterators to zip, I figured using the stdlib was even more straightforward. On my system there's ~2% performance increase on `bench_hamming_dist_equal_str_1000iter`.

I'm not familiar enough with this project to know the conventions for copyright etc - let me know what to do if needed.
Thanks, ben