### PR TITLE
Fixes benches so they compile.

### DIFF
--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -1,7 +1,6 @@
 #![feature(test)]
 
 extern crate bio;
-extern crate bit_vec;
 extern crate test;
 
 use test::Bencher;

--- a/benches/pairwise.rs
+++ b/benches/pairwise.rs
@@ -1,7 +1,6 @@
 #![feature(test)]
 
 extern crate bio;
-extern crate bit_vec;
 extern crate test;
 
 use bio::alignment::pairwise::*;

--- a/benches/suffix_array.rs
+++ b/benches/suffix_array.rs
@@ -1,7 +1,6 @@
 #![feature(test)]
 
 extern crate bio;
-extern crate bit_vec;
 extern crate test;
 
 use test::Bencher;


### PR DESCRIPTION
The benchmarks weren't compiling because they were referring to an unknown extern crates. This PR fixes that so they can be run again.