### PR TITLE
Adding trait Zero for the probability types.

### DIFF
--- a/src/stats/probs/mod.rs
+++ b/src/stats/probs/mod.rs
@@ -14,7 +14,7 @@ use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 
 use itertools::Itertools;
 use itertools_num::linspace;
-use num_traits::Float;
+use num_traits::{Float, Zero};
 use ordered_float::NotNaN;
 
 /// A factor to convert log-probabilities to PHRED-scale (phred = p * `LOG_TO_PHRED_FACTOR`).
@@ -412,6 +412,36 @@ impl Default for PHREDProb {
     }
 }
 
+impl Zero for Prob {
+    fn zero() -> Self {
+        Prob(0.0)
+    }
+
+    fn is_zero(&self) -> bool {
+        **self == 0.0
+    }
+}
+
+impl Zero for LogProb {
+    fn zero() -> Self {
+        LogProb::ln_zero()
+    }
+
+    fn is_zero(&self) -> bool {
+        self.is_infinite() && self.signum() < 0.0
+    }
+}
+
+impl Zero for PHREDProb {
+    fn zero() -> Self {
+        PHREDProb::from(Prob(0.0))
+    }
+
+    fn is_zero(&self) -> bool {
+        *self == Self::zero()
+    }
+}
+
 quick_error! {
     #[derive(Debug)]
     pub enum ProbError {
@@ -515,5 +545,12 @@ mod tests {
             LogProb::ln_one().ln_add_exp(LogProb::ln_zero()),
             LogProb::ln_one()
         );
+    }
+
+    #[test]
+    fn test_zero() {
+        assert!(LogProb::zero().is_zero());
+        assert!(Prob::zero().is_zero());
+        assert!(PHREDProb::zero().is_zero());
     }
 }


### PR DESCRIPTION
This is necessary, e.g., for using `LogProb` in an `ndarray::Array2`.