### PR TITLE
Implement the fast but accurate approximation of exp presented by Kopcynski 2017.

### DIFF
--- a/src/stats/bayesian.rs
+++ b/src/stats/bayesian.rs
@@ -58,6 +58,6 @@ mod tests {
 
         assert_relative_eq!(*fdrs[1], *LogProb::ln_zero());
         assert_relative_eq!(*fdrs[0], *LogProb(0.05f64.ln()));
-        assert_relative_eq!(*fdrs[2], *LogProb((0.35 / 3.0f64).ln()), epsilon=0.000001);
+        assert_relative_eq!(*fdrs[2], *LogProb((0.35 / 3.0f64).ln()), epsilon = 0.000001);
     }
 }

--- a/src/stats/bayesian.rs
+++ b/src/stats/bayesian.rs
@@ -58,6 +58,6 @@ mod tests {
 
         assert_relative_eq!(*fdrs[1], *LogProb::ln_zero());
         assert_relative_eq!(*fdrs[0], *LogProb(0.05f64.ln()));
-        assert_relative_eq!(*fdrs[2], *LogProb((0.35 / 3.0f64).ln()));
+        assert_relative_eq!(*fdrs[2], *LogProb((0.35 / 3.0f64).ln()), epsilon=0.000001);
     }
 }

--- a/src/stats/probs/cdf.rs
+++ b/src/stats/probs/cdf.rs
@@ -60,7 +60,7 @@ impl<T: Ord> CDF<T> {
 
         // cap at prob=1.0 if there are slightly exceeding values due to numerical issues.
         for e in &mut cdf.inner {
-            if relative_eq!(*e.prob, *LogProb::ln_one()) && *e.prob > *LogProb::ln_one() {
+            if relative_eq!(*e.prob, *LogProb::ln_one(), epsilon=0.00001) && *e.prob > *LogProb::ln_one() {
                 e.prob = LogProb::ln_one();
             }
         }
@@ -277,10 +277,10 @@ mod test {
         let cdf = CDF::from_pmf(pmf.clone());
         println!("{:?}", cdf);
         for e in pmf.iter().skip(2) {
-            assert_ulps_eq!(
+            assert_relative_eq!(
                 *e.prob,
                 *cdf.get_pmf(&e.value).unwrap(),
-                epsilon = 0.0000000000001
+                epsilon = 0.000003
             );
         }
         assert_relative_eq!(*cdf.total_prob(), 1.0f64.ln());
@@ -297,7 +297,7 @@ mod test {
 
         {
             for e in cdf.iter_pmf() {
-                assert_relative_eq!(e.prob.exp(), if **e.value == 0.0 { 0.2 } else { 0.1 });
+                assert_relative_eq!(e.prob.exp(), if **e.value == 0.0 { 0.2 } else { 0.1 }, epsilon=0.0001);
             }
         }
 

--- a/src/stats/probs/cdf.rs
+++ b/src/stats/probs/cdf.rs
@@ -60,7 +60,9 @@ impl<T: Ord> CDF<T> {
 
         // cap at prob=1.0 if there are slightly exceeding values due to numerical issues.
         for e in &mut cdf.inner {
-            if relative_eq!(*e.prob, *LogProb::ln_one(), epsilon=0.00001) && *e.prob > *LogProb::ln_one() {
+            if relative_eq!(*e.prob, *LogProb::ln_one(), epsilon = 0.00001)
+                && *e.prob > *LogProb::ln_one()
+            {
                 e.prob = LogProb::ln_one();
             }
         }
@@ -277,11 +279,7 @@ mod test {
         let cdf = CDF::from_pmf(pmf.clone());
         println!("{:?}", cdf);
         for e in pmf.iter().skip(2) {
-            assert_relative_eq!(
-                *e.prob,
-                *cdf.get_pmf(&e.value).unwrap(),
-                epsilon = 0.000003
-            );
+            assert_relative_eq!(*e.prob, *cdf.get_pmf(&e.value).unwrap(), epsilon = 0.000003);
         }
         assert_relative_eq!(*cdf.total_prob(), 1.0f64.ln());
         assert_relative_eq!(
@@ -297,7 +295,11 @@ mod test {
 
         {
             for e in cdf.iter_pmf() {
-                assert_relative_eq!(e.prob.exp(), if **e.value == 0.0 { 0.2 } else { 0.1 }, epsilon=0.0001);
+                assert_relative_eq!(
+                    e.prob.exp(),
+                    if **e.value == 0.0 { 0.2 } else { 0.1 },
+                    epsilon = 0.0001
+                );
             }
         }
 

--- a/src/stats/probs/mod.rs
+++ b/src/stats/probs/mod.rs
@@ -481,7 +481,7 @@ mod tests {
 
         assert_relative_eq!(*cumsum[0], *LogProb::ln_zero());
         assert_relative_eq!(*cumsum[1], 0.01f64.ln());
-        assert_relative_eq!(*cumsum[2], 0.011f64.ln(), epsilon=0.000001);
+        assert_relative_eq!(*cumsum[2], 0.011f64.ln(), epsilon = 0.000001);
     }
 
     #[test]
@@ -493,7 +493,7 @@ mod tests {
         assert_relative_eq!(
             *LogProb::ln_one().ln_sub_exp(LogProb(0.5f64.ln())),
             *LogProb(0.5f64.ln()),
-            epsilon=0.0000000001
+            epsilon = 0.0000000001
         );
         assert_relative_eq!(
             *LogProb(-1.6094379124341).ln_sub_exp(LogProb::ln_zero()),

--- a/src/stats/probs/mod.rs
+++ b/src/stats/probs/mod.rs
@@ -16,6 +16,7 @@ use itertools::Itertools;
 use itertools_num::linspace;
 use num_traits::{Float, Zero};
 use ordered_float::NotNaN;
+use utils::FastExp;
 
 /// A factor to convert log-probabilities to PHRED-scale (phred = p * `LOG_TO_PHRED_FACTOR`).
 const LOG_TO_PHRED_FACTOR: f64 = -4.342_944_819_032_517_5; // -10 * 1 / ln(10)
@@ -28,7 +29,7 @@ const PHRED_TO_LOG_FACTOR: f64 = -0.230_258_509_299_404_56; // 1 / (-10 * log10(
 fn ln_1m_exp(p: f64) -> f64 {
     assert!(p <= 0.0);
     if p < -0.693 {
-        (-p.exp()).ln_1p()
+        (-p.fastexp()).ln_1p()
     } else {
         (-p.exp_m1()).ln()
     }
@@ -227,7 +228,7 @@ impl LogProb {
                             if i == imax {
                                 None
                             } else {
-                                Some((p - pmax).exp())
+                                Some((p - pmax).fastexp())
                             }
                         }).fold(0.0, |s, e| s + e)).ln_1p(),
                 )
@@ -246,7 +247,7 @@ impl LogProb {
         } else if *p0 == f64::INFINITY {
             LogProb(f64::INFINITY)
         } else {
-            p0 + LogProb((p1 - p0).exp().ln_1p())
+            p0 + LogProb((p1 - p0).fastexp().ln_1p())
         }
     }
 
@@ -363,7 +364,7 @@ impl From<LogProb> for NotNaN<f64> {
 
 impl From<LogProb> for Prob {
     fn from(p: LogProb) -> Prob {
-        Prob(p.exp())
+        Prob(p.fastexp())
     }
 }
 

--- a/src/stats/probs/mod.rs
+++ b/src/stats/probs/mod.rs
@@ -482,7 +482,7 @@ mod tests {
 
         assert_relative_eq!(*cumsum[0], *LogProb::ln_zero());
         assert_relative_eq!(*cumsum[1], 0.01f64.ln());
-        assert_relative_eq!(*cumsum[2], 0.011f64.ln(), epsilon=0.000001);
+        assert_relative_eq!(*cumsum[2], 0.011f64.ln(), epsilon = 0.000001);
     }
 
     #[test]
@@ -494,7 +494,7 @@ mod tests {
         assert_relative_eq!(
             *LogProb::ln_one().ln_sub_exp(LogProb(0.5f64.ln())),
             *LogProb(0.5f64.ln()),
-            epsilon=0.0000000001
+            epsilon = 0.0000000001
         );
         assert_relative_eq!(
             *LogProb(-1.6094379124341).ln_sub_exp(LogProb::ln_zero()),

--- a/src/stats/probs/mod.rs
+++ b/src/stats/probs/mod.rs
@@ -3,7 +3,8 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Handling log-probabilities.
+//! Handling log-probabilities. Log probabilities are an important tool to deal with probabilities
+//! in a numerically stable way, in particular when having probabilities close to zero.
 
 pub mod cdf;
 
@@ -481,7 +482,7 @@ mod tests {
 
         assert_relative_eq!(*cumsum[0], *LogProb::ln_zero());
         assert_relative_eq!(*cumsum[1], 0.01f64.ln());
-        assert_relative_eq!(*cumsum[2], 0.011f64.ln(), epsilon = 0.000001);
+        assert_relative_eq!(*cumsum[2], 0.011f64.ln(), epsilon=0.000001);
     }
 
     #[test]
@@ -493,7 +494,7 @@ mod tests {
         assert_relative_eq!(
             *LogProb::ln_one().ln_sub_exp(LogProb(0.5f64.ln())),
             *LogProb(0.5f64.ln()),
-            epsilon = 0.0000000001
+            epsilon=0.0000000001
         );
         assert_relative_eq!(
             *LogProb(-1.6094379124341).ln_sub_exp(LogProb::ln_zero()),

--- a/src/utils/fastexp.rs
+++ b/src/utils/fastexp.rs
@@ -15,12 +15,12 @@ const MIN_VAL: f64 = -500.0;
 
 
 pub trait FastExp<V: Float + ops::MulAssign> {
+    /// Fast approximation of exp() as shown by Kopcynski 2017:
+    /// https://eldorado.tu-dortmund.de/bitstream/2003/36203/1/Dissertation_Kopczynski.pdf
     fn fastexp(&self) -> V;
 }
 
 impl FastExp<f64> for f64 {
-    /// Fast approximation of exp() as shown by Kopcynski 2017:
-    /// https://eldorado.tu-dortmund.de/bitstream/2003/36203/1/Dissertation_Kopczynski.pdf
     fn fastexp(&self) -> f64 {
         if *self > MIN_VAL {
             let mut x = ONEBYLOG2 * self;

--- a/src/utils/fastexp.rs
+++ b/src/utils/fastexp.rs
@@ -1,0 +1,75 @@
+use num_traits::Float;
+use std::ops;
+
+const COEFF_0: f64 = 1.0;
+const COEFF_1: f64 = 4.831794110;
+const COEFF_2: f64 = 0.143440676;
+const COEFF_3: f64 = 0.019890581;
+const COEFF_4: f64 =  0.006935931;
+const ONEBYLOG2: f64 =  1.442695041;
+const OFFSET_F32: i64 = 127;
+const OFFSET_F64: i64 = 1023;
+const FRACTION_F32: u32 = 23;
+const FRACTION_F64: u32 = 52;
+const MIN_VAL: f64 = -500.0;
+
+
+pub trait FastExp<V: Float + ops::MulAssign> {
+    fn fastexp(&self) -> V;
+}
+
+impl FastExp<f64> for f64 {
+    /// Fast approximation of exp() as shown by Kopcynski 2017:
+    /// https://eldorado.tu-dortmund.de/bitstream/2003/36203/1/Dissertation_Kopczynski.pdf
+    fn fastexp(&self) -> f64 {
+        if *self > MIN_VAL {
+            let mut x = ONEBYLOG2 * self;
+
+            #[repr(C)]
+            union F1 {
+                i: i64,
+                f: f64,
+            }
+            let mut f1 = F1 { i: x as i64 };
+
+            x -= unsafe { f1.i } as f64;
+            let mut f2 = x;
+            let mut x_tmp = x;
+
+            unsafe {
+                f1.i += OFFSET_F64;
+                f1.i <<= FRACTION_F64;
+            }
+
+            f2 *= COEFF_4;
+            x_tmp += COEFF_1;
+            f2 += COEFF_3;
+            x_tmp *= x;
+            f2 *= x;
+            f2 += COEFF_2;
+            f2 *= x_tmp;
+            f2 += COEFF_0;
+
+            unsafe { f1.f * f2 }
+        } else {
+            0.0
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fastexp() {
+        let x = 1e-15_f64.ln();
+        assert_relative_eq!(x.fastexp(), 1e-15);
+        let x = 1e-8_f64.ln();
+        assert_relative_eq!(x.fastexp(), 1e-8, epsilon=0.00000000000002);
+        let x = 0.5_f64.ln();
+        assert_relative_eq!(x.fastexp(), 0.5, epsilon=0.01);
+        let x = -159.00000002327861_f64;
+        assert_relative_eq!(x.fastexp(), (-159.00000002327861).exp());
+    }
+}

--- a/src/utils/fastexp.rs
+++ b/src/utils/fastexp.rs
@@ -1,3 +1,12 @@
+// Copyright 2014-2016 Johannes Köster.
+// Licensed under the MIT license (http://opensource.org/licenses/MIT)
+// This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This module provides a trait adding a fast approximation of the exponential function to f64.
+//! This can be very useful if the exact value is not too important, for example when working with
+//! `bio::stats::LogProb`.
+
 use num_traits::Float;
 use std::ops;
 
@@ -7,20 +16,19 @@ const COEFF_2: f64 = 0.143440676;
 const COEFF_3: f64 = 0.019890581;
 const COEFF_4: f64 =  0.006935931;
 const ONEBYLOG2: f64 =  1.442695041;
-const OFFSET_F32: i64 = 127;
 const OFFSET_F64: i64 = 1023;
-const FRACTION_F32: u32 = 23;
 const FRACTION_F64: u32 = 52;
 const MIN_VAL: f64 = -500.0;
 
 
+/// This trait adds a fast approximation of exp to float types.
 pub trait FastExp<V: Float + ops::MulAssign> {
-    /// Fast approximation of exp() as shown by Kopcynski 2017:
-    /// https://eldorado.tu-dortmund.de/bitstream/2003/36203/1/Dissertation_Kopczynski.pdf
     fn fastexp(&self) -> V;
 }
 
 impl FastExp<f64> for f64 {
+    /// Fast approximation of exp() as shown by Kopcynski 2017:
+    /// https://eldorado.tu-dortmund.de/bitstream/2003/36203/1/Dissertation_Kopczynski.pdf
     fn fastexp(&self) -> f64 {
         if *self > MIN_VAL {
             let mut x = ONEBYLOG2 * self;

--- a/src/utils/fastexp.rs
+++ b/src/utils/fastexp.rs
@@ -14,12 +14,11 @@ const COEFF_0: f64 = 1.0;
 const COEFF_1: f64 = 4.831794110;
 const COEFF_2: f64 = 0.143440676;
 const COEFF_3: f64 = 0.019890581;
-const COEFF_4: f64 =  0.006935931;
-const ONEBYLOG2: f64 =  1.442695041;
+const COEFF_4: f64 = 0.006935931;
+const ONEBYLOG2: f64 = 1.442695041;
 const OFFSET_F64: i64 = 1023;
 const FRACTION_F64: u32 = 52;
 const MIN_VAL: f64 = -500.0;
-
 
 /// This trait adds a fast approximation of exp to float types.
 pub trait FastExp<V: Float + ops::MulAssign> {
@@ -74,9 +73,9 @@ mod tests {
         let x = 1e-15_f64.ln();
         assert_relative_eq!(x.fastexp(), 1e-15);
         let x = 1e-8_f64.ln();
-        assert_relative_eq!(x.fastexp(), 1e-8, epsilon=0.00000000000002);
+        assert_relative_eq!(x.fastexp(), 1e-8, epsilon = 0.00000000000002);
         let x = 0.5_f64.ln();
-        assert_relative_eq!(x.fastexp(), 0.5, epsilon=0.01);
+        assert_relative_eq!(x.fastexp(), 0.5, epsilon = 0.01);
         let x = -159.00000002327861_f64;
         assert_relative_eq!(x.fastexp(), (-159.00000002327861).exp());
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,6 +5,9 @@
 
 //! Common utilities.
 
+mod fastexp;
+pub use self::fastexp::FastExp;
+
 mod text;
 pub use self::text::{trim_newline, IntoTextIterator, Text, TextIterator, TextSlice};
 


### PR DESCRIPTION
Use the approximation for LogProbs. This should provide speedups up to 5x, depending on the function.