### PR TITLE
Optimize pairHMM implementation

### DIFF
--- a/benches/pairhmm.rs
+++ b/benches/pairhmm.rs
@@ -1,0 +1,102 @@
+#![feature(test)]
+
+extern crate bio;
+extern crate test;
+
+use test::Bencher;
+use bio::stats::pairhmm::*;
+use bio::stats::{LogProb, Prob};
+
+static TEXT: &'static [u8] = b"GATCACAGGTCTATCACCCTATTAACCACTCACGGGAGCTCTCCATGC\
+ATTTGGTATTTTCGTCTGGGGGGTATGCACGCGATAGCATTGCGAGACGCTGGAGCCGGAGCACCCTATGTCGCAGTAT\
+CTGTCTTTGATTCCTGCCTCATCCTATTATTTATCGCACCTACGTTCAATATTACAGGCGAACATACTTACTAAAGTGT";
+
+static PATTERN: &'static [u8] = b"GGGTATGCACGCGATAGCATTGCGAGACGCTGGAGCCGGAGCACCCTATGTCGC";
+
+// Single base insertion and deletion rates for R1 according to Schirmer et al.
+// BMC Bioinformatics 2016, 10.1186/s12859-016-0976-y
+static PROB_ILLUMINA_INS: Prob = Prob(2.8e-6);
+static PROB_ILLUMINA_DEL: Prob = Prob(5.1e-6);
+static PROB_ILLUMINA_SUBST: Prob = Prob(0.0021);
+
+fn prob_emit_x_or_y() -> LogProb {
+    LogProb::from(Prob(1.0) - PROB_ILLUMINA_SUBST)
+}
+
+
+pub struct TestEmissionParams {
+    x: &'static [u8],
+    y: &'static [u8],
+}
+
+impl EmissionParameters for TestEmissionParams {
+    fn prob_emit_xy(&self, i: usize, j: usize) -> LogProb {
+        if self.x[i] == self.y[j] {
+            LogProb::from(Prob(1.0) - PROB_ILLUMINA_SUBST)
+        } else {
+            LogProb::from(PROB_ILLUMINA_SUBST / Prob(3.0))
+        }
+    }
+
+    fn prob_emit_x(&self, _: usize) -> LogProb {
+        prob_emit_x_or_y()
+    }
+
+    fn prob_emit_y(&self, _: usize) -> LogProb {
+        prob_emit_x_or_y()
+    }
+
+    fn len_x(&self) -> usize {
+        self.x.len()
+    }
+
+    fn len_y(&self) -> usize {
+        self.y.len()
+    }
+}
+
+
+pub struct SemiglobalGapParams;
+
+impl GapParameters for SemiglobalGapParams {
+    fn prob_gap_x(&self) -> LogProb {
+        LogProb::from(PROB_ILLUMINA_INS)
+    }
+
+    fn prob_gap_y(&self) -> LogProb {
+        LogProb::from(PROB_ILLUMINA_DEL)
+    }
+
+    fn prob_gap_x_extend(&self) -> LogProb {
+        LogProb::ln_zero()
+    }
+
+    fn prob_gap_y_extend(&self) -> LogProb {
+        LogProb::ln_zero()
+    }
+}
+
+impl StartEndGapParameters for SemiglobalGapParams {
+    fn free_start_gap_x(&self) -> bool {
+        true
+    }
+
+    fn free_end_gap_x(&self) -> bool {
+        true
+    }
+}
+
+
+
+#[bench]
+fn pairhmm_semiglobal(b: &mut Bencher) {
+    let emission_params = TestEmissionParams { x: TEXT, y: PATTERN };
+    let gap_params = SemiglobalGapParams;
+
+    let mut pair_hmm = PairHMM::new();
+
+    b.iter(|| {
+        let p = pair_hmm.prob_related(&gap_params, &emission_params);
+        assert!(*p <= 0.0);
+    });
+}

--- a/benches/pairhmm.rs
+++ b/benches/pairhmm.rs
@@ -3,9 +3,9 @@
 extern crate bio;
 extern crate test;
 
-use test::Bencher;
 use bio::stats::pairhmm::*;
 use bio::stats::{LogProb, Prob};
+use test::Bencher;
 
 static TEXT: &'static [u8] = b"GATCACAGGTCTATCACCCTATTAACCACTCACGGGAGCTCTCCATGC\
 ATTTGGTATTTTCGTCTGGGGGGTATGCACGCGATAGCATTGCGAGACGCTGGAGCCGGAGCACCCTATGTCGCAGTAT\
@@ -22,7 +22,6 @@ static PROB_ILLUMINA_SUBST: Prob = Prob(0.0021);
 fn prob_emit_x_or_y() -> LogProb {
     LogProb::from(Prob(1.0) - PROB_ILLUMINA_SUBST)
 }
-
 
 pub struct TestEmissionParams {
     x: &'static [u8],
@@ -55,7 +54,6 @@ impl EmissionParameters for TestEmissionParams {
     }
 }
 
-
 pub struct SemiglobalGapParams;
 
 impl GapParameters for SemiglobalGapParams {
@@ -86,11 +84,12 @@ impl StartEndGapParameters for SemiglobalGapParams {
     }
 }
 
-
-
 #[bench]
 fn pairhmm_semiglobal(b: &mut Bencher) {
-    let emission_params = TestEmissionParams { x: TEXT, y: PATTERN };
+    let emission_params = TestEmissionParams {
+        x: TEXT,
+        y: PATTERN,
+    };
     let gap_params = SemiglobalGapParams;
 
     let mut pair_hmm = PairHMM::new();

--- a/src/data_structures/rank_select.rs
+++ b/src/data_structures/rank_select.rs
@@ -222,9 +222,9 @@ fn superblocks(t: bool, n: usize, s: usize, bits: &BitVec<u8>) -> Vec<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bv::bit_vec;
     use bv::BitVec;
     use bv::BitsMut;
-    use bv::bit_vec;
 
     #[test]
     fn test_rank_select() {

--- a/src/data_structures/rank_select.rs
+++ b/src/data_structures/rank_select.rs
@@ -224,6 +224,7 @@ mod tests {
     use super::*;
     use bv::BitVec;
     use bv::BitsMut;
+    use bv::bit_vec;
 
     #[test]
     fn test_rank_select() {

--- a/src/stats/hmm.rs
+++ b/src/stats/hmm.rs
@@ -674,6 +674,7 @@ pub mod univariate_continuous_emission {
 mod tests {
     use super::super::Prob;
     use statrs::distribution::Normal;
+    use ndarray::array;
 
     use super::discrete_emission::Model as DiscreteEmissionHMM;
     use super::univariate_continuous_emission::GaussianModel as GaussianHMM;

--- a/src/stats/hmm.rs
+++ b/src/stats/hmm.rs
@@ -673,8 +673,8 @@ pub mod univariate_continuous_emission {
 #[cfg(test)]
 mod tests {
     use super::super::Prob;
-    use statrs::distribution::Normal;
     use ndarray::array;
+    use statrs::distribution::Normal;
 
     use super::discrete_emission::Model as DiscreteEmissionHMM;
     use super::univariate_continuous_emission::GaussianModel as GaussianHMM;

--- a/src/stats/pairhmm.rs
+++ b/src/stats/pairhmm.rs
@@ -8,6 +8,7 @@
 //! probability that a certain sequencing read comes from a given position in a reference genome.
 
 use std::mem;
+use std::cmp;
 
 use stats::LogProb;
 
@@ -127,8 +128,8 @@ impl PairHMM {
         let prob_gap_y = gap_params.prob_gap_y();
         let prob_gap_x_extend = gap_params.prob_gap_x_extend();
         let prob_gap_y_extend = gap_params.prob_gap_y_extend();
-        // let do_gap_extend = prob_gap_x_extend != LogProb::ln_zero() &&
-        //                     prob_gap_y_extend != LogProb::ln_zero();
+        let do_gap_y_extend = prob_gap_y_extend != LogProb::ln_zero();
+        let do_gap_x_extend = prob_gap_x_extend != LogProb::ln_zero();
 
         let mut prev = 0;
         let mut curr = 1;
@@ -141,40 +142,77 @@ impl PairHMM {
 
             let prob_emit_x = emission_params.prob_emit_x(i);
 
+            let j_min = if do_gap_x_extend {
+                0
+            } else {
+                // The final upper triangle in the dynamic programming matrix
+                // will be only zeros if gap extension is not allowed on x.
+                // Hence we can omit it.
+                emission_params.len_y().saturating_sub(emission_params.len_x() - i + 1)
+            };
+
+            let j_max = if do_gap_x_extend {
+                emission_params.len_y()
+            } else {
+                // The initial lower triangle in the dynamic programming matrix
+                // will be only zeros if gap extension is not allowed on x.
+                // Hence we can omit it.
+                cmp::min(i + 1, emission_params.len_y())
+            };
+
             // iterate over y
-            for j in 0..emission_params.len_y() {
+            for j in j_min..j_max {
                 let j_ = j + 1;
+                let j_minus_one = j_ - 1;
 
-                // match or mismatch
-                self.fm[curr][j_] = emission_params.prob_emit_xy(i, j) + LogProb::ln_sum_exp(&[
-                    // coming from state M
-                    prob_no_gap + self.fm[prev][j_ - 1],
-                    // coming from state X
-                    prob_no_gap_x_extend + self.fx[prev][j_ - 1],
-                    // coming from state Y
-                    prob_no_gap_y_extend + self.fy[prev][j_ - 1],
-                ]);
+                let (prob_match_mismatch, prob_gap_x, prob_gap_y) = {
+                    let fm_curr = &self.fm[curr];
+                    let fm_prev = &self.fm[prev];
+                    let fx_prev = &self.fx[prev];
+                    let fy_curr = &self.fy[curr];
+                    let fy_prev = &self.fy[prev];
 
-                // gap in y
-                self.fx[curr][j_] = prob_emit_x
-                    + (
-                    // open gap
-                    prob_gap_y + self.fm[prev][j_]
-                )
-                        .ln_add_exp(
-                            // extend gap
-                            prob_gap_y_extend + self.fx[prev][j_],
-                        );
+                    // match or mismatch
+                    let prob_match_mismatch = emission_params.prob_emit_xy(i, j) + LogProb::ln_sum_exp(&[
+                        // coming from state M
+                        prob_no_gap + fm_prev[j_minus_one],
+                        // coming from state X
+                        prob_no_gap_x_extend + fx_prev[j_minus_one],
+                        // coming from state Y
+                        prob_no_gap_y_extend + fy_prev[j_minus_one],
+                    ]);
 
-                // gap in x
-                self.fy[curr][j_] = emission_params.prob_emit_y(j)
-                    + (
-                    // open gap
-                    prob_gap_x + self.fm[curr][j_ - 1]
-                ).ln_add_exp(
-                        // extend gap
-                        prob_gap_x_extend + self.fy[curr][j_ - 1],
+                    // gap in y
+                    let mut prob_gap_y = prob_emit_x + (
+                        // open gap
+                        prob_gap_y + fm_prev[j_]
                     );
+                    if do_gap_y_extend {
+                        prob_gap_y = prob_gap_y.ln_add_exp(
+                            // extend gap
+                            prob_gap_y_extend + fx_prev[j_],
+                        );
+                    }
+
+
+                    // gap in x
+                    let mut prob_gap_x = emission_params.prob_emit_y(j) + (
+                        // open gap
+                        prob_gap_x + fm_curr[j_minus_one]
+                    );
+                    if do_gap_x_extend {
+                        prob_gap_x = prob_gap_x.ln_add_exp(
+                            // extend gap
+                            prob_gap_x_extend + fy_curr[j_minus_one],
+                        );
+                    }
+
+                    (prob_match_mismatch, prob_gap_x, prob_gap_y)
+                };
+
+                self.fm[curr][j_] = prob_match_mismatch;
+                self.fx[curr][j_] = prob_gap_y;
+                self.fy[curr][j_] = prob_gap_x;
             }
 
             if gap_params.free_end_gap_x() {

--- a/src/stats/pairhmm.rs
+++ b/src/stats/pairhmm.rs
@@ -7,8 +7,8 @@
 //! each other. Depending on the used parameters, this can, e.g., be used to calculate the
 //! probability that a certain sequencing read comes from a given position in a reference genome.
 
-use std::mem;
 use std::cmp;
+use std::mem;
 
 use stats::LogProb;
 
@@ -148,7 +148,9 @@ impl PairHMM {
                 // The final upper triangle in the dynamic programming matrix
                 // will be only zeros if gap extension is not allowed on x.
                 // Hence we can omit it.
-                emission_params.len_y().saturating_sub(emission_params.len_x() - i + 1)
+                emission_params
+                    .len_y()
+                    .saturating_sub(emission_params.len_x() - i + 1)
             };
 
             let j_max = if do_gap_x_extend {
@@ -173,17 +175,19 @@ impl PairHMM {
                     let fy_prev = &self.fy[prev];
 
                     // match or mismatch
-                    let prob_match_mismatch = emission_params.prob_emit_xy(i, j) + LogProb::ln_sum_exp(&[
-                        // coming from state M
-                        prob_no_gap + fm_prev[j_minus_one],
-                        // coming from state X
-                        prob_no_gap_x_extend + fx_prev[j_minus_one],
-                        // coming from state Y
-                        prob_no_gap_y_extend + fy_prev[j_minus_one],
-                    ]);
+                    let prob_match_mismatch = emission_params.prob_emit_xy(i, j)
+                        + LogProb::ln_sum_exp(&[
+                            // coming from state M
+                            prob_no_gap + fm_prev[j_minus_one],
+                            // coming from state X
+                            prob_no_gap_x_extend + fx_prev[j_minus_one],
+                            // coming from state Y
+                            prob_no_gap_y_extend + fy_prev[j_minus_one],
+                        ]);
 
                     // gap in y
-                    let mut prob_gap_y = prob_emit_x + (
+                    let mut prob_gap_y = prob_emit_x
+                        + (
                         // open gap
                         prob_gap_y + fm_prev[j_]
                     );
@@ -194,9 +198,9 @@ impl PairHMM {
                         );
                     }
 
-
                     // gap in x
-                    let mut prob_gap_x = emission_params.prob_emit_y(j) + (
+                    let mut prob_gap_x = emission_params.prob_emit_y(j)
+                        + (
                         // open gap
                         prob_gap_x + fm_curr[j_minus_one]
                     );

--- a/src/stats/probs/mod.rs
+++ b/src/stats/probs/mod.rs
@@ -237,7 +237,8 @@ impl LogProb {
                             } else {
                                 Some((p - pmax).fastexp())
                             }
-                        }).sum::<f64>().ln_1p(),
+                        }).sum::<f64>()
+                        .ln_1p(),
                 )
             }
         }


### PR DESCRIPTION
* Omit superfluous parts of the matrix.
* Skip unnecessary ln or exp operations.
* Avoid repeated indexing into vectors.

This should improve pairHMM runtime by up to 40% (in the semiglobal case) and about 20% in the global case.