### PR TITLE
Reader traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [0.25.0] - Unreleased
+- Added `FQRead` and `FARead` traits to `FastaReader` and `FastqReader` to be more flexible with input types. This allows to use readers on gzipped and on plain text input interchangeably.
+
 # [0.24.0] - 2018-11-26
 - API overhaul to become more flexible when accepting text iterators. Now, anything that iterates over something can be borrowed as u8 is allowed.
 - FMIndex and FMDIndex now also allow plain owned versions of BWT, Less and Occ. This should greatly simplify their usage.

--- a/src/data_structures/bwt.rs
+++ b/src/data_structures/bwt.rs
@@ -12,7 +12,6 @@ use std::iter::repeat;
 use alphabets::Alphabet;
 use bytecount;
 use data_structures::suffix_array::RawSuffixArray;
-use std::ops::Deref;
 use utils::prescan;
 
 pub type BWT = Vec<u8>;

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -29,7 +29,7 @@ use utils::{Text, TextSlice};
 const MAX_FASTA_BUFFER_SIZE: usize = 512;
 
 /// Trait for FASTA readers.
-pub trait Read {
+pub trait FastaRead {
     fn read(&mut self, record: &mut Record) -> io::Result<()>;
 }
 
@@ -96,7 +96,7 @@ impl<R: io::Read> Reader<R> {
     }
 }
 
-impl<R> Read for Reader<R>
+impl<R> FastaRead for Reader<R>
 where
     R: io::Read,
 {
@@ -105,7 +105,7 @@ where
     /// # Example
     /// ```rust
     /// # use std::io;
-    /// # use bio::io::fasta::{Reader, Read};
+    /// # use bio::io::fasta::{Reader, FastaRead};
     /// # use bio::io::fasta::Record;
     /// # fn main() {
     /// # const fasta_file: &'static [u8] = b">id desc
@@ -795,7 +795,7 @@ ATTGTTGTTTTA
     #[test]
     fn test_faread_trait() {
         let path = "genome.fa.gz";
-        let mut fa_reader: Box<Read> = match path.ends_with(".gz") {
+        let mut fa_reader: Box<FastaRead> = match path.ends_with(".gz") {
             true => Box::new(Reader::new(io::BufReader::new(FASTA_FILE))),
             false => Box::new(Reader::new(FASTA_FILE)),
         };

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 Johannes Köster, Christopher Schröder, Henning Timm.
+// Copyright 2014-2018 Johannes Köster, Christopher Schröder, Henning Timm.
 // Licensed under the MIT license (http://opensource.org/licenses/MIT)
 // This file may not be copied, modified, or distributed
 // except according to those terms.

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -792,19 +792,11 @@ ATTGTTGTTTTA
 
     #[test]
     fn test_faread_trait() {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let mut fa_reader: Box<FARead>;
-        // Generate some randomness/ uncertainty for the compiler
-        // without using the rand crate.
-        // The exact flavour of the generic inside reader is unknown
-        match SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .subsec_nanos() % 2
-        {
-            0 => fa_reader = Box::new(Reader::new(FASTA_FILE)),
-            _ => fa_reader = Box::new(Reader::new(io::BufReader::new(FASTA_FILE))),
-        }
+        let path = "genome.fa.gz";
+        let mut fa_reader: Box<FARead> = match path.ends_with(".gz") {
+            true => Box::new(Reader::new(io::BufReader::new(FASTA_FILE))),
+            false => Box::new(Reader::new(FASTA_FILE)),
+        };
         // The read method can be called, since it is implemented by
         // FQRead. Right now, the records method would not work.
         let mut record = Record::new();

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -29,7 +29,7 @@ use utils::{Text, TextSlice};
 const MAX_FASTA_BUFFER_SIZE: usize = 512;
 
 /// Trait for FASTA readers.
-pub trait FARead {
+pub trait Read {
     fn read(&mut self, record: &mut Record) -> io::Result<()>;
 }
 
@@ -96,7 +96,7 @@ impl<R: io::Read> Reader<R> {
     }
 }
 
-impl<R> FARead for Reader<R>
+impl<R> Read for Reader<R>
 where
     R: io::Read,
 {
@@ -105,7 +105,7 @@ where
     /// # Example
     /// ```rust
     /// # use std::io;
-    /// # use bio::io::fasta::{Reader, FARead};
+    /// # use bio::io::fasta::{Reader, Read};
     /// # use bio::io::fasta::Record;
     /// # fn main() {
     /// # const fasta_file: &'static [u8] = b">id desc
@@ -795,7 +795,7 @@ ATTGTTGTTTTA
     #[test]
     fn test_faread_trait() {
         let path = "genome.fa.gz";
-        let mut fa_reader: Box<FARead> = match path.ends_with(".gz") {
+        let mut fa_reader: Box<Read> = match path.ends_with(".gz") {
             true => Box::new(Reader::new(io::BufReader::new(FASTA_FILE))),
             false => Box::new(Reader::new(FASTA_FILE)),
         };

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -96,7 +96,10 @@ impl<R: io::Read> Reader<R> {
     }
 }
 
-impl<R> FARead for Reader<R> where R: io::Read {
+impl<R> FARead for Reader<R>
+where
+    R: io::Read,
+{
     /// Read next FASTA record into the given `Record`.
     ///
     /// # Example
@@ -155,7 +158,6 @@ impl<R> FARead for Reader<R> where R: io::Read {
         Ok(())
     }
 }
-
 
 /// A FASTA index as created by SAMtools (.fai).
 #[derive(Debug, Clone)]
@@ -805,9 +807,12 @@ ATTGTTGTTTTA
         assert_eq!(record.check(), Ok(()));
         assert_eq!(record.id(), "id");
         assert_eq!(record.desc(), Some("desc"));
-        assert_eq!(record.seq().to_vec(), b"ACCGTAGGCTGACCGTAGGCTGAACGTAGGCTGAAAGTAGGCTGAAAACCCC".to_vec());
+        assert_eq!(
+            record.seq().to_vec(),
+            b"ACCGTAGGCTGACCGTAGGCTGAACGTAGGCTGAAAGTAGGCTGAAAACCCC".to_vec()
+        );
     }
-    
+
     #[test]
     fn test_reader_wrong_header() {
         let mut reader = Reader::new(&b"!test\nACGTA\n"[..]);

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 Johannes Köster, Henning Timm.
+// Copyright 2014-2018 Johannes Köster, Henning Timm.
 // Licensed under the MIT license (http://opensource.org/licenses/MIT)
 // This file may not be copied, modified, or distributed
 // except according to those terms.
@@ -23,7 +23,7 @@ use std::path::Path;
 use utils::TextSlice;
 
 /// Trait for FASTQ readers.
-pub trait FQRead {
+pub trait Read {
     fn read(&mut self, record: &mut Record) -> io::Result<()>;
 }
 
@@ -56,7 +56,7 @@ impl<R: io::Read> Reader<R> {
     }
 }
 
-impl<R> FQRead for Reader<R>
+impl<R> Read for Reader<R>
 where
     R: io::Read,
 {
@@ -309,12 +309,12 @@ IIIIIIJJJJJJ
     #[test]
     fn test_fqread_trait() {
         let path = "reads.fq.gz";
-        let mut fq_reader: Box<FQRead> = match path.ends_with(".gz") {
+        let mut fq_reader: Box<Read> = match path.ends_with(".gz") {
             true => Box::new(Reader::new(io::BufReader::new(FASTQ_FILE))),
             false => Box::new(Reader::new(FASTQ_FILE)),
         };
         // The read method can be called, since it is implemented by
-        // FQRead. Right now, the records method would not work.
+        // `Read`. Right now, the records method would not work.
         let mut record = Record::new();
         fq_reader.read(&mut record).unwrap();
         // Check if the returned result is correct.

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -307,19 +307,11 @@ IIIIIIJJJJJJ
 
     #[test]
     fn test_fqread_trait() {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let mut fq_reader: Box<FQRead>;
-        // Generate some randomness/ uncertainty for the compiler
-        // without using the rand crate.
-        // The exact flavour of the generic inside reader is unknown
-        match SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .subsec_nanos() % 2
-        {
-            0 => fq_reader = Box::new(Reader::new(FASTQ_FILE)),
-            _ => fq_reader = Box::new(Reader::new(io::BufReader::new(FASTQ_FILE))),
-        }
+        let path = "reads.fq.gz";
+        let mut fq_reader: Box<FQRead> = match path.ends_with(".gz") {
+            true => Box::new(Reader::new(io::BufReader::new(FASTQ_FILE))),
+            false => Box::new(Reader::new(FASTQ_FILE)),
+        };
         // The read method can be called, since it is implemented by
         // FQRead. Right now, the records method would not work.
         let mut record = Record::new();

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -22,6 +22,12 @@ use std::path::Path;
 
 use utils::TextSlice;
 
+/// Trait for FASTQ readers.
+pub trait FQRead {
+    fn read(&mut self, record: &mut Record) -> io::Result<()>;
+}
+
+
 /// A FastQ reader.
 #[derive(Debug)]
 pub struct Reader<R: io::Read> {
@@ -45,10 +51,18 @@ impl<R: io::Read> Reader<R> {
         }
     }
 
+    /// Return an iterator over the records of this FastQ file.
+    pub fn records(self) -> Records<R> {
+        Records { reader: self }
+    }
+}
+
+
+impl<R> FQRead for Reader<R> where R: io::Read {
     /// Read into a given record.
     /// Returns an error if the record in incomplete or syntax is violated.
     /// The content of the record can be checked via the record object.
-    pub fn read(&mut self, record: &mut Record) -> io::Result<()> {
+    fn read(&mut self, record: &mut Record) -> io::Result<()> {
         record.clear();
 
         let mut header = String::new();
@@ -86,11 +100,6 @@ impl<R: io::Read> Reader<R> {
         }
 
         Ok(())
-    }
-
-    /// Return an iterator over the records of this FastQ file.
-    pub fn records(self) -> Records<R> {
-        Records { reader: self }
     }
 }
 
@@ -294,6 +303,33 @@ IIIIIIJJJJJJ
             assert_eq!(record.seq(), b"ACCGTAGGCTGA");
             assert_eq!(record.qual(), b"IIIIIIJJJJJJ");
         }
+    }
+
+    #[test]
+    fn test_fqread_trait() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let mut fq_reader: Box<FQRead>;
+        // Generate some randomness/ uncertainty for the compiler
+        // without using the rand crate.
+        // The exact flavour of the generic inside reader is unknown
+        match SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos() % 2
+        {
+            0 => fq_reader = Box::new(Reader::new(FASTQ_FILE)),
+            _ => fq_reader = Box::new(Reader::new(io::BufReader::new(FASTQ_FILE))),
+        }
+        // The read method can be called, since it is implemented by
+        // FQRead. Right now, the records method would not work.
+        let mut record = Record::new();
+        fq_reader.read(&mut record).unwrap();
+        // Check if the returned result is correct.
+        assert_eq!(record.check(), Ok(()));
+        assert_eq!(record.id(), "id");
+        assert_eq!(record.desc(), Some("desc"));
+        assert_eq!(record.seq(), b"ACCGTAGGCTGA");
+        assert_eq!(record.qual(), b"IIIIIIJJJJJJ");
     }
 
     #[test]

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -27,7 +27,6 @@ pub trait FQRead {
     fn read(&mut self, record: &mut Record) -> io::Result<()>;
 }
 
-
 /// A FastQ reader.
 #[derive(Debug)]
 pub struct Reader<R: io::Read> {
@@ -57,8 +56,10 @@ impl<R: io::Read> Reader<R> {
     }
 }
 
-
-impl<R> FQRead for Reader<R> where R: io::Read {
+impl<R> FQRead for Reader<R>
+where
+    R: io::Read,
+{
     /// Read into a given record.
     /// Returns an error if the record in incomplete or syntax is violated.
     /// The content of the record can be checked via the record object.

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 Johannes Köster.
+// Copyright 2014-2016 Johannes Köster, Henning Timm.
 // Licensed under the MIT license (http://opensource.org/licenses/MIT)
 // This file may not be copied, modified, or distributed
 // except according to those terms.

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 use utils::TextSlice;
 
 /// Trait for FASTQ readers.
-pub trait Read {
+pub trait FastqRead {
     fn read(&mut self, record: &mut Record) -> io::Result<()>;
 }
 
@@ -56,7 +56,7 @@ impl<R: io::Read> Reader<R> {
     }
 }
 
-impl<R> Read for Reader<R>
+impl<R> FastqRead for Reader<R>
 where
     R: io::Read,
 {
@@ -309,7 +309,7 @@ IIIIIIJJJJJJ
     #[test]
     fn test_fqread_trait() {
         let path = "reads.fq.gz";
-        let mut fq_reader: Box<Read> = match path.ends_with(".gz") {
+        let mut fq_reader: Box<FastqRead> = match path.ends_with(".gz") {
             true => Box::new(Reader::new(io::BufReader::new(FASTQ_FILE))),
             false => Box::new(Reader::new(FASTQ_FILE)),
         };


### PR DESCRIPTION
I added the traits `FQRead` and `FARead` to the `FastqReader` and `FastaReader` modules respectively. The contain the `read` method which allows to use them when the input type is not clear at compile time, for example if the user could either supply a `.fq` file or a `.fq.gz` file. These would result in different flavors of the generic `<R>` of the reader and in turn make it complicated to use a pattern like this:
```
let path = "reads.fq.gz";
let mut fq_reader: Box<FQRead> = match path.ends_with(".gz") {
    true => Box::new(Reader::new(io::BufReader::new(FASTQ_FILE))),
    false => Box::new(Reader::new(FASTQ_FILE)),
};
```

Right now, this is only implemented for the `read` method. It would be nice, to also have this for the `records` method, but that turned out to be not that straight forward due to `Records`' generic.