### PR TITLE
Add test for calculating GC content

### DIFF
--- a/src/seq_analysis/gc.rs
+++ b/src/seq_analysis/gc.rs
@@ -34,3 +34,18 @@ pub fn gc_content<C: Borrow<u8>, T: IntoIterator<Item = C>>(sequence: T) -> f32 
 pub fn gc3_content<C: Borrow<u8>, T: IntoIterator<Item = C>>(sequence: T) -> f32 {
     gcn_content(sequence, 3usize)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gc_content() {
+        let gc0 = b"ATAT";
+        assert_eq!(gc_content(gc0), 0.0);
+        let gc50 = b"ATGC";
+        assert_eq!(gc_content(gc50), 0.5);
+        let gc100 = b"GCGC";
+        assert_eq!(gc_content(gc100), 1.0);
+    }
+}


### PR DESCRIPTION
I'm new to Rust and saw this test was missing so I figured it was an easy way to start getting involved. I was also thinking on expanding the `seq_analysis` module with additional quality metric functions e.g. calculating base quality and content by position within a read?