### PR TITLE
Updated codebase to be 2018 edition compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/bio"
 readme = "README.md"
 license = "MIT"
 build = "build.rs"
+edition = "2018"
 
 
 [features]

--- a/benches/approximate_matching.rs
+++ b/benches/approximate_matching.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-
 extern crate test;
 
 use test::Bencher;

--- a/benches/approximate_matching.rs
+++ b/benches/approximate_matching.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
 
-extern crate bio;
+
 extern crate test;
 
 use test::Bencher;

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-
 extern crate test;
 
 use test::Bencher;

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
 
-extern crate bio;
+
 extern crate test;
 
 use test::Bencher;

--- a/benches/fmindex.rs
+++ b/benches/fmindex.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-
 extern crate test;
 
 use bio::alphabets;

--- a/benches/fmindex.rs
+++ b/benches/fmindex.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
 
-extern crate bio;
+
 extern crate test;
 
 use bio::alphabets;

--- a/benches/interval_tree.rs
+++ b/benches/interval_tree.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-
 extern crate test;
 
 use test::Bencher;

--- a/benches/interval_tree.rs
+++ b/benches/interval_tree.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
 
-extern crate bio;
+
 extern crate test;
 
 use test::Bencher;
@@ -14,14 +14,14 @@ use std::ops::Range;
 fn bench_interval_few_large_queries(b: &mut Bencher) {
     // insert 100_000 intervals of size 10
     // do 1000 queries, each resulting in 1000 matches
-    b.iter(|| test_insert_query(10, &(100_000..200_000), 1000, (105_000..106_000)));
+    b.iter(|| test_insert_query(10, &(100_000..200_000), 1000, 105_000..106_000));
 }
 
 #[bench]
 fn bench_interval_many_small_queries(b: &mut Bencher) {
     // insert 100_000 intervals of size 10
     // do 100_000 queries, each resulting in at most 10 matches
-    b.iter(|| test_insert_query(10, &(100_000..200_000), 10, (99_995..199_995)));
+    b.iter(|| test_insert_query(10, &(100_000..200_000), 10, 99_995..199_995));
 }
 
 fn test_insert_query(
@@ -33,7 +33,7 @@ fn test_insert_query(
     let mut tree: IntervalTree<i64, Range<i64>> = IntervalTree::new();
 
     for i in insert_bounds.clone() {
-        tree.insert((i..i + insert_size), (i..i + insert_size));
+        tree.insert(i..i + insert_size, i..i + insert_size);
     }
     for i in query_bounds {
         let lower_bound = i;
@@ -44,7 +44,7 @@ fn test_insert_query(
         for j in smallest_start..largest_start {
             expected_intersections.push(j..j + insert_size);
         }
-        assert_intersections(&tree, (lower_bound..upper_bound), &expected_intersections);
+        assert_intersections(&tree, lower_bound..upper_bound, &expected_intersections);
     }
 }
 

--- a/benches/orf.rs
+++ b/benches/orf.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-
 extern crate test;
 
 use test::Bencher;

--- a/benches/orf.rs
+++ b/benches/orf.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
 
-extern crate bio;
+
 extern crate test;
 
 use test::Bencher;

--- a/benches/pairhmm.rs
+++ b/benches/pairhmm.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-
 extern crate test;
 
 use bio::stats::pairhmm::*;

--- a/benches/pairhmm.rs
+++ b/benches/pairhmm.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
 
-extern crate bio;
+
 extern crate test;
 
 use bio::stats::pairhmm::*;

--- a/benches/pairwise.rs
+++ b/benches/pairwise.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
 
-extern crate bio;
+
 extern crate test;
 
 use bio::alignment::pairwise::*;

--- a/benches/pairwise.rs
+++ b/benches/pairwise.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-
 extern crate test;
 
 use bio::alignment::pairwise::*;

--- a/benches/pattern_matching.rs
+++ b/benches/pattern_matching.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
 
-extern crate bio;
+
 extern crate test;
 
 use bio::pattern_matching::bndm::BNDM;

--- a/benches/pattern_matching.rs
+++ b/benches/pattern_matching.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-
 extern crate test;
 
 use bio::pattern_matching::bndm::BNDM;

--- a/benches/suffix_array.rs
+++ b/benches/suffix_array.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-
 extern crate test;
 
 use test::Bencher;

--- a/benches/suffix_array.rs
+++ b/benches/suffix_array.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
 
-extern crate bio;
+
 extern crate test;
 
 use test::Bencher;

--- a/src/alignment/distance.rs
+++ b/src/alignment/distance.rs
@@ -7,7 +7,7 @@
 
 use std::cmp::min;
 
-use utils::TextSlice;
+use crate::utils::TextSlice;
 
 /// Compute the Hamming distance between two strings. Complexity: O(n).
 ///
@@ -23,7 +23,7 @@ use utils::TextSlice;
 /// // TTTAGCTAGCG
 /// assert_eq!(hamming(x, y), 5);
 /// ```
-pub fn hamming(alpha: TextSlice, beta: TextSlice) -> u64 {
+pub fn hamming(alpha: TextSlice<'_>, beta: TextSlice<'_>) -> u64 {
     assert_eq!(
         alpha.len(),
         beta.len(),
@@ -57,7 +57,7 @@ pub fn hamming(alpha: TextSlice, beta: TextSlice) -> u64 {
 /// assert_eq!(ldist, 5);
 /// ```
 #[allow(unused_assignments)]
-pub fn levenshtein(alpha: TextSlice, beta: TextSlice) -> u32 {
+pub fn levenshtein(alpha: TextSlice<'_>, beta: TextSlice<'_>) -> u32 {
     let mut columns = [vec![0u32; alpha.len() + 1], vec![0u32; alpha.len() + 1]];
     let mut i_prev = 0;
     let mut i_cur = 1;

--- a/src/alignment/pairwise/banded.rs
+++ b/src/alignment/pairwise/banded.rs
@@ -80,17 +80,17 @@
 //! // aligner.custom_with_prehash(x, y, &y_kmers_hash) is also supported
 //! ```
 
-use alignment::{Alignment, AlignmentOperation};
+use crate::alignment::{Alignment, AlignmentOperation};
 use std::cmp::max;
 use std::cmp::min;
 use std::i32;
 use std::ops::Range;
-use utils::TextSlice;
+use crate::utils::TextSlice;
 
 use super::*;
-use alignment::pairwise::Scoring;
-use alignment::sparse;
-use alignment::sparse::HashMapFx;
+use crate::alignment::pairwise::Scoring;
+use crate::alignment::sparse;
+use crate::alignment::sparse::HashMapFx;
 
 const MAX_CELLS: usize = 5_000_000;
 const DEFAULT_MATCH_SCORE: i32 = 2;
@@ -267,7 +267,7 @@ impl<F: MatchFunc> Aligner<F> {
     /// * `x` - Textslice
     /// * `y` - Textslice
     ///
-    pub fn custom(&mut self, x: TextSlice, y: TextSlice) -> Alignment {
+    pub fn custom(&mut self, x: TextSlice<'_>, y: TextSlice<'_>) -> Alignment {
         self.band = Band::create(x, y, self.k, self.w, &self.scoring);
         self.compute_alignment(x, y)
     }
@@ -282,8 +282,8 @@ impl<F: MatchFunc> Aligner<F> {
     ///
     pub fn custom_with_prehash(
         &mut self,
-        x: TextSlice,
-        y: TextSlice,
+        x: TextSlice<'_>,
+        y: TextSlice<'_>,
         y_kmer_hash: &HashMapFx<&[u8], Vec<u32>>,
     ) -> Alignment {
         self.band = Band::create_with_prehash(x, y, self.k, self.w, &self.scoring, y_kmer_hash);
@@ -302,8 +302,8 @@ impl<F: MatchFunc> Aligner<F> {
     ///
     pub fn custom_with_matches(
         &mut self,
-        x: TextSlice,
-        y: TextSlice,
+        x: TextSlice<'_>,
+        y: TextSlice<'_>,
         matches: &[(u32, u32)],
     ) -> Alignment {
         self.band = Band::create_with_matches(x, y, self.k, self.w, &self.scoring, &matches);
@@ -328,8 +328,8 @@ impl<F: MatchFunc> Aligner<F> {
     ///
     pub fn custom_with_expanded_matches(
         &mut self,
-        x: TextSlice,
-        y: TextSlice,
+        x: TextSlice<'_>,
+        y: TextSlice<'_>,
         matches: Vec<(u32, u32)>,
         allowed_mismatches: Option<usize>,
         use_lcskpp_union: bool,
@@ -370,7 +370,7 @@ impl<F: MatchFunc> Aligner<F> {
     // Computes the alignment. The band needs to be populated prior
     // to calling this function
     #[inline(never)]
-    fn compute_alignment(&mut self, x: TextSlice, y: TextSlice) -> Alignment {
+    fn compute_alignment(&mut self, x: TextSlice<'_>, y: TextSlice<'_>) -> Alignment {
         if self.band.num_cells() > MAX_CELLS {
             // Too many cells in the band. Return an empty alignment
             return Alignment {
@@ -770,7 +770,7 @@ impl<F: MatchFunc> Aligner<F> {
     }
 
     /// Calculate global alignment of x against y.
-    pub fn global(&mut self, x: TextSlice, y: TextSlice) -> Alignment {
+    pub fn global(&mut self, x: TextSlice<'_>, y: TextSlice<'_>) -> Alignment {
         // Store the current clip penalties
         let clip_penalties = [
             self.scoring.xclip_prefix,
@@ -799,7 +799,7 @@ impl<F: MatchFunc> Aligner<F> {
     }
 
     /// Calculate semiglobal alignment of x against y (x is global, y is local).
-    pub fn semiglobal(&mut self, x: TextSlice, y: TextSlice) -> Alignment {
+    pub fn semiglobal(&mut self, x: TextSlice<'_>, y: TextSlice<'_>) -> Alignment {
         // Store the current clip penalties
         let clip_penalties = [
             self.scoring.xclip_prefix,
@@ -838,8 +838,8 @@ impl<F: MatchFunc> Aligner<F> {
     /// alignment computation.
     pub fn semiglobal_with_prehash(
         &mut self,
-        x: TextSlice,
-        y: TextSlice,
+        x: TextSlice<'_>,
+        y: TextSlice<'_>,
         y_kmer_hash: &HashMapFx<&[u8], Vec<u32>>,
     ) -> Alignment {
         // Store the current clip penalties
@@ -873,7 +873,7 @@ impl<F: MatchFunc> Aligner<F> {
     }
 
     /// Calculate local alignment of x against y.
-    pub fn local(&mut self, x: TextSlice, y: TextSlice) -> Alignment {
+    pub fn local(&mut self, x: TextSlice<'_>, y: TextSlice<'_>) -> Alignment {
         // Store the current clip penalties
         let clip_penalties = [
             self.scoring.xclip_prefix,
@@ -1188,8 +1188,8 @@ impl Band {
     }
 
     fn create<F: MatchFunc>(
-        x: TextSlice,
-        y: TextSlice,
+        x: TextSlice<'_>,
+        y: TextSlice<'_>,
         k: usize,
         w: usize,
         scoring: &Scoring<F>,
@@ -1199,8 +1199,8 @@ impl Band {
     }
 
     fn create_with_prehash<F: MatchFunc>(
-        x: TextSlice,
-        y: TextSlice,
+        x: TextSlice<'_>,
+        y: TextSlice<'_>,
         k: usize,
         w: usize,
         scoring: &Scoring<F>,
@@ -1211,8 +1211,8 @@ impl Band {
     }
 
     fn create_with_matches<F: MatchFunc>(
-        x: TextSlice,
-        y: TextSlice,
+        x: TextSlice<'_>,
+        y: TextSlice<'_>,
         k: usize,
         w: usize,
         scoring: &Scoring<F>,
@@ -1240,8 +1240,8 @@ impl Band {
     }
 
     fn create_from_match_path<F: MatchFunc>(
-        x: TextSlice,
-        y: TextSlice,
+        x: TextSlice<'_>,
+        y: TextSlice<'_>,
         k: usize,
         w: usize,
         scoring: &Scoring<F>,
@@ -1326,12 +1326,12 @@ impl Band {
 
 #[cfg(test)]
 mod banded {
-    use alignment::pairwise::{self, banded, Scoring};
-    use alignment::sparse::hash_kmers;
-    use utils::TextSlice;
+    use crate::alignment::pairwise::{self, banded, Scoring};
+    use crate::alignment::sparse::hash_kmers;
+    use crate::utils::TextSlice;
 
     // Check that the banded alignment is equivalent to the exhaustive SW alignment
-    fn compare_to_full_alignment_local(x: TextSlice, y: TextSlice) {
+    fn compare_to_full_alignment_local(x: TextSlice<'_>, y: TextSlice<'_>) {
         let score = |a: u8, b: u8| if a == b { 1i32 } else { -1i32 };
 
         let mut banded_aligner =
@@ -1345,7 +1345,7 @@ mod banded {
         assert_eq!(banded_alignment, full_alignment);
     }
 
-    fn compare_to_full_alignment_global(x: TextSlice, y: TextSlice) {
+    fn compare_to_full_alignment_global(x: TextSlice<'_>, y: TextSlice<'_>) {
         let score = |a: u8, b: u8| if a == b { 1i32 } else { -1i32 };
 
         let mut banded_aligner =
@@ -1359,7 +1359,7 @@ mod banded {
         assert_eq!(banded_alignment, full_alignment);
     }
 
-    fn compare_to_full_alignment_semiglobal(x: TextSlice, y: TextSlice) {
+    fn compare_to_full_alignment_semiglobal(x: TextSlice<'_>, y: TextSlice<'_>) {
         let score = |a: u8, b: u8| if a == b { 1i32 } else { -1i32 };
 
         let mut banded_aligner =
@@ -1671,8 +1671,8 @@ mod banded {
     //     compare_to_full_alignment_semiglobal(x, y);
     // }
 
-    use alignment::AlignmentOperation::*;
-    use scores::blosum62;
+    use crate::alignment::AlignmentOperation::*;
+    use crate::scores::blosum62;
     use std::iter::repeat;
 
     #[test]

--- a/src/alignment/pairwise/banded.rs
+++ b/src/alignment/pairwise/banded.rs
@@ -81,11 +81,11 @@
 //! ```
 
 use crate::alignment::{Alignment, AlignmentOperation};
+use crate::utils::TextSlice;
 use std::cmp::max;
 use std::cmp::min;
 use std::i32;
 use std::ops::Range;
-use crate::utils::TextSlice;
 
 use super::*;
 use crate::alignment::pairwise::Scoring;

--- a/src/alignment/pairwise/mod.rs
+++ b/src/alignment/pairwise/mod.rs
@@ -101,8 +101,8 @@ use std::cmp::max;
 use std::i32;
 use std::iter::repeat;
 
-use alignment::{Alignment, AlignmentMode, AlignmentOperation};
-use utils::TextSlice;
+use crate::alignment::{Alignment, AlignmentMode, AlignmentOperation};
+use crate::utils::TextSlice;
 
 pub mod banded;
 
@@ -433,7 +433,7 @@ impl<F: MatchFunc> Aligner<F> {
     /// * `x` - Textslice
     /// * `y` - Textslice
     ///
-    pub fn custom(&mut self, x: TextSlice, y: TextSlice) -> Alignment {
+    pub fn custom(&mut self, x: TextSlice<'_>, y: TextSlice<'_>) -> Alignment {
         let (m, n) = (x.len(), y.len());
         self.traceback.init(m, n);
 
@@ -762,7 +762,7 @@ impl<F: MatchFunc> Aligner<F> {
     }
 
     /// Calculate global alignment of x against y.
-    pub fn global(&mut self, x: TextSlice, y: TextSlice) -> Alignment {
+    pub fn global(&mut self, x: TextSlice<'_>, y: TextSlice<'_>) -> Alignment {
         // Store the current clip penalties
         let clip_penalties = [
             self.scoring.xclip_prefix,
@@ -791,7 +791,7 @@ impl<F: MatchFunc> Aligner<F> {
     }
 
     /// Calculate semiglobal alignment of x against y (x is global, y is local).
-    pub fn semiglobal(&mut self, x: TextSlice, y: TextSlice) -> Alignment {
+    pub fn semiglobal(&mut self, x: TextSlice<'_>, y: TextSlice<'_>) -> Alignment {
         // Store the current clip penalties
         let clip_penalties = [
             self.scoring.xclip_prefix,
@@ -823,7 +823,7 @@ impl<F: MatchFunc> Aligner<F> {
     }
 
     /// Calculate local alignment of x against y.
-    pub fn local(&mut self, x: TextSlice, y: TextSlice) -> Alignment {
+    pub fn local(&mut self, x: TextSlice<'_>, y: TextSlice<'_>) -> Alignment {
         // Store the current clip penalties
         let clip_penalties = [
             self.scoring.xclip_prefix,
@@ -1013,8 +1013,8 @@ impl Traceback {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alignment::AlignmentOperation::*;
-    use scores::blosum62;
+    use crate::alignment::AlignmentOperation::*;
+    use crate::scores::blosum62;
 
     #[test]
     fn traceback_cell() {

--- a/src/alignment/sparse.rs
+++ b/src/alignment/sparse.rs
@@ -27,10 +27,10 @@
 //! assert_eq!(match_path, vec![(0,2), (1,3), (2,4), (3,5), (4,6), (5,7), (6,8)]);
 //! assert_eq!(sparse_al.score, 14);
 
-extern crate fxhash;
+use fxhash;
 
 use self::fxhash::FxHasher;
-use data_structures::bit_tree::MaxBitTree;
+use crate::data_structures::bit_tree::MaxBitTree;
 use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;

--- a/src/alphabets/dna.rs
+++ b/src/alphabets/dna.rs
@@ -17,7 +17,7 @@
 
 use std::borrow::Borrow;
 
-use alphabets::Alphabet;
+use crate::alphabets::Alphabet;
 
 /// The DNA alphabet (uppercase and lowercase).
 pub fn alphabet() -> Alphabet {

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -117,7 +117,7 @@ impl RankTransform {
     /// as `usize` by storing the symbol ranks in log2(|A|) bits (with |A| being the alphabet size).
     ///
     /// If q is larger than usize::BITS / log2(|A|), this method fails with an assertion.
-    pub fn qgrams<C, T>(&self, q: u32, text: T) -> QGrams<C, T::IntoIter>
+    pub fn qgrams<C, T>(&self, q: u32, text: T) -> QGrams<'_, C, T::IntoIter>
     where
         C: Borrow<u8>,
         T: IntoIterator<Item = C>,

--- a/src/alphabets/protein.rs
+++ b/src/alphabets/protein.rs
@@ -14,7 +14,7 @@
 //! assert!(!alphabet.is_word(b"BzJ"));
 //! ```
 
-use alphabets::Alphabet;
+use crate::alphabets::Alphabet;
 
 /// Returns the standard protein alphabet, containing the 20 common amino acids.
 pub fn alphabet() -> Alphabet {

--- a/src/alphabets/rna.rs
+++ b/src/alphabets/rna.rs
@@ -17,7 +17,7 @@
 
 use std::borrow::Borrow;
 
-use alphabets::Alphabet;
+use crate::alphabets::Alphabet;
 
 /// The RNA alphabet (uppercase and lowercase).
 pub fn alphabet() -> Alphabet {

--- a/src/data_structures/annot_map.rs
+++ b/src/data_structures/annot_map.rs
@@ -3,10 +3,10 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 
-use bio_types::annot::loc::Loc;
 use crate::data_structures::interval_tree;
 use crate::data_structures::interval_tree::{IntervalTree, IntervalTreeIterator};
 use crate::utils::Interval;
+use bio_types::annot::loc::Loc;
 
 /// Efficient container for querying annotations, using `HashMap` and
 /// `IntervalTree`.

--- a/src/data_structures/annot_map.rs
+++ b/src/data_structures/annot_map.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 use bio_types::annot::loc::Loc;
-use data_structures::interval_tree;
-use data_structures::interval_tree::{IntervalTree, IntervalTreeIterator};
-use utils::Interval;
+use crate::data_structures::interval_tree;
+use crate::data_structures::interval_tree::{IntervalTree, IntervalTreeIterator};
+use crate::utils::Interval;
 
 /// Efficient container for querying annotations, using `HashMap` and
 /// `IntervalTree`.

--- a/src/data_structures/bitenc.rs
+++ b/src/data_structures/bitenc.rs
@@ -124,7 +124,7 @@ impl BitEnc {
     }
 
     /// Iterate over stored values (values will be unpacked into bytes).
-    pub fn iter(&self) -> BitEncIter {
+    pub fn iter(&self) -> BitEncIter<'_> {
         BitEncIter { bitenc: self, i: 0 }
     }
 

--- a/src/data_structures/bwt.rs
+++ b/src/data_structures/bwt.rs
@@ -9,10 +9,10 @@
 
 use std::iter::repeat;
 
-use alphabets::Alphabet;
+use crate::alphabets::Alphabet;
 use bytecount;
-use data_structures::suffix_array::RawSuffixArray;
-use utils::prescan;
+use crate::data_structures::suffix_array::RawSuffixArray;
+use crate::utils::prescan;
 
 pub type BWT = Vec<u8>;
 pub type BWTSlice = [u8];
@@ -184,8 +184,8 @@ pub fn bwtfind(bwt: &BWTSlice, alphabet: &Alphabet) -> BWTFind {
 #[cfg(test)]
 mod tests {
     use super::{bwt, bwtfind, invert_bwt, Occ};
-    use alphabets::Alphabet;
-    use data_structures::suffix_array::suffix_array;
+    use crate::alphabets::Alphabet;
+    use crate::data_structures::suffix_array::suffix_array;
 
     #[test]
     fn test_bwtfind() {

--- a/src/data_structures/bwt.rs
+++ b/src/data_structures/bwt.rs
@@ -10,9 +10,9 @@
 use std::iter::repeat;
 
 use crate::alphabets::Alphabet;
-use bytecount;
 use crate::data_structures::suffix_array::RawSuffixArray;
 use crate::utils::prescan;
+use bytecount;
 
 pub type BWT = Vec<u8>;
 pub type BWTSlice = [u8];

--- a/src/data_structures/fmindex.rs
+++ b/src/data_structures/fmindex.rs
@@ -56,9 +56,9 @@
 use std::borrow::Borrow;
 use std::iter::DoubleEndedIterator;
 
-use alphabets::dna;
-use data_structures::bwt::{Less, Occ, BWT};
-use data_structures::suffix_array::SuffixArray;
+use crate::alphabets::dna;
+use crate::data_structures::bwt::{Less, Occ, BWT};
+use crate::data_structures::suffix_array::SuffixArray;
 use std::mem::swap;
 
 /// A suffix array interval.
@@ -410,9 +410,9 @@ impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> FMDIndex<DBWT, D
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alphabets::dna;
-    use data_structures::bwt::{bwt, less, Occ};
-    use data_structures::suffix_array::suffix_array;
+    use crate::alphabets::dna;
+    use crate::data_structures::bwt::{bwt, less, Occ};
+    use crate::data_structures::suffix_array::suffix_array;
 
     #[test]
     fn test_fmindex() {

--- a/src/data_structures/interval_tree.rs
+++ b/src/data_structures/interval_tree.rs
@@ -27,10 +27,10 @@
 //! ```
 //!
 
+use crate::utils::Interval;
 use std::cmp;
 use std::iter::FromIterator;
 use std::mem;
-use crate::utils::Interval;
 
 /// An interval tree for storing intervals with data
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -203,7 +203,10 @@ impl<N: Clone + Ord, D> IntervalTree<N, D> {
 
     /// Uses the provided `Interval` to find overlapping intervals in the tree and returns an
     /// `IntervalTreeIteratorMut` that allows mutable access to the `data`
-    pub fn find_mut<I: Into<Interval<N>>>(&mut self, interval: I) -> IntervalTreeIteratorMut<'_, N, D> {
+    pub fn find_mut<I: Into<Interval<N>>>(
+        &mut self,
+        interval: I,
+    ) -> IntervalTreeIteratorMut<'_, N, D> {
         let interval = interval.into();
         match self.root {
             Some(ref mut n) => IntervalTreeIteratorMut {
@@ -376,10 +379,10 @@ fn intersect<N: Ord + Clone>(range_1: &Interval<N>, range_2: &Interval<N>) -> bo
 #[cfg(test)]
 mod tests {
     use super::{Entry, IntervalTree, Node};
+    use crate::utils::Interval;
     use std::cmp;
     use std::cmp::{max, min};
     use std::ops::Range;
-    use crate::utils::Interval;
 
     fn validate(node: &Node<i64, String>) {
         validate_height(node);

--- a/src/data_structures/interval_tree.rs
+++ b/src/data_structures/interval_tree.rs
@@ -30,7 +30,7 @@
 use std::cmp;
 use std::iter::FromIterator;
 use std::mem;
-use utils::Interval;
+use crate::utils::Interval;
 
 /// An interval tree for storing intervals with data
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -187,7 +187,7 @@ impl<N: Clone + Ord, D> IntervalTree<N, D> {
 
     /// Uses the provided `Interval` to find overlapping intervals in the tree and returns an
     /// `IntervalTreeIterator`
-    pub fn find<I: Into<Interval<N>>>(&self, interval: I) -> IntervalTreeIterator<N, D> {
+    pub fn find<I: Into<Interval<N>>>(&self, interval: I) -> IntervalTreeIterator<'_, N, D> {
         let interval = interval.into();
         match self.root {
             Some(ref n) => IntervalTreeIterator {
@@ -203,7 +203,7 @@ impl<N: Clone + Ord, D> IntervalTree<N, D> {
 
     /// Uses the provided `Interval` to find overlapping intervals in the tree and returns an
     /// `IntervalTreeIteratorMut` that allows mutable access to the `data`
-    pub fn find_mut<I: Into<Interval<N>>>(&mut self, interval: I) -> IntervalTreeIteratorMut<N, D> {
+    pub fn find_mut<I: Into<Interval<N>>>(&mut self, interval: I) -> IntervalTreeIteratorMut<'_, N, D> {
         let interval = interval.into();
         match self.root {
             Some(ref mut n) => IntervalTreeIteratorMut {
@@ -379,7 +379,7 @@ mod tests {
     use std::cmp;
     use std::cmp::{max, min};
     use std::ops::Range;
-    use utils::Interval;
+    use crate::utils::Interval;
 
     fn validate(node: &Node<i64, String>) {
         validate_height(node);
@@ -475,7 +475,7 @@ mod tests {
         target: Range<i64>,
         expected_results: Vec<Range<i64>>,
     ) {
-        let mut actual_entries: Vec<Entry<i64, String>> = tree.find(&target).collect();
+        let mut actual_entries: Vec<Entry<'_, i64, String>> = tree.find(&target).collect();
         println!("{:?}", actual_entries);
         actual_entries.sort_by(|x1, x2| x1.data.cmp(&x2.data));
         let expected_entries = make_entry_tuples(expected_results);

--- a/src/data_structures/qgram_index.rs
+++ b/src/data_structures/qgram_index.rs
@@ -32,8 +32,8 @@ use std::cmp;
 use std::collections;
 use std::collections::hash_map::Entry;
 
-use alphabets::{Alphabet, RankTransform};
-use utils;
+use crate::alphabets::{Alphabet, RankTransform};
+use crate::utils;
 
 /// A classical, flexible, q-gram index implementation.
 #[derive(Serialize, Deserialize)]
@@ -235,7 +235,7 @@ pub struct ExactMatch {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alphabets;
+    use crate::alphabets;
 
     fn setup() -> (&'static [u8], alphabets::Alphabet) {
         let text = b"ACGGCTGAGATGAT";

--- a/src/data_structures/smallints.rs
+++ b/src/data_structures/smallints.rs
@@ -123,7 +123,7 @@ impl<S: Integer + Bounded + NumCast + Copy, B: Integer + NumCast + Copy> SmallIn
     }
 
     /// Iterate over sequence. Values will be returned in the big integer type (`B`).
-    pub fn iter(&self) -> Iter<S, B> {
+    pub fn iter(&self) -> Iter<'_, S, B> {
         Iter {
             smallints: self,
             items: self.smallints.iter().enumerate(),

--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -19,8 +19,8 @@ use num_traits::{cast, NumCast, Unsigned};
 use bv::{BitVec, Bits, BitsMut};
 use vec_map::VecMap;
 
-use alphabets::{Alphabet, RankTransform};
-use data_structures::smallints::SmallInts;
+use crate::alphabets::{Alphabet, RankTransform};
+use crate::data_structures::smallints::SmallInts;
 
 pub type LCPArray = SmallInts<i8, isize>;
 pub type RawSuffixArray = Vec<usize>;
@@ -664,7 +664,7 @@ mod tests {
     // See issue #70
     use super::*;
     use super::{transform_text, PosTypes, SAIS};
-    use alphabets::Alphabet;
+    use crate::alphabets::Alphabet;
     use bv::{BitVec, BitsPush};
     //use data_structures::bwt::{bwt, less, Occ};
     use std::str;

--- a/src/io/bed.rs
+++ b/src/io/bed.rs
@@ -58,7 +58,7 @@ impl<R: io::Read> Reader<R> {
     }
 
     /// Iterate over all records.
-    pub fn records(&mut self) -> Records<R> {
+    pub fn records(&mut self) -> Records<'_, R> {
         Records {
             inner: self.inner.deserialize(),
         }
@@ -68,7 +68,7 @@ impl<R: io::Read> Reader<R> {
 type BedRecordCsv = (String, u64, u64, Option<Vec<String>>);
 
 /// A BED record.
-pub struct Records<'a, R: 'a + io::Read> {
+pub struct Records<'a, R: io::Read> {
     inner: csv::DeserializeRecordsIter<'a, R, BedRecordCsv>,
 }
 

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 
 use csv;
 
-use utils::{Text, TextSlice};
+use crate::utils::{Text, TextSlice};
 
 /// Maximum size of temporary buffer used for reading indexed FASTA files.
 const MAX_FASTA_BUFFER_SIZE: usize = 512;
@@ -123,7 +123,7 @@ where
     fn read(&mut self, record: &mut Record) -> io::Result<()> {
         record.clear();
         if self.line.is_empty() {
-            try!(self.reader.read_line(&mut self.line));
+            r#try!(self.reader.read_line(&mut self.line));
             if self.line.is_empty() {
                 return Ok(());
             }
@@ -148,7 +148,7 @@ where
             .map(|s| s.to_owned());
         loop {
             self.line.clear();
-            try!(self.reader.read_line(&mut self.line));
+            r#try!(self.reader.read_line(&mut self.line));
             if self.line.is_empty() || self.line.starts_with('>') {
                 break;
             }
@@ -238,7 +238,7 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
     /// Read from a FASTA and its index, both given as `io::Read`. FASTA has to
     /// be `io::Seek` in addition.
     pub fn new<I: io::Read>(fasta: R, fai: I) -> csv::Result<Self> {
-        let index = try!(Index::new(fai));
+        let index = r#try!(Index::new(fai));
         Ok(IndexedReader {
             reader: io::BufReader::new(fasta),
             index,
@@ -311,7 +311,7 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
     }
 
     /// Return an iterator yielding the fetched sequence.
-    pub fn read_iter(&mut self) -> io::Result<IndexedReaderIterator<R>> {
+    pub fn read_iter(&mut self) -> io::Result<IndexedReaderIterator<'_, R>> {
         let idx = self.fetched_idx.clone();
         match (idx, self.start, self.stop) {
             (Some(idx), Some(start), Some(stop)) => self.read_into_iter(idx, start, stop),
@@ -357,7 +357,7 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
         idx: IndexRecord,
         start: u64,
         stop: u64,
-    ) -> io::Result<IndexedReaderIterator<R>> {
+    ) -> io::Result<IndexedReaderIterator<'_, R>> {
         if stop > idx.len {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -417,7 +417,7 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
         let line_offset = start % idx.line_bases;
         let line_start = start / idx.line_bases * idx.line_bytes;
         let offset = idx.offset + line_start + line_offset;
-        try!(self.reader.seek(io::SeekFrom::Start(offset)));
+        r#try!(self.reader.seek(io::SeekFrom::Start(offset)));
 
         Ok(line_offset)
     }
@@ -487,7 +487,7 @@ pub struct Sequence {
     pub len: u64,
 }
 
-pub struct IndexedReaderIterator<'a, R: io::Read + io::Seek + 'a> {
+pub struct IndexedReaderIterator<'a, R: io::Read + io::Seek> {
     reader: &'a mut IndexedReader<R>,
     record: IndexRecord,
     bases_left: u64,
@@ -575,16 +575,16 @@ impl<W: io::Write> Writer<W> {
     }
 
     /// Write a Fasta record with given id, optional description and sequence.
-    pub fn write(&mut self, id: &str, desc: Option<&str>, seq: TextSlice) -> io::Result<()> {
-        try!(self.writer.write_all(b">"));
-        try!(self.writer.write_all(id.as_bytes()));
+    pub fn write(&mut self, id: &str, desc: Option<&str>, seq: TextSlice<'_>) -> io::Result<()> {
+        r#try!(self.writer.write_all(b">"));
+        r#try!(self.writer.write_all(id.as_bytes()));
         if desc.is_some() {
-            try!(self.writer.write_all(b" "));
-            try!(self.writer.write_all(desc.unwrap().as_bytes()));
+            r#try!(self.writer.write_all(b" "));
+            r#try!(self.writer.write_all(desc.unwrap().as_bytes()));
         }
-        try!(self.writer.write_all(b"\n"));
-        try!(self.writer.write_all(seq));
-        try!(self.writer.write_all(b"\n"));
+        r#try!(self.writer.write_all(b"\n"));
+        r#try!(self.writer.write_all(seq));
+        r#try!(self.writer.write_all(b"\n"));
 
         Ok(())
     }
@@ -614,7 +614,7 @@ impl Record {
     }
 
     /// Create a new Fasta record from given attributes.
-    pub fn with_attrs(id: &str, desc: Option<&str>, seq: TextSlice) -> Self {
+    pub fn with_attrs(id: &str, desc: Option<&str>, seq: TextSlice<'_>) -> Self {
         let desc = match desc {
             Some(desc) => Some(desc.to_owned()),
             _ => None,
@@ -657,7 +657,7 @@ impl Record {
     }
 
     /// Return the sequence of the record.
-    pub fn seq(&self) -> TextSlice {
+    pub fn seq(&self) -> TextSlice<'_> {
         self.seq.as_bytes()
     }
 
@@ -796,7 +796,7 @@ ATTGTTGTTTTA
     #[test]
     fn test_faread_trait() {
         let path = "genome.fa.gz";
-        let mut fa_reader: Box<FastaRead> = match path.ends_with(".gz") {
+        let mut fa_reader: Box<dyn FastaRead> = match path.ends_with(".gz") {
             true => Box::new(Reader::new(io::BufReader::new(FASTA_FILE))),
             false => Box::new(Reader::new(FASTA_FILE)),
         };

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -91,7 +91,7 @@ impl<R: io::Read> Reader<R> {
     }
 
     /// Iterate over all records.
-    pub fn records(&mut self) -> Records<R> {
+    pub fn records(&mut self) -> Records<'_, R> {
         let (delim, term, vdelim) = self.gff_type.separator();
         let r = format!(
             r" *(?P<key>[^{delim}{term}\t]+){delim}(?P<value>[^{delim}{term}\t]+){term}?",
@@ -120,7 +120,7 @@ type GffRecordInner = (
 );
 
 /// A GFF record.
-pub struct Records<'a, R: 'a + io::Read> {
+pub struct Records<'a, R: io::Read> {
     inner: csv::DeserializeRecordsIter<'a, R, GffRecordInner>,
     attribute_re: Regex,
     value_delim: char,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,37 +86,37 @@
 //!
 //! Documentation and further examples for each module can be found in the module descriptions below.
 
-extern crate bio_types;
+
 
 #[macro_use]
 extern crate approx;
-extern crate bit_set;
-extern crate bytecount;
-extern crate csv;
+
+
+
 #[macro_use]
 extern crate custom_derive;
-extern crate itertools;
-extern crate itertools_num;
+
+
 #[macro_use]
 extern crate lazy_static;
-extern crate multimap;
-extern crate ndarray;
+
+
 #[macro_use]
 extern crate newtype_derive;
-extern crate num_integer;
-extern crate num_traits;
-extern crate ordered_float;
+
+
+
 #[macro_use]
 extern crate quick_error;
-extern crate regex;
-extern crate serde;
+
+
 #[macro_use]
 extern crate serde_derive;
-extern crate bv;
-extern crate fnv;
-extern crate statrs;
-extern crate strum;
-extern crate vec_map;
+
+
+
+use strum;
+
 #[macro_use]
 extern crate strum_macros;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,34 +86,23 @@
 //!
 //! Documentation and further examples for each module can be found in the module descriptions below.
 
-
-
 #[macro_use]
 extern crate approx;
-
-
 
 #[macro_use]
 extern crate custom_derive;
 
-
 #[macro_use]
 extern crate lazy_static;
-
 
 #[macro_use]
 extern crate newtype_derive;
 
-
-
 #[macro_use]
 extern crate quick_error;
 
-
 #[macro_use]
 extern crate serde_derive;
-
-
 
 use strum;
 

--- a/src/pattern_matching/bndm.rs
+++ b/src/pattern_matching/bndm.rs
@@ -18,9 +18,9 @@
 //! assert_eq!(occ, [7, 17]);
 //! ```
 
-use pattern_matching::shift_and::masks;
+use crate::pattern_matching::shift_and::masks;
 use std::borrow::Borrow;
-use utils::TextSlice;
+use crate::utils::TextSlice;
 
 /// BNDM algorithm.
 pub struct BNDM {
@@ -48,7 +48,7 @@ impl BNDM {
     }
 
     /// Find all matches of pattern with a given text. Matches are returned as iterator over start positions.
-    pub fn find_all<'a>(&'a self, text: TextSlice<'a>) -> Matches {
+    pub fn find_all<'a>(&'a self, text: TextSlice<'a>) -> Matches<'_> {
         Matches {
             bndm: self,
             window: self.m,

--- a/src/pattern_matching/bndm.rs
+++ b/src/pattern_matching/bndm.rs
@@ -19,8 +19,8 @@
 //! ```
 
 use crate::pattern_matching::shift_and::masks;
-use std::borrow::Borrow;
 use crate::utils::TextSlice;
+use std::borrow::Borrow;
 
 /// BNDM algorithm.
 pub struct BNDM {

--- a/src/pattern_matching/bom.rs
+++ b/src/pattern_matching/bom.rs
@@ -21,7 +21,7 @@
 use std::borrow::Borrow;
 use std::cmp::Ord;
 use std::iter::repeat;
-use utils::TextSlice;
+use crate::utils::TextSlice;
 
 use vec_map::VecMap;
 
@@ -96,7 +96,7 @@ impl BOM {
     }
 
     /// Find all matches of the pattern in the given text. Matches are returned as an iterator over start positions.
-    pub fn find_all<'a>(&'a self, text: TextSlice<'a>) -> Matches {
+    pub fn find_all<'a>(&'a self, text: TextSlice<'a>) -> Matches<'_> {
         Matches {
             bom: self,
             text,

--- a/src/pattern_matching/bom.rs
+++ b/src/pattern_matching/bom.rs
@@ -18,10 +18,10 @@
 //! assert_eq!(occ, [8, 25]);
 //! ```
 
+use crate::utils::TextSlice;
 use std::borrow::Borrow;
 use std::cmp::Ord;
 use std::iter::repeat;
-use crate::utils::TextSlice;
 
 use vec_map::VecMap;
 

--- a/src/pattern_matching/horspool.rs
+++ b/src/pattern_matching/horspool.rs
@@ -38,7 +38,7 @@
 //! assert_eq!(occ, [8, 25]);
 //! ```
 
-use utils::TextSlice;
+use crate::utils::TextSlice;
 
 /// Algorithm of Horspool.
 pub struct Horspool<'a> {
@@ -63,7 +63,7 @@ impl<'a> Horspool<'a> {
 
     /// Find all matches with a given text. Matches are returned as an iterator over start
     /// positions.
-    pub fn find_all<'b>(&'b self, text: TextSlice<'b>) -> Matches {
+    pub fn find_all<'b>(&'b self, text: TextSlice<'b>) -> Matches<'_> {
         Matches {
             horspool: self,
             text,

--- a/src/pattern_matching/kmp.rs
+++ b/src/pattern_matching/kmp.rs
@@ -25,7 +25,7 @@
 use std::borrow::Borrow;
 use std::iter::{repeat, Enumerate};
 
-use utils::TextSlice;
+use crate::utils::TextSlice;
 
 type LPS = Vec<usize>;
 

--- a/src/pattern_matching/myers/mod.rs
+++ b/src/pattern_matching/myers/mod.rs
@@ -193,7 +193,7 @@ use std::u64;
 
 use num_traits::{Bounded, FromPrimitive, One, PrimInt, ToPrimitive, WrappingAdd, Zero};
 
-use alignment::{Alignment, AlignmentMode, AlignmentOperation};
+use crate::alignment::{Alignment, AlignmentMode, AlignmentOperation};
 
 mod builder;
 mod traceback;
@@ -336,7 +336,7 @@ impl<T: BitVec> Myers<T> {
 
     /// Finds all matches of pattern in the given text up to a given maximum distance.
     /// Matches are returned as an iterator over pairs of end position and distance.
-    pub fn find_all_end<C, I>(&self, text: I, max_dist: T::DistType) -> Matches<T, C, I::IntoIter>
+    pub fn find_all_end<C, I>(&self, text: I, max_dist: T::DistType) -> Matches<'_, T, C, I::IntoIter>
     where
         C: Borrow<u8>,
         I: IntoIterator<Item = C>,
@@ -419,7 +419,7 @@ where
 /// Iterator over pairs of end positions and distance of matches.
 pub struct Matches<'a, T, C, I>
 where
-    T: 'a + BitVec,
+    T: BitVec,
     C: Borrow<u8>,
     I: Iterator<Item = C>,
 {
@@ -469,7 +469,7 @@ where
 /// methods for obtaining the hit alignment path are provided.
 pub struct FullMatches<'a, T, C, I>
 where
-    T: 'a + BitVec,
+    T: BitVec,
     C: Borrow<u8>,
     I: Iterator<Item = C>,
 {
@@ -608,7 +608,7 @@ where
 /// methods for obtaining the hit alignment path are provided.
 pub struct LazyMatches<'a, T, C, I>
 where
-    T: 'a + BitVec,
+    T: BitVec,
     C: Borrow<u8>,
     I: Iterator<Item = C>,
 {
@@ -730,8 +730,8 @@ fn update_aln(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alignment::AlignmentOperation::*;
-    use alignment::{Alignment, AlignmentMode};
+    use crate::alignment::AlignmentOperation::*;
+    use crate::alignment::{Alignment, AlignmentMode};
     use itertools::Itertools;
     use std::iter::repeat;
 

--- a/src/pattern_matching/myers/mod.rs
+++ b/src/pattern_matching/myers/mod.rs
@@ -336,7 +336,11 @@ impl<T: BitVec> Myers<T> {
 
     /// Finds all matches of pattern in the given text up to a given maximum distance.
     /// Matches are returned as an iterator over pairs of end position and distance.
-    pub fn find_all_end<C, I>(&self, text: I, max_dist: T::DistType) -> Matches<'_, T, C, I::IntoIter>
+    pub fn find_all_end<C, I>(
+        &self,
+        text: I,
+        max_dist: T::DistType,
+    ) -> Matches<'_, T, C, I::IntoIter>
     where
         C: Borrow<u8>,
         I: IntoIterator<Item = C>,

--- a/src/pattern_matching/myers/traceback.rs
+++ b/src/pattern_matching/myers/traceback.rs
@@ -236,7 +236,7 @@ where
         let m = self.m.to_usize().unwrap();
 
         let mut out: Vec<_> = (0..m + 1).map(|_| vec![]).collect();
-        for mut s in states.into_iter().cloned() {
+        for s in states.into_iter().cloned() {
             let mut current_pos = T::one() << (m - 1);
             let mut dist = s.dist;
             for i in 0..m + 1 {

--- a/src/pattern_matching/pssm/dnamotif.rs
+++ b/src/pattern_matching/pssm/dnamotif.rs
@@ -184,7 +184,7 @@ impl From<Array2<f32>> for DNAMotif {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pattern_matching::pssm::ScoredPos;
+    use crate::pattern_matching::pssm::ScoredPos;
     #[test]
     fn simple_pssm() {
         let pssm: DNAMotif = DNAMotif::from_seqs(

--- a/src/pattern_matching/shift_and.rs
+++ b/src/pattern_matching/shift_and.rs
@@ -46,7 +46,7 @@ impl ShiftAnd {
 
     /// Find all matches of pattern in the given text. Matches are returned as an iterator
     /// over start positions.
-    pub fn find_all<C, T>(&self, text: T) -> Matches<C, T::IntoIter>
+    pub fn find_all<C, T>(&self, text: T) -> Matches<'_, C, T::IntoIter>
     where
         C: Borrow<u8>,
         T: IntoIterator<Item = C>,

--- a/src/pattern_matching/ukkonen.rs
+++ b/src/pattern_matching/ukkonen.rs
@@ -29,7 +29,7 @@ use std::cmp::min;
 use std::iter;
 use std::iter::repeat;
 
-use utils::TextSlice;
+use crate::utils::TextSlice;
 
 /// Default cost function (unit costs).
 pub fn unit_cost(a: u8, b: u8) -> u32 {
@@ -66,7 +66,7 @@ where
         pattern: TextSlice<'a>,
         text: T,
         k: usize,
-    ) -> Matches<F, C, T::IntoIter>
+    ) -> Matches<'_, F, C, T::IntoIter>
     where
         C: Borrow<u8>,
         T: IntoIterator<Item = C>,
@@ -90,7 +90,7 @@ where
 /// Iterator over pairs of end positions and distance of matches.
 pub struct Matches<'a, F, C, T>
 where
-    F: 'a + Fn(u8, u8) -> u32,
+    F: Fn(u8, u8) -> u32,
     C: Borrow<u8>,
     T: Iterator<Item = C>,
 {

--- a/src/seq_analysis/orf.rs
+++ b/src/seq_analysis/orf.rs
@@ -69,7 +69,7 @@ impl Finder {
     }
 
     /// Find all orfs in the given sequence
-    pub fn find_all<C, T>(&self, seq: T) -> Matches<C, T::IntoIter>
+    pub fn find_all<C, T>(&self, seq: T) -> Matches<'_, C, T::IntoIter>
     where
         C: Borrow<u8>,
         T: IntoIterator<Item = C>,

--- a/src/stats/bayesian/bayes_factors.rs
+++ b/src/stats/bayesian/bayes_factors.rs
@@ -1,4 +1,4 @@
-use stats::LogProb;
+use crate::stats::LogProb;
 
 pub mod evidence {
     /// Scale of evidence as defined by

--- a/src/stats/bayesian/mod.rs
+++ b/src/stats/bayesian/mod.rs
@@ -11,7 +11,7 @@ pub use self::bayes_factors::BayesFactor;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
 
-use stats::LogProb;
+use crate::stats::LogProb;
 
 /// For each of the hypothesis tests given as posterior error probabilities
 /// (PEPs, i.e. the posterior probability of the null hypothesis), estimate the FDR
@@ -47,7 +47,7 @@ pub fn expected_fdr(peps: &[LogProb]) -> Vec<LogProb> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stats::LogProb;
+    use crate::stats::LogProb;
 
     #[test]
     fn test_expected_fdr() {

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -11,4 +11,4 @@ pub mod hmm;
 pub mod pairhmm;
 pub mod probs;
 
-pub use stats::probs::{LogProb, PHREDProb, Prob};
+pub use crate::stats::probs::{LogProb, PHREDProb, Prob};

--- a/src/stats/pairhmm.rs
+++ b/src/stats/pairhmm.rs
@@ -11,7 +11,7 @@ use std::cmp;
 use std::mem;
 use std::usize;
 
-use stats::LogProb;
+use crate::stats::LogProb;
 
 /// Trait for parametrization of `PairHMM` gap behavior.
 pub trait GapParameters {
@@ -361,7 +361,7 @@ impl PairHMM {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stats::{LogProb, Prob};
+    use crate::stats::{LogProb, Prob};
 
     // Single base insertion and deletion rates for R1 according to Schirmer et al.
     // BMC Bioinformatics 2016, 10.1186/s12859-016-0976-y

--- a/src/stats/probs/cdf.rs
+++ b/src/stats/probs/cdf.rs
@@ -262,8 +262,8 @@ pub type CDFPMFIter<'a, T> = iter::Scan<
 #[cfg(test)]
 mod test {
     use super::*;
-    use ordered_float::NotNan;
     use crate::stats::LogProb;
+    use ordered_float::NotNan;
 
     #[test]
     fn test_cdf() {

--- a/src/stats/probs/cdf.rs
+++ b/src/stats/probs/cdf.rs
@@ -14,7 +14,7 @@ use std::slice;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
 
-use stats::LogProb;
+use crate::stats::LogProb;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Entry<T: Ord> {
@@ -106,18 +106,18 @@ impl<T: Ord> CDF<T> {
     }
 
     /// Provide iterator.
-    pub fn iter(&self) -> slice::Iter<Entry<T>> {
+    pub fn iter(&self) -> slice::Iter<'_, Entry<T>> {
         self.inner.iter()
     }
 
     /// Mutable iterator over entries. This does not check for consistency. In other words, you
     /// should not change the order of the entries, nor the probabilities!
-    pub fn iter_mut(&mut self) -> slice::IterMut<Entry<T>> {
+    pub fn iter_mut(&mut self) -> slice::IterMut<'_, Entry<T>> {
         self.inner.iter_mut()
     }
 
     /// Iterator over corresponding PMF.
-    pub fn iter_pmf(&self) -> CDFPMFIter<T> {
+    pub fn iter_pmf(&self) -> CDFPMFIter<'_, T> {
         fn cdf_to_pmf<'a, G: Ord>(
             last_prob: &mut LogProb,
             e: &'a Entry<G>,
@@ -263,7 +263,7 @@ pub type CDFPMFIter<'a, T> = iter::Scan<
 mod test {
     use super::*;
     use ordered_float::NotNan;
-    use stats::LogProb;
+    use crate::stats::LogProb;
 
     #[test]
     fn test_cdf() {

--- a/src/stats/probs/mod.rs
+++ b/src/stats/probs/mod.rs
@@ -17,7 +17,7 @@ use itertools::Itertools;
 use itertools_num::linspace;
 use num_traits::{Float, Zero};
 use ordered_float::NotNan;
-use utils::FastExp;
+use crate::utils::FastExp;
 
 /// A factor to convert log-probabilities to PHRED-scale (phred = p * `LOG_TO_PHRED_FACTOR`).
 const LOG_TO_PHRED_FACTOR: f64 = -4.342_944_819_032_517_5; // -10 * 1 / ln(10)

--- a/src/stats/probs/mod.rs
+++ b/src/stats/probs/mod.rs
@@ -13,11 +13,11 @@ use std::iter;
 use std::mem;
 use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 
+use crate::utils::FastExp;
 use itertools::Itertools;
 use itertools_num::linspace;
 use num_traits::{Float, Zero};
 use ordered_float::NotNan;
-use crate::utils::FastExp;
 
 /// A factor to convert log-probabilities to PHRED-scale (phred = p * `LOG_TO_PHRED_FACTOR`).
 const LOG_TO_PHRED_FACTOR: f64 = -4.342_944_819_032_517_5; // -10 * 1 / ln(10)


### PR DESCRIPTION
* Updated code via `cargo fix` command
* Set edition flag in Cargo.toml
* Updated code via `cargo fix --edition-idioms`
* Fixed a new warning about an unnecessary `mut` annotation