### PR TITLE
Fix various clippy warnings

### DIFF
--- a/src/alignment/pairwise/banded.rs
+++ b/src/alignment/pairwise/banded.rs
@@ -466,7 +466,7 @@ impl<F: MatchFunc> Aligner<F> {
             }
         }
 
-        for j in 1..n + 1 {
+        for j in 1..=n {
             let curr = j % 2;
             let prev = 1 - curr;
 
@@ -625,7 +625,7 @@ impl<F: MatchFunc> Aligner<F> {
         }
 
         // Handle suffix clipping in the j=n case
-        for i in 0..m + 1 {
+        for i in 0..=m {
             let j = n;
             let curr = j % 2;
             if self.Sn[i] > self.S[curr][i] {
@@ -961,7 +961,7 @@ impl Band {
     //
     fn new(m: usize, n: usize) -> Self {
         let mut ranges: Vec<Range<usize>> = Vec::with_capacity(n + 1);
-        for _ in 0..n + 1 {
+        for _ in 0..=n {
             ranges.push(m + 1..0);
         }
 

--- a/src/alignment/pairwise/mod.rs
+++ b/src/alignment/pairwise/mod.rs
@@ -462,7 +462,7 @@ impl<F: MatchFunc> Aligner<F> {
                 self.Sn.extend(repeat(MIN_SCORE).take(m + 1));
             }
 
-            for i in 1..m + 1 {
+            for i in 1..=m {
                 let mut tb = TracebackCell::new();
                 tb.set_all(TB_START);
                 if i == 1 {
@@ -510,7 +510,7 @@ impl<F: MatchFunc> Aligner<F> {
             }
         }
 
-        for j in 1..n + 1 {
+        for j in 1..=n {
             let curr = j % 2;
             let prev = 1 - curr;
 
@@ -556,7 +556,7 @@ impl<F: MatchFunc> Aligner<F> {
                 self.traceback.set(0, j, tb);
             }
 
-            for i in 1..m + 1 {
+            for i in 1..=m {
                 self.S[curr][i] = MIN_SCORE;
             }
 
@@ -646,7 +646,7 @@ impl<F: MatchFunc> Aligner<F> {
         }
 
         // Handle suffix clipping in the j=n case
-        for i in 0..m + 1 {
+        for i in 0..=m {
             let j = n;
             let curr = j % 2;
             if self.Sn[i] > self.S[curr][i] {
@@ -662,7 +662,7 @@ impl<F: MatchFunc> Aligner<F> {
 
         // Since there could be a change in the last column of S,
         // recompute the last column of I as this could also change
-        for i in 1..m + 1 {
+        for i in 1..=m {
             let j = n;
             let curr = j % 2;
             let s_score = self.S[curr][i - 1] + self.scoring.gap_open + self.scoring.gap_extend;
@@ -930,22 +930,22 @@ impl TracebackCell {
 
     // Gets 4 bits [pos, pos+4) of v
     #[inline(always)]
-    fn get_bits(&self, pos: u8) -> u16 {
+    fn get_bits(self, pos: u8) -> u16 {
         (self.v >> pos) & (0b1111)
     }
 
     #[inline(always)]
-    pub fn get_i_bits(&self) -> u16 {
+    pub fn get_i_bits(self) -> u16 {
         self.get_bits(I_POS)
     }
 
     #[inline(always)]
-    pub fn get_d_bits(&self) -> u16 {
+    pub fn get_d_bits(self) -> u16 {
         self.get_bits(D_POS)
     }
 
     #[inline(always)]
-    pub fn get_s_bits(&self) -> u16 {
+    pub fn get_s_bits(self) -> u16 {
         self.get_bits(S_POS)
     }
 
@@ -980,7 +980,7 @@ impl Traceback {
         let mut start = TracebackCell::new();
         start.set_all(TB_START);
         // set every cell to start
-        self.resize(m, n, &start);
+        self.resize(m, n, start);
     }
 
     #[inline(always)]
@@ -1003,10 +1003,10 @@ impl Traceback {
         &mut self.matrix[i * self.cols + j]
     }
 
-    fn resize(&mut self, m: usize, n: usize, v: &TracebackCell) {
+    fn resize(&mut self, m: usize, n: usize, v: TracebackCell) {
         self.rows = m + 1;
         self.cols = n + 1;
-        self.matrix.resize(self.rows * self.cols, *v);
+        self.matrix.resize(self.rows * self.cols, v);
     }
 }
 

--- a/src/data_structures/annot_map.rs
+++ b/src/data_structures/annot_map.rs
@@ -261,6 +261,10 @@ mod tests {
         let query = Contig::new("chrXI".to_owned(), 462400, 100, ReqStrand::Forward);
         let hits: Vec<&String> = genes.find(&query).map(|e| e.data()).collect();
         assert!(hits.is_empty());
+
+        let query = Contig::new("NotFound".to_owned(), 0, 0, ReqStrand::Forward);
+        let hits: Vec<&String> = genes.find(&query).map(|e| e.data()).collect();
+        assert!(hits.is_empty());
     }
 
     #[test]

--- a/src/data_structures/annot_map.rs
+++ b/src/data_structures/annot_map.rs
@@ -75,7 +75,7 @@ where
         let itree = self
             .refid_itrees
             .entry(location.refid().clone())
-            .or_insert_with(|| IntervalTree::new());
+            .or_insert_with(IntervalTree::new);
         let rng = location.start()..(location.start() + (location.length() as isize));
         itree.insert(rng, data);
     }
@@ -144,7 +144,7 @@ where
         let itree = self
             .refid_itrees
             .entry(data.refid().clone())
-            .or_insert_with(|| IntervalTree::new());
+            .or_insert_with(IntervalTree::new);
         let rng = data.start()..(data.start() + (data.length() as isize));
         itree.insert(rng, data);
     }
@@ -154,8 +154,7 @@ where
 #[derive(Debug, Clone)]
 pub struct Entry<'a, R, T>
 where
-    R: 'a + Eq + Hash,
-    T: 'a,
+    R: Eq + Hash,
 {
     itree_entry: interval_tree::Entry<'a, isize, T>,
     refid: &'a R,
@@ -163,8 +162,7 @@ where
 
 impl<'a, R, T> Entry<'a, R, T>
 where
-    R: 'a + Eq + Hash,
-    T: 'a,
+    R: Eq + Hash,
 {
     /// Returns a reference to the data value in the `AnnotMap`.
     pub fn data(&self) -> &'a T {
@@ -188,8 +186,7 @@ where
 /// This struct is created by the `find` function on `AnnotMap`.
 pub struct AnnotMapIterator<'a, R, T>
 where
-    R: 'a + Eq + Hash,
-    T: 'a,
+    R: Eq + Hash,
 {
     itree_iter: Option<IntervalTreeIterator<'a, isize, T>>,
     refid: &'a R,

--- a/src/data_structures/interval_tree.rs
+++ b/src/data_structures/interval_tree.rs
@@ -47,7 +47,7 @@ impl<N: Ord + Clone, D> Default for IntervalTree<N, D> {
 /// A `find` query on the interval tree does not directly return references to the nodes in the tree, but
 /// wraps the fields `interval` and `data` in an `Entry`.
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub struct Entry<'a, N: Ord + Clone + 'a, D: 'a> {
+pub struct Entry<'a, N: Ord + Clone, D> {
     data: &'a D,
     interval: &'a Interval<N>,
 }
@@ -66,7 +66,7 @@ impl<'a, N: Ord + Clone + 'a, D: 'a> Entry<'a, N, D> {
 
 /// An `IntervalTreeIterator` is returned by `Intervaltree::find` and iterates over the entries
 /// overlapping the query
-pub struct IntervalTreeIterator<'a, N: Ord + Clone + 'a, D: 'a> {
+pub struct IntervalTreeIterator<'a, N: Ord + Clone, D> {
     nodes: Vec<&'a Node<N, D>>,
     interval: Interval<N>,
 }
@@ -111,7 +111,7 @@ impl<'a, N: Ord + Clone + 'a, D: 'a> Iterator for IntervalTreeIterator<'a, N, D>
 /// wraps the fields `interval` and `data` in an `EntryMut`. Only the data part can be mutably accessed
 /// using the `data` method
 #[derive(PartialEq, Eq, Debug)]
-pub struct EntryMut<'a, N: Ord + Clone + 'a, D: 'a> {
+pub struct EntryMut<'a, N: Ord + Clone, D> {
     data: &'a mut D,
     interval: &'a Interval<N>,
 }
@@ -130,7 +130,7 @@ impl<'a, N: Ord + Clone + 'a, D: 'a> EntryMut<'a, N, D> {
 
 /// An `IntervalTreeIteratorMut` is returned by `Intervaltree::find_mut` and iterates over the entries
 /// overlapping the query allowing mutable access to the data `D`, not the `Interval`.
-pub struct IntervalTreeIteratorMut<'a, N: Ord + Clone + 'a, D: 'a> {
+pub struct IntervalTreeIteratorMut<'a, N: Ord + Clone, D> {
     nodes: Vec<&'a mut Node<N, D>>,
     interval: Interval<N>,
 }

--- a/src/data_structures/smallints.rs
+++ b/src/data_structures/smallints.rs
@@ -157,8 +157,8 @@ impl<S: Integer + Bounded + NumCast + Copy, B: Integer + NumCast + Copy> SmallIn
 /// Iterator over the elements of a `SmallInts` sequence.
 pub struct Iter<'a, S, B>
 where
-    S: 'a + Integer + Bounded + NumCast + Copy,
-    B: 'a + Integer + NumCast + Copy,
+    S: Integer + Bounded + NumCast + Copy,
+    B: Integer + NumCast + Copy,
     <S as Num>::FromStrRadixErr: 'a,
     <B as Num>::FromStrRadixErr: 'a,
 {

--- a/src/io/bed.rs
+++ b/src/io/bed.rs
@@ -206,7 +206,7 @@ impl Record {
 
     /// Set name.
     pub fn set_name(&mut self, name: &str) {
-        if self.aux.len() < 1 {
+        if self.aux.is_empty() {
             self.aux.push(name.to_owned());
         } else {
             self.aux[0] = name.to_owned();
@@ -215,7 +215,7 @@ impl Record {
 
     /// Set score.
     pub fn set_score(&mut self, score: &str) {
-        if self.aux.len() < 1 {
+        if self.aux.is_empty() {
             self.aux.push("".to_owned());
         }
         if self.aux.len() < 2 {

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -53,8 +53,8 @@ impl GffType {
     /// First field is key value separator.
     /// Second field terminates a key value pair.
     /// Third field
-    fn separator(&self) -> (u8, u8, u8) {
-        match *self {
+    fn separator(self) -> (u8, u8, u8) {
+        match self {
             GffType::GFF3 => (b'=', b';', b','),
             GffType::GFF2 => (b' ', b';', 0u8),
             GffType::GTF2 => (b' ', b';', 0u8),

--- a/src/pattern_matching/myers/builder.rs
+++ b/src/pattern_matching/myers/builder.rs
@@ -149,7 +149,7 @@ impl MyersBuilder {
     ///     .build(b"TGAGCG*");
     /// // ...
     /// # }
-    pub fn build<'a, T, C, P>(&self, pattern: P) -> Myers<T>
+    pub fn build<T, C, P>(&self, pattern: P) -> Myers<T>
     where
         T: BitVec,
         C: Borrow<u8>,
@@ -181,9 +181,9 @@ impl MyersBuilder {
         }
 
         Myers {
-            peq: peq,
+            peq,
             bound: T::one() << (m.to_usize().unwrap() - 1),
-            m: m,
+            m,
             tb: Traceback::new(),
         }
     }

--- a/src/pattern_matching/myers/mod.rs
+++ b/src/pattern_matching/myers/mod.rs
@@ -264,7 +264,7 @@ where
 
 impl<T: BitVec> Myers<T> {
     /// Create a new instance of Myers algorithm for a given pattern.
-    pub fn new<'a, C, P>(pattern: P) -> Self
+    pub fn new<C, P>(pattern: P) -> Self
     where
         C: Borrow<u8>,
         P: IntoIterator<Item = C>,
@@ -283,9 +283,9 @@ impl<T: BitVec> Myers<T> {
         }
 
         Myers {
-            peq: peq,
+            peq,
             bound: T::one() << (m.to_usize().unwrap() - 1),
-            m: m,
+            m,
             tb: Traceback::new(),
         }
     }
@@ -442,10 +442,10 @@ where
     fn new(myers: &'a Myers<T>, text: I, max_dist: T::DistType) -> Self {
         let state = State::init(myers.m);
         Matches {
-            myers: myers,
-            state: state,
+            myers,
+            state,
             text: text.enumerate(),
-            max_dist: max_dist,
+            max_dist,
         }
     }
 }
@@ -499,12 +499,12 @@ where
         let num_cols = (myers.m + min(max_dist, myers.m)).to_usize().unwrap();
         myers.tb.init(state.clone(), num_cols, myers.m);
         FullMatches {
-            state: state,
+            state,
             m: myers.m,
-            myers: myers,
+            myers,
             text_len: text_iter.len(),
             text: text_iter.enumerate(),
-            max_dist: max_dist,
+            max_dist,
             pos: 0,
             finished: false,
         }
@@ -653,12 +653,12 @@ where
         let state = State::init(myers.m);
         myers.tb.init(state.clone(), text_iter.len(), myers.m);
         LazyMatches {
-            state: state,
+            state,
             m: myers.m,
-            myers: myers,
+            myers,
             text_len: text_iter.len(),
             text: text_iter.enumerate(),
-            max_dist: max_dist,
+            max_dist,
         }
     }
 
@@ -810,7 +810,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn test_alignment() {
         let text =  "GGTCCTGAGGGATTA".replace('-', "");
         let pattern = "TCCT-AGGGA".replace('-', "");

--- a/src/pattern_matching/myers/traceback.rs
+++ b/src/pattern_matching/myers/traceback.rs
@@ -97,7 +97,7 @@ where
         // Reverse iterator over states. If remembering all positions,
         // the chain() and cycle() are not actually needed, but there seems
         // to be almost no performance loss.
-        let mut states = self.states[..pos + 1]
+        let mut states = self.states[..=pos]
             .iter()
             .rev()
             .chain(self.states.iter().rev().cycle());
@@ -228,18 +228,18 @@ where
     // Useful for debugging
     #[allow(dead_code)]
     fn print_tb_matrix(&self, pos: usize) {
-        let states = self.states[..pos + 1]
+        let states = self.states[..=pos]
             .iter()
             .rev()
             .chain(self.states.iter().rev().cycle());
 
         let m = self.m.to_usize().unwrap();
 
-        let mut out: Vec<_> = (0..m + 1).map(|_| vec![]).collect();
-        for s in states.into_iter().cloned() {
+        let mut out: Vec<_> = (0..=m).map(|_| vec![]).collect();
+        for s in states {
             let mut current_pos = T::one() << (m - 1);
             let mut dist = s.dist;
-            for i in 0..m + 1 {
+            for i in 0..=m {
                 out[i].push(dist.to_usize().unwrap());
                 if s.pv & current_pos != T::zero() {
                     dist -= T::DistType::one();

--- a/src/pattern_matching/pssm/dnamotif.rs
+++ b/src/pattern_matching/pssm/dnamotif.rs
@@ -171,7 +171,7 @@ impl Motif for DNAMotif {
 impl From<Array2<f32>> for DNAMotif {
     fn from(scores: Array2<f32>) -> Self {
         let mut m = DNAMotif {
-            scores: scores,
+            scores,
             min_score: 0.0,
             max_score: 0.0,
         };

--- a/src/pattern_matching/pssm/mod.rs
+++ b/src/pattern_matching/pssm/mod.rs
@@ -137,7 +137,7 @@ pub trait Motif {
             ));
         }
 
-        if seqs.len() == 0 {
+        if seqs.is_empty() {
             return Err(PSSMError::EmptyMotif);
         }
 
@@ -232,7 +232,7 @@ pub trait Motif {
         // we have to look at slices, so a simple iterator won't do
         let seq = seq_it.into_iter().map(|c| *c.borrow()).collect_vec();
         let scores = self.get_scores();
-        for start in 0..seq.len() - pssm_len + 1 {
+        for start in 0..=seq.len() - pssm_len {
             let m: Vec<f32> = match (0..pssm_len)
                 .map(|i| match Self::lookup(seq[start + i]) {
                     Err(e) => Err(e),

--- a/src/pattern_matching/pssm/protmotif.rs
+++ b/src/pattern_matching/pssm/protmotif.rs
@@ -145,7 +145,7 @@ impl Motif for ProtMotif {
 impl From<Array2<f32>> for ProtMotif {
     fn from(scores: Array2<f32>) -> Self {
         let mut m = ProtMotif {
-            scores: scores,
+            scores,
             min_score: 0.0,
             max_score: 0.0,
         };

--- a/src/pattern_matching/shift_and.rs
+++ b/src/pattern_matching/shift_and.rs
@@ -30,7 +30,7 @@ pub struct ShiftAnd {
 
 impl ShiftAnd {
     /// Create new ShiftAnd instance from a given pattern.
-    pub fn new<'a, C, P>(pattern: P) -> Self
+    pub fn new<C, P>(pattern: P) -> Self
     where
         P::IntoIter: ExactSizeIterator,
         C: Borrow<u8>,

--- a/src/pattern_matching/ukkonen.rs
+++ b/src/pattern_matching/ukkonen.rs
@@ -75,7 +75,7 @@ where
         self.D[0].clear();
         self.D[0].extend(repeat(k + 1).take(m + 1));
         self.D[1].clear();
-        self.D[1].extend(0..m + 1);
+        self.D[1].extend(0..=m);
         Matches {
             ukkonen: self,
             pattern,
@@ -121,7 +121,7 @@ where
             self.lastk = min(self.lastk + 1, self.m);
             // in each column, go at most one cell further than before
             // do not look at cells with too big k
-            for j in 1..self.lastk + 1 {
+            for j in 1..=self.lastk {
                 self.ukkonen.D[col][j] = min(
                     min(self.ukkonen.D[prev][j] + 1, self.ukkonen.D[col][j - 1] + 1),
                     self.ukkonen.D[prev][j - 1] + (cost)(self.pattern[j - 1], *c.borrow()) as usize,

--- a/src/seq_analysis/orf.rs
+++ b/src/seq_analysis/orf.rs
@@ -49,19 +49,19 @@ impl Finder {
     ) -> Self {
         Finder {
             start_codons: start_codons
-                .into_iter() // Convert start_ and
+                .iter() // Convert start_ and
                 .map(|x| {
                     // stop_codons from
-                    x.into_iter() // Vec<&[u8;3]> to
+                    x.iter() // Vec<&[u8;3]> to
                         .map(|&x| x as u8) // Vec<VecDeque<u8>>
                         .collect::<VecDeque<u8>>() // so they can be
                 }) // easily compared
                 .collect(), // with codon built
             stop_codons: stop_codons
-                .into_iter() // from IntoTextIterator
+                .iter() // from IntoTextIterator
                 .map(|x| {
                     // object.
-                    x.into_iter().map(|&x| x as u8).collect::<VecDeque<u8>>()
+                    x.iter().map(|&x| x as u8).collect::<VecDeque<u8>>()
                 })
                 .collect(),
             min_len,

--- a/src/stats/pairhmm.rs
+++ b/src/stats/pairhmm.rs
@@ -484,7 +484,7 @@ mod tests {
         let x = b"AGCTCGATCGATCGATC";
         let y = b"AGCTCGATCTGATCGATCT";
 
-        let emission_params = TestEmissionParams { x: x, y: y };
+        let emission_params = TestEmissionParams { x, y };
         let gap_params = TestGapParams;
 
         let mut pair_hmm = PairHMM::new();
@@ -499,7 +499,7 @@ mod tests {
         let x = b"AGCTCGATCTGATCGATCT";
         let y = b"AGCTCGATCGATCGATC";
 
-        let emission_params = TestEmissionParams { x: x, y: y };
+        let emission_params = TestEmissionParams { x, y };
         let gap_params = TestGapParams;
 
         let mut pair_hmm = PairHMM::new();
@@ -514,7 +514,7 @@ mod tests {
         let x = b"AGCTCGAGCGATCGATC";
         let y = b"TGCTCGATCGATCGATC";
 
-        let emission_params = TestEmissionParams { x: x, y: y };
+        let emission_params = TestEmissionParams { x, y };
         let gap_params = TestGapParams;
 
         let mut pair_hmm = PairHMM::new();
@@ -536,7 +536,7 @@ CTGTCTTTGATTCCTGCCTCATCCTATTATTTATCGCACCTACGTTCAATATTACAGGCGAACATACTTACTAAAGTGT"
 
         let y = b"GGGTATGCACGCGATAGCATTGCGAGATGCTGGAGCTGGAGCACCCTATGTCGC";
 
-        let emission_params = TestEmissionParams { x: x, y: y };
+        let emission_params = TestEmissionParams { x, y };
         let gap_params = SemiglobalGapParams;
 
         let mut pair_hmm = PairHMM::new();

--- a/src/utils/fastexp.rs
+++ b/src/utils/fastexp.rs
@@ -11,11 +11,11 @@ use num_traits::Float;
 use std::ops;
 
 const COEFF_0: f64 = 1.0;
-const COEFF_1: f64 = 4.831794110;
-const COEFF_2: f64 = 0.143440676;
-const COEFF_3: f64 = 0.019890581;
-const COEFF_4: f64 = 0.006935931;
-const ONEBYLOG2: f64 = 1.442695041;
+const COEFF_1: f64 = 4.831_794_110;
+const COEFF_2: f64 = 0.143_440_676;
+const COEFF_3: f64 = 0.019_890_581;
+const COEFF_4: f64 = 0.006_935_931;
+const ONEBYLOG2: f64 = 1.442_695_041;
 const OFFSET_F64: i64 = 1023;
 const FRACTION_F64: u32 = 52;
 const MIN_VAL: f64 = -500.0;


### PR DESCRIPTION
* fix all redundant field name issues
* fix redunant closures
* fix unused lifetimes
* use inclusive range syntax
* use is_empty()
* remove useless into_iter
* fix inferable lifetimes
* use rustfmt::cfg rather than cfg_attr
* fix long literal warnings
* fix more range inclusive warnings
* fix pass by reference warnings