### PR TITLE
Remove unused crate in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ bio-types = ">=0.4"
 fnv = "1.0"
 strum = "0.13"
 strum_macros = "0.13"
-derive-new = "0.5"
 
 [dependencies.vec_map]
 version = "0.8"


### PR DESCRIPTION
The derive-new crate was added in c56eaa53a17f6e2d6d072fe54a7cca42d83893e9, as part of PR #224, but its use was dropped in subsequent commits.