### PR TITLE
update some deps to stay current.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,9 @@ build = "build.rs"
 edition = "2018"
 
 
-[features]
-avx-accel = ["bytecount/avx-accel"]
-simd-accel = ["bytecount/simd-accel"]
-
 [dependencies]
-bytecount = "0.3.1"
-csv = "1.0.0-beta.5"
+bytecount = { version = "0.5.1", features = ["runtime-dispatch-simd"] }
+csv = "1.0"
 num-traits = "0.2"
 num-integer = "0.1"
 itertools = "0.7"
@@ -38,11 +34,11 @@ quick-error = "1.2"
 regex = "1.0"
 multimap = "0.4"
 fxhash = "0.2"
-statrs = "0.9.0"
+statrs = "0.11"
 bio-types = ">=0.5.1"
 fnv = "1.0"
-strum = "0.13"
-strum_macros = "0.13"
+strum = "0.15"
+strum_macros = "0.15"
 
 [dependencies.vec_map]
 version = "0.8"


### PR DESCRIPTION
Use runtime dispatch SIMD for bytecount to get binaries that automatically use the best instructions.