### PR TITLE
Adding support for EDS parsing and writing [WIP]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ fnv = "1.0"
 strum = "0.16"
 strum_macros = "0.16"
 snafu = "0.5"
+sprs = "0.6.5"
+byteorder = "1.3.1"
+flate2 = "1.0.12"
+libmath = "0.2.1"
 
 [dependencies.vec_map]
 version = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,5 +114,6 @@ pub mod io;
 pub mod pattern_matching;
 pub mod scores;
 pub mod seq_analysis;
+pub mod single_cell;
 pub mod stats;
 pub mod utils;

--- a/src/single_cell/eds.rs
+++ b/src/single_cell/eds.rs
@@ -42,7 +42,7 @@ fn get_reserved_spaces(num_bit_vecs: usize,
                        num_rows: usize,
                        mut file: GzDecoder<BufReader<File>>
 ) -> Result<Vec<usize>, Box<dyn Error>> {
-    let mut bit_vec_length: Vec<usize> = vec![0, num_bit_vecs + 1];
+    let mut bit_vec_lengths: Vec<usize> = vec![0; num_rows + 1];
     let mut bit_vec = vec![0; num_bit_vecs];
     let mut running_sum = 0;
 
@@ -54,7 +54,7 @@ fn get_reserved_spaces(num_bit_vecs: usize,
         }
 
         running_sum += num_ones;
-        bit_vec_length[i+1] = running_sum;
+        bit_vec_lengths[i+1] = running_sum;
 
         // no seek command yet
         // copied from https://github.com/rust-lang/rust/issues/53294#issue-349837288
@@ -62,7 +62,7 @@ fn get_reserved_spaces(num_bit_vecs: usize,
         //file.seek(SeekFrom::Current((num_ones * 4) as i64))?;
     }
 
-    Ok(bit_vec_length)
+    Ok(bit_vec_lengths)
 }
 
 // writes the EDS format single cell matrix into the given path
@@ -101,7 +101,7 @@ pub fn reader(
         let num_bit_vecs: usize = round::ceil(num_columns as f64 / 8.0, 0) as usize;
         let bit_vector_lengths = get_reserved_spaces(num_bit_vecs, num_rows, file)?;
 
-        let total_nnz = bit_vector_lengths.iter().sum();
+        let total_nnz = bit_vector_lengths[num_rows];
         let mut data: Vec<f64> = vec![0.0; total_nnz];
         let mut indices: Vec<usize> = vec![0; total_nnz];
 

--- a/src/single_cell/eds.rs
+++ b/src/single_cell/eds.rs
@@ -1,0 +1,227 @@
+use std::fs::{File, canonicalize};
+use std::io;
+use std::path::PathBuf;
+use std::error::Error;
+use std::io::{Read, Write, BufReader, BufRead, BufWriter};
+
+use byteorder::{ByteOrder, LittleEndian};
+use flate2::read::GzDecoder;
+use math::round;
+
+use flate2::write::GzEncoder;
+use flate2::Compression;
+
+use sprs::CsMatBase;
+use crate::single_cell::scmatrix;
+
+fn get_file_names(path: &str) -> Result<(PathBuf, PathBuf, PathBuf), Box<dyn Error>> {
+    // futuristic customization of alevin output name
+    let eds_type = 0_14;
+    let quants_mat: PathBuf;
+    let mut quants_mat_rows: PathBuf;
+    let mut quants_mat_cols: PathBuf;
+    { // assigning names of the file to read
+        match eds_type {
+            0_14 => {
+                quants_mat = canonicalize(path)?;
+
+                quants_mat_rows = quants_mat.clone();
+                quants_mat_rows.set_file_name("quants_mat_rows.txt");
+
+                quants_mat_cols = quants_mat.clone();
+                quants_mat_cols.set_file_name("quants_mat_cols.txt");
+            },
+            _ => unreachable!(),
+        };
+    }
+
+    Ok((quants_mat, quants_mat_rows, quants_mat_cols))
+}
+
+fn get_reserved_spaces(num_bit_vecs: usize,
+                       num_rows: usize,
+                       mut file: GzDecoder<BufReader<File>>
+) -> Result<Vec<usize>, Box<dyn Error>> {
+    let mut bit_vec_length: Vec<usize> = vec![0, num_bit_vecs + 1];
+    let mut bit_vec = vec![0; num_bit_vecs];
+    let mut running_sum = 0;
+
+    for i in 0..num_rows {
+        file.read_exact(&mut bit_vec[..])?;
+        let mut num_ones = 0;
+        for bits in bit_vec.iter() {
+            num_ones += bits.count_ones() as usize;
+        }
+
+        running_sum += num_ones;
+        bit_vec_length[i+1] = running_sum;
+
+        // no seek command yet
+        // copied from https://github.com/rust-lang/rust/issues/53294#issue-349837288
+        io::copy(&mut file.by_ref().take((num_ones * 4) as u64), &mut io::sink())?;
+        //file.seek(SeekFrom::Current((num_ones * 4) as i64))?;
+    }
+
+    Ok(bit_vec_length)
+}
+
+// writes the EDS format single cell matrix into the given path
+pub fn reader(
+    input_path: &str,
+) -> Result<scmatrix::ScMatrix, Box<dyn Error>> {
+    // extracting the path of the files
+    let (quants_mat, quants_mat_rows, quants_mat_cols) = get_file_names(input_path)?;
+
+    let mut row_names: Vec<String> = Vec::with_capacity(1_000);
+    { // reading rows file
+        let file_handle = File::open(quants_mat_rows)?;
+        let buffered = BufReader::new(file_handle);
+        for line in buffered.lines() {
+            row_names.push(line?);
+        }
+    }
+
+    let mut column_names: Vec<String> = Vec::with_capacity(1_000);
+    { // reading columns file
+        let file_handle = File::open(quants_mat_cols)?;
+        let buffered = BufReader::new(file_handle);
+        for line in buffered.lines() {
+            column_names.push(line?);
+        }
+    }
+
+    let matrix = { // reading the matrix
+        let num_rows = row_names.len();
+        let num_columns = column_names.len();
+
+        let file_handle = File::open(quants_mat.clone())?;
+        let buffered = BufReader::new(file_handle);
+        let file = GzDecoder::new(buffered);
+
+        let num_bit_vecs: usize = round::ceil(num_columns as f64 / 8.0, 0) as usize;
+        let bit_vector_lengths = get_reserved_spaces(num_bit_vecs, num_rows, file)?;
+
+        let total_nnz = bit_vector_lengths.iter().sum();
+        let mut data: Vec<f64> = vec![0.0; total_nnz];
+        let mut indices: Vec<usize> = vec![0; total_nnz];
+
+        let file_handle = File::open(quants_mat)?;
+        let buffered = BufReader::new(file_handle);
+        let mut file = GzDecoder::new(buffered);
+
+        let mut global_pointer = 0;
+        let mut bit_vec = vec![0; num_bit_vecs];
+        for i in 0..num_rows {
+            file.read_exact(&mut bit_vec[..])?;
+            let num_ones = bit_vector_lengths[i+1] - bit_vector_lengths[i];
+
+            let mut one_validator = 0;
+            for (j, flag) in bit_vec.iter().enumerate() {
+                if *flag != 0 {
+                    for (i, bit_id) in format!("{:8b}", flag).chars().enumerate() {
+                        match bit_id {
+                            '1' => {
+                                let offset = i + (8 * j);
+                                indices[ global_pointer + one_validator ] = offset;
+
+                                one_validator += 1;
+                            },
+                            _ => (),
+                        };
+                    }
+                }
+            }
+            assert_eq!(num_ones, one_validator);
+
+            let mut expression: Vec<u8> = vec![0; 4 * (num_ones as usize)];
+            let mut float_buffer: Vec<f32> = vec![0.0_f32; num_ones as usize];
+            file.read_exact(&mut expression[..])?;
+            LittleEndian::read_f32_into(&expression, &mut float_buffer);
+
+            for i in 0..float_buffer.len() {
+                data[global_pointer] = float_buffer[i] as f64;
+                global_pointer += 1;
+            }
+        }
+
+        assert_eq!(global_pointer, total_nnz);
+        CsMatBase::new(
+            (num_rows, num_columns),
+            bit_vector_lengths,
+            indices,
+            data,
+        )
+    };
+
+    Ok(scmatrix::ScMatrix::new(
+        matrix,
+        row_names,
+        column_names
+    ))
+}
+
+
+// writes the EDS format single cell matrix into the given path
+pub fn writer(
+    matrix: scmatrix::ScMatrix,
+    path_str: &str,
+) -> Result<(), Box<dyn Error>> {
+    let (quants_mat, quants_mat_rows, quants_mat_cols) = get_file_names(path_str)?;
+
+    { // writing row file
+        let file_handle = File::create(quants_mat_rows)?;
+        let mut file = BufWriter::new(file_handle);
+
+        let row_names = matrix.row_names();
+        for name in row_names {
+            write!(&mut file, "{}\n", name)?;
+        }
+    }
+
+    { // writing columns file
+        let file_handle = File::create(quants_mat_cols)?;
+        let mut file = BufWriter::new(file_handle);
+
+        let column_names = matrix.column_names();
+        for name in column_names {
+            write!(&mut file, "{}\n", name)?;
+        }
+    }
+
+    { // writing matrix
+        let file_handle = File::create(quants_mat)?;
+        let buffered = BufWriter::new(file_handle);
+        let mut file = GzEncoder::new(buffered, Compression::default());
+
+        let num_bit_vecs: usize = round::ceil(matrix.num_columns() as f64 / 8.0, 0) as usize;
+        let mut bit_vecs: Vec<u8> = vec![0; num_bit_vecs];
+
+        for row_vec in matrix.data().outer_iterator() {
+            let mut positions = Vec::new();
+            let mut values = Vec::new();
+
+            for (col_ind, &val) in row_vec.iter() {
+                positions.push(col_ind);
+                values.push(val as f32);
+            }
+
+            // clearing old bit vector
+            bit_vecs.iter_mut().for_each(|x| *x = 0);
+
+            // refilling bit vector
+            for pos in positions {
+                let i = round::floor(pos as f64 / 8.0, 0) as usize;
+                let j = pos % 8;
+
+                bit_vecs[i] |= 128u8 >> j;
+            }
+
+            let mut bin_exp: Vec<u8> = vec![0_u8; values.len() * 4];
+            LittleEndian::write_f32_into(&values, &mut bin_exp);
+            file.write_all(&bit_vecs)?;
+            file.write_all(&bin_exp)?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/single_cell/eds.rs
+++ b/src/single_cell/eds.rs
@@ -166,7 +166,8 @@ pub fn writer(
     matrix: scmatrix::ScMatrix,
     path_str: &str,
 ) -> Result<(), Box<dyn Error>> {
-    let (quants_mat, quants_mat_rows, quants_mat_cols) = get_file_names(path_str)?;
+    let quants_file_handle = File::create(path_str)?;
+    let (_, quants_mat_rows, quants_mat_cols) = get_file_names(path_str)?;
 
     { // writing row file
         let file_handle = File::create(quants_mat_rows)?;
@@ -189,8 +190,7 @@ pub fn writer(
     }
 
     { // writing matrix
-        let file_handle = File::create(quants_mat)?;
-        let buffered = BufWriter::new(file_handle);
+        let buffered = BufWriter::new(quants_file_handle);
         let mut file = GzEncoder::new(buffered, Compression::default());
 
         let num_bit_vecs: usize = round::ceil(matrix.num_columns() as f64 / 8.0, 0) as usize;

--- a/src/single_cell/mod.rs
+++ b/src/single_cell/mod.rs
@@ -1,0 +1,2 @@
+pub mod eds;
+pub mod scmatrix;

--- a/src/single_cell/scmatrix.rs
+++ b/src/single_cell/scmatrix.rs
@@ -4,13 +4,14 @@ use std::error::Error;
 use crate::single_cell::eds;
 
 // currently fixing the generic to f64
+#[derive(Debug)]
 pub struct ScMatrix {
     data: CsMatBase<f64, usize, Vec<usize>, Vec<usize>, Vec<f64>>,
     row_names: Vec<String>,
     column_names: Vec<String>,
 }
 
-//#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub enum ScMatType {
     EDS,
     MTX,
@@ -58,7 +59,7 @@ impl ScMatrix {
 
     // single cell matrix reader based on the file format
     pub fn reader(mat_type: ScMatType,
-              input_path: &str
+                  input_path: &str
     ) -> Result<ScMatrix, Box<dyn Error>> {
         match mat_type {
             ScMatType::EDS => eds::reader(input_path),
@@ -68,8 +69,8 @@ impl ScMatrix {
 
     // single cell matrix writer based on the file format
     pub fn writer(mat_type: ScMatType,
-              matrix: ScMatrix,
-              output_path: &str
+                  matrix: ScMatrix,
+                  output_path: &str
     ) -> Result<(), Box<dyn Error>> {
         match mat_type {
             ScMatType::EDS => eds::writer(matrix, output_path),

--- a/src/single_cell/scmatrix.rs
+++ b/src/single_cell/scmatrix.rs
@@ -1,0 +1,79 @@
+use sprs::CsMatBase;
+use std::error::Error;
+
+use crate::single_cell::eds;
+
+// currently fixing the generic to f64
+pub struct ScMatrix {
+    data: CsMatBase<f64, usize, Vec<usize>, Vec<usize>, Vec<f64>>,
+    row_names: Vec<String>,
+    column_names: Vec<String>,
+}
+
+//#[derive(Clone, Debug, PartialEq)]
+pub enum ScMatType {
+    EDS,
+    MTX,
+    H5,
+    CSV,
+    Dummy(String),
+}
+
+impl ScMatrix {
+    // returns number of rows in the matrix
+    pub fn num_rows(&self) -> usize {
+        return self.row_names.len()
+    }
+
+    // returns number of columns in the matrix
+    pub fn num_columns(&self) -> usize {
+        return self.column_names.len()
+    }
+
+    // returns the reference to the row names
+    pub fn row_names(&self) -> &Vec<String> {
+        return &self.row_names
+    }
+
+    // returns the reference to the column names
+    pub fn column_names(&self) -> &Vec<String> {
+        return &self.column_names
+    }
+
+    // returns the reference to the sparse matrix data
+    pub fn data(&self) -> &sprs::CsMat<f64> {
+        return &self.data
+    }
+
+    pub fn new(data: sprs::CsMat<f64>,
+               row_names: Vec<String>,
+               column_names: Vec<String>
+    ) -> ScMatrix {
+        ScMatrix {
+            data: data,
+            row_names: row_names,
+            column_names: column_names
+        }
+    }
+
+    // single cell matrix reader based on the file format
+    pub fn reader(mat_type: ScMatType,
+              input_path: &str
+    ) -> Result<ScMatrix, Box<dyn Error>> {
+        match mat_type {
+            ScMatType::EDS => eds::reader(input_path),
+            _ => unimplemented!(),
+        }
+    }
+
+    // single cell matrix writer based on the file format
+    pub fn writer(mat_type: ScMatType,
+              matrix: ScMatrix,
+              output_path: &str
+    ) -> Result<(), Box<dyn Error>> {
+        match mat_type {
+            ScMatType::EDS => eds::writer(matrix, output_path),
+            _ => unimplemented!(),
+        }
+    }
+}


### PR DESCRIPTION
Hi team rust-bio,

I am excited to make my first PR contribution to this great community effort !
As discussed in https://github.com/rust-bio/rust-bio/issues/236 , the idea is to support parsing, writing and converting various single cell cell-v-feature count matrices. Initial effort for comparing (mtx, loom, H5, EDS, CSV) wrt their size, loading time and memory can be found [here](https://github.com/COMBINE-lab/EDS/blob/master/README.md). As this is my first contribution, please feel free to comment if I missed any contributor guidelines. I do have a few questions.

* what's the guidelines for logging the progress ? I really like progress monitors or at least being able to log at what stage the pipeline has reached but I was unsure how to do that in rust-bio world?
* What are the guidelines for propagating the `Error` object upstream to the library, currently I am working with generic `Box<dyn Error>`?

PS: This PR adds the EDS based parsers, I will add the support for other formats ones I have few more cycles