### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -777,7 +777,7 @@ mod tests {
                 "complex with revcomps"),
              ];
 
-        for &(text, test_name) in test_cases.into_iter() {
+        for &(text, test_name) in test_cases.iter() {
             let pos = suffix_array(text);
             for i in 0..(pos.len() - 2) {
                 // Check that every element in the suffix array is lexically <= the next elem

--- a/src/pattern_matching/myers/common_tests.rs
+++ b/src/pattern_matching/myers/common_tests.rs
@@ -136,7 +136,7 @@ macro_rules! impl_tests {
 
             // compare with each other and lazy matches
             for ((&start, (end, dist)), (f_start, f_end, f_dist)) in
-                starts_exp.into_iter().zip(end_dist).zip(full_hits)
+                starts_exp.iter().zip(end_dist).zip(full_hits)
             {
                 assert_eq!(start, f_start);
                 assert_eq!(dist, f_dist);


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.