### PR TITLE
Allow any whitespace (w.r.t unicode) between id and description in FASTA headers

### DIFF
--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -151,7 +151,7 @@ where
                 "Expected > at record start.",
             ));
         }
-        let mut header_fields = self.line[1..].trim_end().splitn(2, ' ');
+        let mut header_fields = self.line[1..].trim_end().splitn(2, char::is_whitespace);
         record.id = header_fields.next().map(|s| s.to_owned()).unwrap();
         record.desc = header_fields.next().map(|s| s.to_owned());
         loop {


### PR DESCRIPTION
There is no "hard" specification for FASTA, but most applications adhere to ">ID{SPACE}DESCRIPTION"; however, some do not use {SPACE} but a different whitespace character such as {TAB}. The question now is whether to rely on the user to supply FASTA files which use space (and only space) as separator between id and description or to allow a larger set of whitespaces.

This PR does the latter:
Instead of splitting at the first _space_, split at the first [whitespace](https://en.wikipedia.org/w/index.php?title=Whitespace_character#Unicode) as given by rust's[ `char::is_whitespace`](https://doc.rust-lang.org/std/primitive.char.html#method.is_whitespace) (or, alternatively [`char::is_ascii_whitespace`](https://doc.rust-lang.org/std/primitive.char.html#method.is_ascii_whitespace)).
(Note that this also treats line feed and carriage return as whitespace, but these cannot be present in the string at that point in the code.)