### PR TITLE
Revert "Handle wrapped fastq files"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,3 @@ fuzz/artifacts
 fuzz/corpus
 fuzz/target
 fuzz/Cargo.lock
-
-.idea


### PR DESCRIPTION
Reverts rust-bio/rust-bio#255

Issue found by @mbhall88:
@johanneskoester I think the merge you performed didn't really merge how you would hope/expect. For instance, the `read` method on `fastq` has mixed the new (line-wrapped-handling) logic with the old logic so that now calling `read` will read two lines - one in the new and another in the old way.
https://github.com/rust-bio/rust-bio/blob/e540963816851c54c63a5cff5049b961ef32e030/src/io/fastq.rs#L135-L202

_Originally posted by @mbhall88 in https://github.com/rust-bio/rust-bio/pull/222#issuecomment-596074611_