### PR TITLE
PHMM: Bugfix for no gap extension case and more stringent tests.

### DIFF
--- a/src/stats/pairhmm.rs
+++ b/src/stats/pairhmm.rs
@@ -456,6 +456,36 @@ mod tests {
     const T_GAP_Y: LogProb = LogProb(-12.186270018233994);
 
     #[test]
+    fn test_interleave_gaps() {
+        let x = b"AGAGAG";
+        let y = b"ACGTACGTACGT";
+
+        let emission_params = TestEmissionParams { x, y };
+        let gap_params = TestSingleGapParams;
+
+        let mut pair_hmm = PairHMM::new();
+        let p = pair_hmm.prob_related(&gap_params, &emission_params, None);
+
+        let n_matches = 6.;
+        let n_insertions = 6.;
+
+        let p_most_likely_path = LogProb(
+            *EMIT_MATCH * n_matches
+                + *T_MATCH * (n_matches - n_insertions)
+                + *EMIT_GAP_X * n_insertions
+                + *T_GAP_X * n_insertions
+                + (1. - *PROB_ILLUMINA_INS).ln() * n_insertions,
+        );
+
+        let p_max = LogProb(*T_GAP_X * n_insertions);
+
+        assert!(*p <= 0.0);
+        assert_relative_eq!(*p_most_likely_path, *p, epsilon = 0.01);
+        assert_relative_eq!(*p, *p_max, epsilon = 0.1);
+        assert!(*p <= *p_max);
+    }
+
+    #[test]
     fn test_same() {
         let x = b"AGCTCGATCGATCGATC";
         let y = b"AGCTCGATCGATCGATC";

--- a/src/stats/pairhmm.rs
+++ b/src/stats/pairhmm.rs
@@ -205,6 +205,7 @@ impl PairHMM {
 
             let prob_emit_x = emission_params.prob_emit_x(i);
 
+            // TODO: in the case of no gap extensions, we can reduce the number of columns of y that need to be looked at (by cone).
             let (j_min, j_max) = (0, emission_params.len_y());
 
             // iterate over y

--- a/src/stats/pairhmm.rs
+++ b/src/stats/pairhmm.rs
@@ -205,25 +205,7 @@ impl PairHMM {
 
             let prob_emit_x = emission_params.prob_emit_x(i);
 
-            let j_min = if do_gap_x_extend {
-                0
-            } else {
-                // The final upper triangle in the dynamic programming matrix
-                // will be only zeros if gap extension is not allowed on x.
-                // Hence we can omit it.
-                emission_params
-                    .len_y()
-                    .saturating_sub(emission_params.len_x() - i + 1)
-            };
-
-            let j_max = if do_gap_x_extend {
-                emission_params.len_y()
-            } else {
-                // The initial lower triangle in the dynamic programming matrix
-                // will be only zeros if gap extension is not allowed on x.
-                // Hence we can omit it.
-                cmp::min(i + 1, emission_params.len_y())
-            };
+            let (j_min, j_max) = (0, emission_params.len_y());
 
             // iterate over y
             for j in j_min..j_max {


### PR DESCRIPTION
Code logic for the case where no gap extensions are allowed was flawed (basically restricted the DP to its diagonal when a cone should be considered instead). This PR fixes this by considering all columns of y, which will be a performance hit for cases where no gap extension is allowed.
This PR also adds more stringent tests, using the (manually defined) probability of the most likely state path as an estimate.