### PR TITLE
Integrating SIMD-accelerated edit distance routines from the `triple_accel` library into the `alignment::distance` module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ strum_macros = ">= 0.16, <= 0.18"
 snafu = ">= 0.5, <= 0.6"
 getset = "0.0.9"
 enum-map = "0.6"
+triple_accel = "0.3.1"
 
 [dependencies.vec_map]
 version = "0.8"

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -3,6 +3,7 @@
 extern crate test;
 
 use test::Bencher;
+use test::black_box;
 
 use bio::alignment::distance::*;
 
@@ -273,7 +274,7 @@ GCCGCGCGCGCGGGGCCGGGCCGCGCGCGCGCCGGGCCGCCGGCGGGGCGCGGCC";
 fn bench_hamming_dist_equal_str_1000iter(b: &mut Bencher) {
     b.iter(|| {
         for _ in 0..1000 {
-            hamming(STR_1, STR_1);
+            black_box(hamming(STR_1, STR_1));
         }
     });
 }
@@ -282,7 +283,7 @@ fn bench_hamming_dist_equal_str_1000iter(b: &mut Bencher) {
 fn bench_hamming_dist_diverse_str_1000iter(b: &mut Bencher) {
     b.iter(|| {
         for _ in 0..1000 {
-            hamming(STR_1, STR_2);
+            black_box(hamming(STR_1, STR_2));
         }
     });
 }
@@ -308,7 +309,7 @@ fn bench_levenshtein_dist_worst_str(b: &mut Bencher) {
 fn bench_simd_hamming_dist_equal_str_1000iter(b: &mut Bencher) {
     b.iter(|| {
         for _ in 0..1000 {
-            simd::hamming(STR_1, STR_1);
+            black_box(simd::hamming(STR_1, STR_1));
         }
     });
 }
@@ -317,7 +318,7 @@ fn bench_simd_hamming_dist_equal_str_1000iter(b: &mut Bencher) {
 fn bench_simd_hamming_dist_diverse_str_1000iter(b: &mut Bencher) {
     b.iter(|| {
         for _ in 0..1000 {
-            simd::hamming(STR_1, STR_2);
+            black_box(simd::hamming(STR_1, STR_2));
         }
     });
 }

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -6,6 +6,8 @@ use test::Bencher;
 
 use bio::alignment::distance::*;
 
+use std::u32;
+
 // 5,000 random nucleotides, GC content = .55
 static STR_1: &'static [u8] = b"ATCTAACTATTCCCTGTGCCTTATGGGGGCCTGCGCTATCTGCCTGT\
 CGAACCATAGGACTCGCGCCAGCGCGCAGGCTTGGATCGAGGTGAAATCTCCGGGGCCTAAGACCACGAGCGTCTGGCG\
@@ -298,4 +300,54 @@ fn bench_levenshtein_dist_diverse_str(b: &mut Bencher) {
 #[bench]
 fn bench_levenshtein_dist_worst_str(b: &mut Bencher) {
     b.iter(|| levenshtein(STR_3, STR_4));
+}
+
+// SIMD-accelerated edit distance routines below
+
+#[bench]
+fn bench_simd_hamming_dist_equal_str_1000iter(b: &mut Bencher) {
+    b.iter(|| {
+        for _ in 0..1000 {
+            simd::hamming(STR_1, STR_1);
+        }
+    });
+}
+
+#[bench]
+fn bench_simd_hamming_dist_diverse_str_1000iter(b: &mut Bencher) {
+    b.iter(|| {
+        for _ in 0..1000 {
+            simd::hamming(STR_1, STR_2);
+        }
+    });
+}
+
+#[bench]
+fn bench_simd_levenshtein_dist_equal_str(b: &mut Bencher) {
+    b.iter(|| simd::levenshtein(STR_1, STR_1));
+}
+
+#[bench]
+fn bench_simd_levenshtein_dist_diverse_str(b: &mut Bencher) {
+    b.iter(|| simd::levenshtein(STR_1, STR_2));
+}
+
+#[bench]
+fn bench_simd_levenshtein_dist_worst_str(b: &mut Bencher) {
+    b.iter(|| simd::levenshtein(STR_3, STR_4));
+}
+
+#[bench]
+fn bench_simd_bounded_levenshtein_dist_equal_str(b: &mut Bencher) {
+    b.iter(|| simd::bounded_levenshtein(STR_1, STR_1, u32::MAX));
+}
+
+#[bench]
+fn bench_simd_bounded_levenshtein_dist_diverse_str(b: &mut Bencher) {
+    b.iter(|| simd::bounded_levenshtein(STR_1, STR_2, u32::MAX));
+}
+
+#[bench]
+fn bench_simd_bounded_levenshtein_dist_worst_str(b: &mut Bencher) {
+    b.iter(|| simd::bounded_levenshtein(STR_3, STR_4, u32::MAX));
 }

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -2,8 +2,7 @@
 
 extern crate test;
 
-use test::Bencher;
-use test::black_box;
+use test::{black_box, Bencher};
 
 use bio::alignment::distance::*;
 

--- a/src/alignment/distance.rs
+++ b/src/alignment/distance.rs
@@ -259,8 +259,17 @@ mod tests {
         //     ||||| |||
         // AAAAACCGTTGAT
         assert_eq!(simd::bounded_levenshtein(x, y, u32::MAX), Some(5));
-        assert_eq!(simd::bounded_levenshtein(x, y, u32::MAX), simd::bounded_levenshtein(y, x, u32::MAX));
-        assert_eq!(simd::bounded_levenshtein(b"AAA", b"TTTT", u32::MAX), Some(4));
-        assert_eq!(simd::bounded_levenshtein(b"TTTT", b"AAA", u32::MAX), Some(4));
+        assert_eq!(
+            simd::bounded_levenshtein(x, y, u32::MAX),
+            simd::bounded_levenshtein(y, x, u32::MAX)
+        );
+        assert_eq!(
+            simd::bounded_levenshtein(b"AAA", b"TTTT", u32::MAX),
+            Some(4)
+        );
+        assert_eq!(
+            simd::bounded_levenshtein(b"TTTT", b"AAA", u32::MAX),
+            Some(4)
+        );
     }
 }

--- a/src/alignment/distance.rs
+++ b/src/alignment/distance.rs
@@ -84,6 +84,99 @@ pub fn levenshtein(alpha: TextSlice<'_>, beta: TextSlice<'_>) -> u32 {
     columns[i_cur - 1][columns[0].len() - 1]
 }
 
+pub mod simd {
+    //! String distance routines accelerated with Single Instruction Multiple Data (SIMD)
+    //! features.
+    //! These routines will automatically fallback to scalar versions if AVX2 or SSE4.1 is
+    //! not supported by the CPU.
+
+    use crate::utils::TextSlice;
+
+    use triple_accel;
+
+    /// SIMD-accelerated Hamming distance between two strings. Complexity: O(n / w), for
+    /// SIMD vectors of length w (usually w = 16 or w = 32).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bio::alignment::distance::simd::*;
+    ///
+    /// let x = b"GTCTGCATGCG";
+    /// let y = b"TTTAGCTAGCG";
+    /// // GTCTGCATGCG
+    /// //  |  ||  |||
+    /// // TTTAGCTAGCG
+    /// assert_eq!(hamming(x, y), 5);
+    /// ```
+    pub fn hamming(alpha: TextSlice<'_>, beta: TextSlice<'_>) -> u64 {
+        assert_eq!(
+            alpha.len(),
+            beta.len(),
+            "simd hamming distance cannot be calculated for texts of different length ({}!={})",
+            alpha.len(),
+            beta.len()
+        );
+        // triple_accel Hamming routine returns an u32
+        triple_accel::hamming(alpha, beta) as u64
+    }
+
+    /// SIMD-accelerated Levenshtein (or Edit) distance between two strings. Complexity:
+    /// O(k / w * (n + m)), with n and m being the length of the given texts, k being the
+    /// number of edits, and w being the length of the SIMD vectors (usually w = 16 or
+    /// w = 32).
+    ///
+    /// Uses exponential search, which is approximately two times slower than the usual
+    /// O(n * m) implementation if the number of edits between the two strings is very large,
+    /// but much faster for cases where the edit distance is low.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bio::alignment::distance::simd::*;
+    ///
+    /// let x = b"ACCGTGGAT";
+    /// let y = b"AAAAACCGTTGAT";
+    /// // ----ACCGTGGAT
+    /// //     ||||| |||
+    /// // AAAAACCGTTGAT
+    /// let ldist = levenshtein(x, y);  // Distance is 5
+    /// assert_eq!(ldist, 5);
+    /// ```
+    pub fn levenshtein(alpha: TextSlice<'_>, beta: TextSlice<'_>) -> u32 {
+        triple_accel::levenshtein_exp(alpha, beta)
+    }
+
+    /// SIMD-accelerated bounded Levenshtein (or Edit) distance between two strings.
+    /// Complexity: O(k / w * (n + m)), with n and m being the length of the given texts,
+    /// k being the threshold on the number of edits, and w being the length of the SIMD vectors
+    /// (usually w = 16 or w = 32).
+    ///
+    /// If the Levenshtein distance between two strings is greater than the threshold k, then
+    /// `None` is returned. This is useful for efficiently calculating whether two strings
+    /// are similar.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bio::alignment::distance::simd::*;
+    ///
+    /// let x = b"ACCGTGGAT";
+    /// let y = b"AAAAACCGTTGAT";
+    /// // ----ACCGTGGAT
+    /// //     ||||| |||
+    /// // AAAAACCGTTGAT
+    /// let ldist = bounded_levenshtein(x, y, 5);  // Distance is 5
+    /// assert_eq!(ldist, Some(5));
+    ///
+    /// let ldist = bounded_levenshtein(x, y, 4);  // Threshold too low!
+    /// assert_eq!(ldist, None);
+    /// ```
+    pub fn bounded_levenshtein(alpha: TextSlice<'_>, beta: TextSlice<'_>, k: u32) -> Option<u32> {
+        triple_accel::levenshtein::levenshtein_simd_k(alpha, beta, k)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -99,6 +192,16 @@ mod tests {
     }
 
     #[test]
+    fn test_simd_hamming_dist_good() {
+        let x = b"GTCTGCATGCG";
+        let y = b"TTTAGCTAGCG";
+        // GTCTGCATGCG
+        //  |  ||  |||
+        // TTTAGCTAGCG
+        assert_eq!(simd::hamming(x, y), 5);
+    }
+
+    #[test]
     #[should_panic(
         expected = "hamming distance cannot be calculated for texts of different length (11!=8)"
     )]
@@ -106,6 +209,16 @@ mod tests {
         let x = b"GACTATATCGA";
         let y = b"TTTAGCTC";
         hamming(x, y);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "simd hamming distance cannot be calculated for texts of different length (11!=8)"
+    )]
+    fn test_simd_hamming_dist_bad() {
+        let x = b"GACTATATCGA";
+        let y = b"TTTAGCTC";
+        simd::hamming(x, y);
     }
 
     #[test]
@@ -119,5 +232,18 @@ mod tests {
         assert_eq!(levenshtein(x, y), levenshtein(y, x));
         assert_eq!(levenshtein(b"AAA", b"TTTT"), 4);
         assert_eq!(levenshtein(b"TTTT", b"AAA"), 4);
+    }
+
+    #[test]
+    fn test_simd_levenshtein_dist() {
+        let x = b"ACCGTGGAT";
+        let y = b"AAAAACCGTTGAT";
+        // ----ACCGTGGAT
+        //     ||||| |||
+        // AAAAACCGTTGAT
+        assert_eq!(simd::levenshtein(x, y), 5);
+        assert_eq!(simd::levenshtein(x, y), simd::levenshtein(y, x));
+        assert_eq!(simd::levenshtein(b"AAA", b"TTTT"), 4);
+        assert_eq!(simd::levenshtein(b"TTTT", b"AAA"), 4);
     }
 }

--- a/src/alignment/distance.rs
+++ b/src/alignment/distance.rs
@@ -91,6 +91,15 @@ pub mod simd {
     //!
     //! These routines will automatically fallback to scalar versions if AVX2 or SSE4.1 is
     //! not supported by the CPU.
+    //!
+    //! With AVX2, SIMD-accelerated Hamming distance can reach up to 40 times faster than
+    //! the scalar version on strings that are long enough.
+    //! The performance of SIMD-accelerated Levenshtein distance depends on the number of
+    //! edits between two strings, so it can perform anywhere from 2 times to nearly 1000
+    //! times faster than the scalar version. When the two strings are completely different,
+    //! there could be no speedup at all.
+    //! If AVX2 support is not available, there is a speed penalty for using SSE4.1 with
+    //! smaller vectors.
 
     use crate::utils::TextSlice;
 
@@ -130,7 +139,8 @@ pub mod simd {
     ///
     /// Uses exponential search, which is approximately two times slower than the usual
     /// O(n * m) implementation if the number of edits between the two strings is very large,
-    /// but much faster for cases where the edit distance is low.
+    /// but much faster for cases where the edit distance is low (when less than half of the
+    /// characters in the strings differ).
     ///
     /// # Example
     ///

--- a/src/alignment/distance.rs
+++ b/src/alignment/distance.rs
@@ -94,10 +94,14 @@ pub mod simd {
     //!
     //! With AVX2, SIMD-accelerated Hamming distance can reach up to 40 times faster than
     //! the scalar version on strings that are long enough.
+    //!
     //! The performance of SIMD-accelerated Levenshtein distance depends on the number of
     //! edits between two strings, so it can perform anywhere from 2 times to nearly 1000
     //! times faster than the scalar version. When the two strings are completely different,
-    //! there could be no speedup at all.
+    //! there could be no speedup at all. It is important to note that the algorithms work
+    //! best when the number of edits is known to be small compared to the length of the
+    //! strings (for example, 10% difference). This should be applicable in many situations.
+    //!
     //! If AVX2 support is not available, there is a speed penalty for using SSE4.1 with
     //! smaller vectors.
 


### PR DESCRIPTION
Hello everyone, I am working on new SIMD-accelerated Hamming and Levenshtein distance functions that are added into the `alignment::distance::simd` module. This work is based on issue/proposal #268.

- [x] Call `triple_accel` SIMD functions
- [x] New `simd` module (for organization) and documentation
- [x] Unit tests
- [x] Benchmark comparisons with existing functions