### PR TITLE
fix test about  io msg with msvc toolchain

### DIFF
--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -1546,9 +1546,11 @@ ATTGTTGTTTTA
 
         assert_eq!(actual.kind(), expected.kind());
 
-        #[cfg(target_os="windows")]
-        assert!(actual.to_string().starts_with("The system cannot find the path specified."));
-        #[cfg(not(target_os="windows"))]
+        #[cfg(target_os = "windows")]
+        assert!(actual
+            .to_string()
+            .starts_with("The system cannot find the path specified."));
+        #[cfg(not(target_os = "windows"))]
         assert!(actual.to_string().starts_with("No such file or directory"))
     }
 

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -1545,6 +1545,11 @@ ATTGTTGTTTTA
         let expected = io::Error::new(io::ErrorKind::NotFound, "foo");
 
         assert_eq!(actual.kind(), expected.kind());
+
+        #[cfg(target_os="windows")]
+        assert!(actual.to_string().starts_with("The system cannot find the path specified."));
+        #[cfg(not(target_os="windows"))]
+        assert!(actual.to_string().starts_with("No such file or directory"))
     }
 
     #[test]

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -101,6 +101,7 @@
 use std::cmp::min;
 use std::collections;
 use std::convert::AsRef;
+use std::env;
 use std::fs;
 use std::io;
 use std::io::prelude::*;

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -758,9 +758,11 @@ IIIIIIJJJJJJ
 
         assert_eq!(actual.kind(), expected.kind());
 
-        #[cfg(target_os="windows")]
-        assert!(actual.to_string().starts_with("The system cannot find the path specified."));
-        #[cfg(not(target_os="windows"))]
+        #[cfg(target_os = "windows")]
+        assert!(actual
+            .to_string()
+            .starts_with("The system cannot find the path specified."));
+        #[cfg(not(target_os = "windows"))]
         assert!(actual.to_string().starts_with("No such file or directory"));
     }
 
@@ -857,9 +859,11 @@ IIIIIIJJJJJJ
 
         assert_eq!(actual.kind(), expected.kind());
 
-        #[cfg(target_os="windows")]
-        assert!(actual.to_string().starts_with("The system cannot find the path specified."));
-        #[cfg(not(target_os="windows"))]
+        #[cfg(target_os = "windows")]
+        assert!(actual
+            .to_string()
+            .starts_with("The system cannot find the path specified."));
+        #[cfg(not(target_os = "windows"))]
         assert!(actual.to_string().starts_with("No such file or directory"))
     }
 

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -102,6 +102,7 @@
 //! ```
 
 use std::convert::AsRef;
+use std::env;
 use std::fmt;
 use std::fs;
 use std::io;

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -757,6 +757,11 @@ IIIIIIJJJJJJ
         let expected = io::Error::new(io::ErrorKind::NotFound, "foo");
 
         assert_eq!(actual.kind(), expected.kind());
+
+        #[cfg(target_os="windows")]
+        assert!(actual.to_string().starts_with("The system cannot find the path specified."));
+        #[cfg(not(target_os="windows"))]
+        assert!(actual.to_string().starts_with("No such file or directory"));
     }
 
     #[test]
@@ -851,6 +856,11 @@ IIIIIIJJJJJJ
         let expected = io::Error::new(io::ErrorKind::NotFound, "foo");
 
         assert_eq!(actual.kind(), expected.kind());
+
+        #[cfg(target_os="windows")]
+        assert!(actual.to_string().starts_with("The system cannot find the path specified."));
+        #[cfg(not(target_os="windows"))]
+        assert!(actual.to_string().starts_with("No such file or directory"))
     }
 
     #[test]


### PR DESCRIPTION
Error messages of some tests on Windows with the msvc toolchain differ from those on Ubuntu. add `cfg` to control assert.