### PR TITLE
Updated debug feature flag so debug output is not printed by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ strum_macros = ">= 0.16, <= 0.18"
 snafu = ">= 0.5, <= 0.6"
 getset = "0.0.9"
 enum-map = "0.6"
-triple_accel = "0.3.1"
+triple_accel = "0.3.2"
 
 [dependencies.vec_map]
 version = "0.8"


### PR DESCRIPTION
The previous version of `triple_accel` looks at the `debug_assertions` flag to determine whether to print debug output. This was potentially annoying for dev builds/tests, so this was swapped out for a separate feature flag that is off by default. This pull request just updates the version of `triple_accel` so that debug output is not printed by default. Debug output can still be enabled by passing the `debug` feature flag to `triple_accel`.