### PR TITLE
Integrate essential info from website into README.md and rendered docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Other contributors:
 * [Jeff Knaggs](https://github.com/jeff-k)
 * [David Lähnemann](https://github.com/dlaehnemann)
 * [Till Hartmann](https://github.com/tedil)
+* [Michael Hall](https://github.com/mbhall88)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,30 @@ Rust-Bio: [![DOI](https://zenodo.org/badge/29821195.svg)](https://zenodo.org/bad
 
 ## Contribute
 
-Any contributions are welcome:
+Any contributions are welcome, from a simple bug report to full-blown new modules:
 
-* If you find a bug, please [check if you can add info to an existing issue](https://github.com/rust-bio/rust-bio/issues). If not, please [file a bug report](https://github.com/rust-bio/rust-bio/issues/new/choose).
-* If you want to contribute fixes, documentation or new code, please [open a pull request](https://github.com/rust-bio/rust-bio/compare), come and say hi in the [`Join the team!` issue](https://github.com/rust-bio/rust-bio/issues/27) and/or have a look at the [roadmap](https://github.com/rust-bio/rust-bio/issues/3).
+If you **find a bug** and don't have the time or in-depth knowledge to fix it, just [check if you can add info to an existing issue](https://github.com/rust-bio/rust-bio/issues) and otherwise [file a bug report](https://github.com/rust-bio/rust-bio/issues/new/choose) with as many infos as possible.
+If you want to contribute fixes, documentation or new code, please [open a pull request](https://github.com/rust-bio/rust-bio/compare).
+You have two options to do this:
+1. For one-time contributions, simply [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the repository, apply your changes to a branch in your fork and then open a pull request.
+2. If you plan on contributing more than once, become a contributor by saying hi in the [`Join the team!` issue](https://github.com/rust-bio/rust-bio/issues/27), we'll add you to the team.
+    Then, you don't have to create a fork, but can simply push new branches into the main repository and open pull requests there.
+ 
+If you want to contribute and don't know where to start, have a look at the [roadmap](https://github.com/rust-bio/rust-bio/issues/3).
 
-### Contribution workflow
+### Documentation guidelines
 
+Every public function and module should have [documentation comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html).
+Check out [which types of comments to use where](https://doc.rust-lang.org/stable/reference/comments.html#doc-comments).
+In `rust-bio`, documentation comments should:
+* [explain functionality](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html)
+* give at least one useful example of how to use it (best as [doctests](https://doc.rust-lang.org/rustdoc/documentation-tests.html), that run during testing)
+* describe time and memory complexity listed (where applicable)
+* cite and link sources and explanations for data structures, algorithms or code (where applicable)
+
+For extra credit, feel free to familiarize yourself with:
+* the Rust [documentation conventions](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text)
+* the Rust [API documentation guidelines](https://rust-lang.github.io/api-guidelines/documentation.html)
 
 ### Contributors
 

--- a/README.md
+++ b/README.md
@@ -7,37 +7,35 @@
 
 # Rust-Bio, a bioinformatics library for Rust.
 
-This library provides implementations of many algorithms and data structures
-that are useful for bioinformatics.
-All provided implementations are rigorously tested via continuous
-integration.
+This library provides [Rust](https://www.rust-lang.org) implementations of algorithms and data structures useful for bioinformatics.
+All provided implementations are rigorously tested via continuous integration.
 
-**Please see the [homepage](https://rust-bio.github.io) for examples and documentation.**
+**Please see the [API documentation](https://docs.rs/bio) for available features and examples of how to use them.**
 
-Currently, rust-bio provides
+When using Rust-Bio, **please cite** the following article:
 
-* most major pattern matching algorithms,
-* a convenient alphabet implementation,
-* pairwise alignment,
-* suffix arrays,
-* BWT and FM-Index,
-* FMD-Index for finding supermaximal exact matches,
-* a q-gram index,
-* utilities to work with [PSSMs](https://en.wikipedia.org/wiki/Position_weight_matrix),
-* an orf research algorithm,
-* a rank/select data structure,
-* [serde](https://github.com/serde-rs/serde) support for all data structures when built with `nightly` feature,
-* FASTQ and FASTA and BED readers and writers,
-* helper functions for combinatorics and dealing with log probabilities.
+[Köster, J. (2016). Rust-Bio: a fast and safe bioinformatics library. Bioinformatics, 32(3), 444-446.](http://bioinformatics.oxfordjournals.org/content/early/2015/10/06/bioinformatics.btv573.short?rss=1)
 
-For reading and writing BAM and BCF files, have a look at https://github.com/christopher-schroeder/rust-htslib.
+Further, you can cite the used versions via DOIs:
 
-## Author
+Rust-Bio: [![DOI](https://zenodo.org/badge/29821195.svg)](https://zenodo.org/badge/latestdoi/29821195)
 
-[Johannes Köster](https://github.com/johanneskoester)
+## Contribute
 
-## Contributors
+Any contributions are welcome:
 
+* If you find a bug, please [check if you can add info to an existing issue](https://github.com/rust-bio/rust-bio/issues). If not, please [file a bug report](https://github.com/rust-bio/rust-bio/issues/new/choose).
+* If you want to contribute fixes, documentation or new code, please [open a pull request](https://github.com/rust-bio/rust-bio/compare), come and say hi in the [`Join the team!` issue](https://github.com/rust-bio/rust-bio/issues/27) and/or have a look at the [roadmap](https://github.com/rust-bio/rust-bio/issues/3).
+
+### Contribution workflow
+
+
+### Contributors
+
+Main author:
+* [Johannes Köster](https://github.com/johanneskoester)
+
+Other contributors:
 * [Christopher Schröder](https://github.com/christopher-schroeder)
 * [Peer Aramillo Irizar](https://github.com/parir)
 * [Fedor Gusev](https://github.com/gusevfe)
@@ -59,8 +57,8 @@ For reading and writing BAM and BCF files, have a look at https://github.com/chr
 * [Kieran Hervold](https://github.com/hervold)
 * [Brett Bowman](https://github.com/bnbowman)
 * [Jeff Knaggs](https://github.com/jeff-k)
-
-The next name in this list could be you! If you are interested in joining the effort to build a general purpose Rust bioinformatics library, just introduce yourself [here](https://github.com/rust-bio/rust-bio/issues/3), or issue a pull request with your first contribution.
+* [David Lähnemann](https://github.com/dlaehnemann)
+* [Till Hartmann](https://github.com/tedil)
 
 ## License
 

--- a/src/alignment/distance.rs
+++ b/src/alignment/distance.rs
@@ -107,8 +107,6 @@ pub mod simd {
 
     use crate::utils::TextSlice;
 
-    use triple_accel;
-
     /// SIMD-accelerated Hamming distance between two strings. Complexity: O(n / w), for
     /// SIMD vectors of length w (usually w = 16 or w = 32).
     ///

--- a/src/alignment/sparse.rs
+++ b/src/alignment/sparse.rs
@@ -27,8 +27,6 @@
 //! assert_eq!(match_path, vec![(0,2), (1,3), (2,4), (3,5), (4,6), (5,7), (6,8)]);
 //! assert_eq!(sparse_al.score, 14);
 
-use fxhash;
-
 use self::fxhash::FxHasher;
 use crate::data_structures::bit_tree::MaxBitTree;
 use std::cmp::{max, min};

--- a/src/alignment/sparse.rs
+++ b/src/alignment/sparse.rs
@@ -27,7 +27,7 @@
 //! assert_eq!(match_path, vec![(0,2), (1,3), (2,4), (3,5), (4,6), (5,7), (6,8)]);
 //! assert_eq!(sparse_al.score, 14);
 
-use self::fxhash::FxHasher;
+use fxhash::FxHasher;
 use crate::data_structures::bit_tree::MaxBitTree;
 use std::cmp::{max, min};
 use std::collections::HashMap;

--- a/src/alignment/sparse.rs
+++ b/src/alignment/sparse.rs
@@ -27,8 +27,8 @@
 //! assert_eq!(match_path, vec![(0,2), (1,3), (2,4), (3,5), (4,6), (5,7), (6,8)]);
 //! assert_eq!(sparse_al.score, 14);
 
-use fxhash::FxHasher;
 use crate::data_structures::bit_tree::MaxBitTree;
+use fxhash::FxHasher;
 use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;

--- a/src/data_structures/bwt.rs
+++ b/src/data_structures/bwt.rs
@@ -12,7 +12,6 @@ use std::iter::repeat;
 use crate::alphabets::Alphabet;
 use crate::data_structures::suffix_array::RawSuffixArray;
 use crate::utils::prescan;
-use bytecount;
 
 pub type BWT = Vec<u8>;
 pub type BWTSlice = [u8];
@@ -164,7 +163,7 @@ impl Occ {
 
         // Otherwise the default case is to count from the low checkpoint.
         let lo_idx = lo_checkpoint * self.k as usize;
-        return lo_occ + bytecount::count(&bwt[lo_idx + 1..=r], a) as usize;
+        bytecount::count(&bwt[lo_idx + 1..=r], a) as usize + lo_occ
     }
 }
 

--- a/src/data_structures/bwt.rs
+++ b/src/data_structures/bwt.rs
@@ -3,7 +3,7 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! The Burrows-Wheeler-Transform and related data structures.
+//! The [Burrows-Wheeler-Transform](https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.37.6774) and related data structures.
 //! The implementation is based on the lecture notes
 //! "Algorithmen auf Sequenzen", Kopczynski, Marschall, Martin and Rahmann, 2008 - 2015.
 

--- a/src/data_structures/fmindex.rs
+++ b/src/data_structures/fmindex.rs
@@ -3,7 +3,8 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! FM-Index and FMD-Index for finding suffix array intervals matching a given pattern in linear time.
+//! The [Full-text index in Minute space index (FM-index)](https://doi.org/10.1109/SFCS.2000.892127) and
+//! the FMD-Index for finding suffix array intervals matching a given pattern in linear time.
 //!
 //! # Examples
 //!

--- a/src/data_structures/interval_tree/array_backed_interval_tree.rs
+++ b/src/data_structures/interval_tree/array_backed_interval_tree.rs
@@ -220,7 +220,7 @@ impl<N: Ord + Clone + Copy, D: Clone> ArrayBackedIntervalTree<N, D> {
                         });
                     }
                 }
-            } else if w == false {
+            } else if !w {
                 // if left child not processed
                 let y = x - (1 << (k - 1)); // the left child of x; NB: y may be out of range (i.e. y>=n)
                 stack[t].k = k;

--- a/src/data_structures/qgram_index.rs
+++ b/src/data_structures/qgram_index.rs
@@ -27,7 +27,6 @@
 //! ]);
 //! ```
 
-use std;
 use std::cmp;
 use std::collections;
 use std::collections::hash_map::Entry;

--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -7,7 +7,6 @@
 //! The implementation is based on the lecture notes
 //! "Algorithmen auf Sequenzen", Kopczynski, Marschall, Martin and Rahmann, 2008 - 2015.
 
-use std;
 use std::cmp;
 use std::fmt::Debug;
 use std::iter;

--- a/src/io/bed.rs
+++ b/src/io/bed.rs
@@ -27,8 +27,6 @@ use std::marker::Copy;
 use std::ops::Deref;
 use std::path::Path;
 
-use csv;
-
 use bio_types::annot;
 use bio_types::annot::loc::Loc;
 use bio_types::strand;

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -21,8 +21,6 @@ use std::io;
 use std::io::prelude::*;
 use std::path::Path;
 
-use csv;
-
 use crate::utils::{Text, TextSlice};
 use std::fmt;
 

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -12,8 +12,8 @@
 //! use bio::io::fastq;
 //! let mut reader = fastq::Reader::new(io::stdin());
 //! let mut record = fastq::Record::new();
-//! loop{
-//!   reader.read(&mut record).expect("Failed to parse record");
+//! reader.read(&mut record).expect("Failed to parse record");
+//! while !record.is_empty() {
 //!   if record.is_empty() {
 //!     break;
 //!   }
@@ -22,6 +22,7 @@
 //!       panic!("I got a rubbish record!")
 //!   }
 //!   // your record is ok - do something with it...
+//!   reader.read(&mut record).expect("Failed to parse record");
 //! }
 //! ```
 

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -14,9 +14,6 @@
 //! let mut record = fastq::Record::new();
 //! reader.read(&mut record).expect("Failed to parse record");
 //! while !record.is_empty() {
-//!   if record.is_empty() {
-//!     break;
-//!   }
 //!   let check = record.check();
 //!   if check.is_err() {
 //!       panic!("I got a rubbish record!")

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -3,21 +3,25 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! FastQ reading and writing.
+//! FastQ reading.
 //!
 //! # Example
 //!
 //! ```
 //! use std::io;
 //! use bio::io::fastq;
-//! let reader = fastq::Reader::new(io::stdin());
-//! let records = reader.records().map(|r| r.unwrap());
-//! for record in records {
-//!     let check = record.check();
-//!     if check.is_err() {
-//!         panic!("I got a rubbish record!")
-//!     }
-//!     // your record is ok - do something with it...
+//! let mut reader = fastq::Reader::new(io::stdin());
+//! let mut record = fastq::Record::new();
+//! loop{
+//!   reader.read(&mut record).expect("Failed to parse record");
+//!   if record.is_empty() {
+//!     break;
+//!   }
+//!   let check = record.check();
+//!   if check.is_err() {
+//!       panic!("I got a rubbish record!")
+//!   }
+//!   // your record is ok - do something with it...
 //! }
 //! ```
 

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -25,8 +25,6 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-use csv;
-
 use bio_types::strand::Strand;
 
 /// `GffType`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,9 @@
 //! that are useful for bioinformatics.
 //! All provided implementations are rigorously tested via continuous
 //! integration.
-//! For installation instructions and a general overview, visit
-//! https://rust-bio.github.io.
+//!
+//! For **getting started** with using `rust-bio`, see [the `Getting started` section below](#getting-started).
+//! For navigating the documentation of the available modules, see [the `Modules` section below](#modules).
 //!
 //! Currently, rust-bio provides
 //!
@@ -17,39 +18,139 @@
 //! * a convenient alphabet implementation,
 //! * pairwise alignment,
 //! * suffix arrays,
-//! * BWT and FM-Index,
+//! * the [Burrows-Wheeler-transform (BWT)]()
+//! * the [Full-text index in Minute space index (FM-index)](https://doi.org/10.1109/SFCS.2000.892127),
 //! * FMD-Index for finding supermaximal exact matches,
 //! * a q-gram index,
-//! * an orf research algorithm,
+//! * utilities to work with [PSSMs](https://en.wikipedia.org/wiki/Position_weight_matrix),
+//! * an open reading frame (ORF) search algorithm,
 //! * a rank/select data structure,
-//! * FASTQ and FASTA and BED readers and writers,
+//! * [serde](https://github.com/serde-rs/serde) support for all data structures when built with `nightly` feature,
+//! * readers and writers for FASTQ, FASTA and BED,
 //! * helper functions for combinatorics and dealing with log probabilities,
-//! * an implementation of Hidden Markov Model and related algorithms.
+//! * an implementation of the Hidden Markov Model and related algorithms.
 //!
-//! # Example
+//! For reading and writing SAM/BAM/CRAM, VCF/BCF files or tabix indexed files, have a look at [rust-htslib](https://docs.rs/rust-htslib).
+//!
+//! # Getting started
+//!
+//! We explain how to use Rust-Bio step-by-step.
+//! Users who already have experience with Rust can skip right to [Step 3: Use Rust-Bio in your project](https://docs.rs/bio/#step-3-use-rust-bio-in-your-project).
+//! Users who already know `rust-bio` might want to jump right into the [modules docs](https://docs.rs/bio/#modules)
+//!
+//! ## Step 1: Setting up Rust
+//!
+//! Rust can be installed following the instruction for [rustup](https://rustup.rs/).
+//!
+//!
+//! ## Step 2: Setting up a new Rust project
+//!
+//! Since Rust-Bio is a library, you need to setup your own new Rust project to use Rust-Bio.
+//! With Rust, projects and their dependencies are managed with the builtin package manager [Cargo](https://doc.rust-lang.org/cargo/index.html).
+//! To create a new Rust project, issue
+//!
+//! ```bash
+//! cargo new hello_world --bin
+//! cd hello_world
+//! ```
+//! in your terminal. The flag `--bin` tells Cargo to create an executable project instead of a library.
+//! In [this section](https://doc.rust-lang.org/nightly/book/hello-cargo.html#a-new-project) of the Rust docs, you find details about what Cargo just created for you.
+//!
+//! Your new project can be compiled with
+//! ```bash
+//! cargo build
+//! ```
+//! If dependencies in your project are out of date, update with
+//! ```bash
+//! cargo update
+//! ```
+//! Execute the compiled code with
+//! ```bash
+//! cargo run
+//! ```
+//! If you are new to Rust, we suggest to proceed with [learning Rust](https://www.rust-lang.org/learn) via the Rust docs.
+//!
+//! ## Step 3: Use Rust-Bio in your project
+//!
+//! To use Rust-Bio in your Rust project, add the following to your `Cargo.toml`
+//!
+//! ```toml
+//! [dependencies]
+//! bio = "*"
+//! ```
+//!
+//! and import the crate from your source code:
 //!
 //! ```rust
+//! extern crate bio;
+//! ```
+//!
+//! ## Example: FM-index and FASTQ
+//!
+//! An example of using `rust-bio`:
+//!
+//! ```rust
+//! // Import some modules
+//! use std::io;
 //! use bio::alphabets;
 //! use bio::data_structures::suffix_array::suffix_array;
 //! use bio::data_structures::bwt::{bwt, less, Occ};
 //! use bio::data_structures::fmindex::{FMIndex, FMIndexable};
+//! use bio::io::fastq;
 //!
-//! let text = b"ACGGATGCTGGATCGGATCGCGCTAGCTA$";
-//! let pattern = b"ACCG";
 //!
-//! // Create an FM-Index for a given text.
+//! // a given text
+//! let text = b"ACAGCTCGATCGGTA";
+//! let pattern = b"ATCG";
+//!
+//! // Create an FM-Index for the given text.
+//!
+//! // instantiate an alphabet
 //! let alphabet = alphabets::dna::iupac_alphabet();
+//! // calculate a suffix array
 //! let sa = suffix_array(text);
+//! // calculate the Burrows-Wheeler-transform
 //! let bwt = bwt(text, &sa);
+//! // calculate the vectors less and Occ (occurrences)
 //! let less = less(&bwt, &alphabet);
 //! let occ = Occ::new(&bwt, 3, &alphabet);
+//! // set up FMIndex
 //! let fmindex = FMIndex::new(&bwt, &less, &occ);
-//!
+//! // do a backwards search for the pattern
 //! let interval = fmindex.backward_search(pattern.iter());
 //! let positions = interval.occ(&sa);
+//!
+//! // Iterate over a FASTQ file, use the alphabet to validate read
+//! // sequences and search for exact matches in the FM-Index.
+//!
+//! // create FASTQ reader
+//! let mut reader = fastq::Reader::new(io::stdin());
+//! let mut record = fastq::Record::new();
+//! loop{
+//!   // obtain record or fail with error
+//!   reader.read(&mut record).expect("Failed to parse record");
+//!   if record.is_empty() {
+//!     // out of records
+//!     break;
+//!   }
+//!   let check = record.check();
+//!   if check.is_err() {
+//!       panic!("I got a rubbish record!")
+//!   }
+//!   // obtain sequence
+//!   let seq = record.seq();
+//!   // check, whether seq is in the expected alphabet
+//!   if alphabet.is_word(seq) {
+//!     let interval = fmindex.backward_search(seq.iter());
+//!     let positions = interval.occ(&pos);
+//!   }
+//! }
 //! ```
 //!
-//! # Multithreaded Example
+//! Documentation and further examples for each module can be found in the module descriptions below.
+//!
+//!
+//! ## Example: Multithreaded
 //!
 //! ```rust
 //! use bio::alphabets;
@@ -85,6 +186,24 @@
 //! ```
 //!
 //! Documentation and further examples for each module can be found in the module descriptions below.
+//!
+//! # Benchmarks
+//!
+//! Since Rust-Bio is based on a compiled language, similar performance to C/C++ based libraries can be expected. Indeed, we find the pattern matching algorithms of Rust-Bio to perform in the range of the C++ library Seqan:
+//!
+//! | Algorithm | Rust-Bio | Seqan   |
+//! | --------- | -------: | ------: |
+//! | BNDM      | 77ms     | 80ms    |
+//! | Horspool  | 122ms    | 125ms   |
+//! | BOM       | 103ms    | 107ms   |
+//! | Shift-And | 241ms    | 545ms   |
+//!
+//! We measured 10000 iterations of searching pattern `GCGCGTACACACCGCCCG` in the sequence of the hg38 MT chromosome.
+//! Initialization time of each algorithm for the given pattern was included in each iteration. Benchmarks were conducted with *Cargo bench* for Rust-Bio and *Python timeit* for Seqan on an Intel Core i5-3427U CPU.
+//! Benchmarking Seqan from *Python timeit* entails an overhead of 1.46ms for calling a C++ binary. This overhead was subtracted from above Seqan run times.
+//! Note that this benchmark only compares the two libraries to exemplify that Rust-Bio has comparable speed to C++ libraries: all used algorithms have their advantages for specific text and pattern structures and lengths (see [the pattern matching section in the documentation](https://docs.rs/bio/0.28.2/bio/pattern_matching/index.html))./!
+//!
+
 
 #[macro_use]
 extern crate approx;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,6 @@
 //! Note that this benchmark only compares the two libraries to exemplify that Rust-Bio has comparable speed to C++ libraries: all used algorithms have their advantages for specific text and pattern structures and lengths (see [the pattern matching section in the documentation](https://docs.rs/bio/0.28.2/bio/pattern_matching/index.html))./!
 //!
 
-
 #[macro_use]
 extern crate approx;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 //!
 //! For **getting started** with using `rust-bio`, see [the `Getting started` section below](#getting-started).
 //! For navigating the documentation of the available modules, see [the `Modules` section below](#modules).
+//! If you want to contribute to `rust-bio`, see [the `Contribute` section in the repo](https://github.com/rust-bio/rust-bio#contribute).
 //!
 //! Currently, rust-bio provides
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,13 +126,8 @@
 //! // create FASTQ reader
 //! let mut reader = fastq::Reader::new(io::stdin());
 //! let mut record = fastq::Record::new();
-//! loop{
-//!   // obtain record or fail with error
-//!   reader.read(&mut record).expect("Failed to parse record");
-//!   if record.is_empty() {
-//!     // out of records
-//!     break;
-//!   }
+//! reader.read(&mut record).expect("Failed to parse record");
+//! while !record.is_empty() {
 //!   let check = record.check();
 //!   if check.is_err() {
 //!       panic!("I got a rubbish record!")
@@ -144,6 +139,7 @@
 //!     let interval = fmindex.backward_search(seq.iter());
 //!     let positions = interval.occ(&pos);
 //!   }
+//!   reader.read(&mut record).expect("Failed to parse record");
 //! }
 //! ```
 //!

--- a/src/scores/blosum62.rs
+++ b/src/scores/blosum62.rs
@@ -3,8 +3,6 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ndarray;
-
 lazy_static! {
     // taken from https://github.com/seqan/seqan/blob/master/include%2Fseqan%2Fscore%2Fscore_matrix_data.h#L327
     static ref MAT: ndarray::Array2<i32> = ndarray::Array::from_shape_vec((27, 27), vec![

--- a/src/scores/pam120.rs
+++ b/src/scores/pam120.rs
@@ -3,8 +3,6 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ndarray;
-
 lazy_static! {
     // taken from https://github.com/seqan/seqan/blob/master/include%2Fseqan%2Fscore%2
     // Fscore_matrix_data.h#L614

--- a/src/scores/pam200.rs
+++ b/src/scores/pam200.rs
@@ -3,8 +3,6 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ndarray;
-
 lazy_static! {
     // Taken from https://github.com/seqan/seqan/blob/master/include%2Fseqan%2Fscore
     // %2Fscore_matrix_data.h#L710

--- a/src/scores/pam250.rs
+++ b/src/scores/pam250.rs
@@ -3,8 +3,6 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ndarray;
-
 lazy_static! {
     // taken from https://github.com/seqan/seqan/blob/master/include%2Fseqan
     // %2Fscore%2Fscore_matrix_data.h#L806

--- a/src/scores/pam40.rs
+++ b/src/scores/pam40.rs
@@ -3,8 +3,6 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ndarray;
-
 lazy_static! {
     // taken from https://github.com/seqan/seqan/blob/master/include%2Fseqan%2Fscore%2Fscore_matrix_data.h#L806
     static ref MAT: ndarray::Array2<i32> = ndarray::Array::from_shape_vec((27, 27), vec![

--- a/src/stats/hmm/mod.rs
+++ b/src/stats/hmm/mod.rs
@@ -565,7 +565,6 @@ pub mod discrete_emission {
 pub mod univariate_continuous_emission {
     use super::super::{LogProb, Prob};
     use super::*;
-    use statrs;
 
     /// Implementation of a `hmm::Model` with emission values from univariate continuous distributions.
     ///

--- a/src/stats/pairhmm/mod.rs
+++ b/src/stats/pairhmm/mod.rs
@@ -85,16 +85,16 @@ pub enum XYEmission {
 
 impl XYEmission {
     pub fn prob(&self) -> LogProb {
-        match self {
-            &XYEmission::Match(p) => p,
-            &XYEmission::Mismatch(p) => p,
+        match *self {
+            XYEmission::Match(p) => p,
+            XYEmission::Mismatch(p) => p,
         }
     }
 
     pub fn is_match(&self) -> bool {
-        match self {
-            &XYEmission::Match(_) => true,
-            &XYEmission::Mismatch(_) => false,
+        match *self {
+            XYEmission::Match(_) => true,
+            XYEmission::Mismatch(_) => false,
         }
     }
 }

--- a/src/stats/pairhmm/pairhmm.rs
+++ b/src/stats/pairhmm/pairhmm.rs
@@ -243,10 +243,10 @@ impl PairHMM {
                 // Cache column probabilities or simply record the last probability.
                 // We can put all of them in one array since we simply have to sum in the end.
                 // This is also good for numerical stability.
-                self.prob_cols.push(self.fm[curr].last().unwrap().clone());
-                self.prob_cols.push(self.fx[curr].last().unwrap().clone());
+                self.prob_cols.push(*self.fm[curr].last().unwrap());
+                self.prob_cols.push(*self.fx[curr].last().unwrap());
                 // TODO check removing this (we don't want open gaps in x):
-                self.prob_cols.push(self.fy[curr].last().unwrap().clone());
+                self.prob_cols.push(*self.fy[curr].last().unwrap());
             }
 
             // next column


### PR DESCRIPTION
In preparation of the docathon, this is an attempt at making the rust-bio website obsolete and moving all documentation to the README.md and the module documentation on docs.rs

Hopefully, this will make both using the docs and maintaining them a bit easier.

Also: Update FASTQ parsing examples to a pre-allocated record, which is a more efficient method.