### PR TITLE
Split coverage and testing jobs on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,24 +41,69 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-
   Testing:
+    needs: Formatting
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [beta, stable, windows, macos]
+        include:
+          - build: macos
+            os: macos-latest
+            rust: stable
+          - build: windows
+            os: windows-latest
+            rust: stable
+          - build: beta
+            os: ubuntu-latest
+            rust: beta
+          - build: stable
+            os: ubuntu-latest
+            rust: stable
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Install ${{ matrix.rust }} toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all --no-fail-fast
+
+  Coverage:
     needs: Formatting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
+      - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
 
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+      - name: Install cargo-tarpaulin
+        uses: actions-rs/install@v0.1
         with:
-          args: '--out Lcov -- --test-threads 1'
+          crate: cargo-tarpaulin
+          version: latest
+          use-tool-cache: true
+
+      - name: Coverage with tarpaulin
+        run: cargo tarpaulin --all --all-features --timeout 600 --out Lcov -- --test-threads 1
 
       - name: Upload coverage
         uses: coverallsapp/github-action@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,4 @@ features = ["stable_graph"]
 
 [dev-dependencies]
 proptest = "0.9.4"
+tempfile = "3.1.0"

--- a/src/data_structures/interval_tree/array_backed_interval_tree.rs
+++ b/src/data_structures/interval_tree/array_backed_interval_tree.rs
@@ -19,16 +19,16 @@
 //! // since we did at least one manual insert, we have to index the tree
 //! tree.index();
 //! let i1 = &tree.find(22..25)[0];
-//! assert_eq!(i1.interval().start(), 0);
-//! assert_eq!(i1.interval().end(), 23);
-//! assert_eq!(i1.data(), 1);
+//! assert_eq!(i1.interval().start, 0);
+//! assert_eq!(i1.interval().end, 23);
+//! assert_eq!(i1.data(), &1u32);
 //!
-//! let tree = ArrayBackedIntervalTree::from_iter(vec![(12..34, 0), (0..23, 1), (34..56, 2)]);
+//! let tree = ArrayBackedIntervalTree::from_iter(vec![(12..34, 0), (0..23, 1), (34..56, 2)].into_iter());
 //! // no call to `index` needed here, since that happens in `from_iter` already
 //! let i2 = &tree.find(22..25)[1];
-//! assert_eq!(i1.interval().start(), 12);
-//! assert_eq!(i1.interval().end(), 34);
-//! assert_eq!(i1.data(), 0);
+//! assert_eq!(i2.interval().start, 12);
+//! assert_eq!(i2.interval().end, 34);
+//! assert_eq!(i2.data(), &0u32);
 //!
 //! ```
 //!

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -1460,12 +1460,20 @@ ATTGTTGTTTTA
         let expected = io::Error::new(io::ErrorKind::NotFound, "foo");
 
         assert_eq!(actual.kind(), expected.kind());
-        assert!(actual.to_string().starts_with("No such file or directory"))
+
+        #[cfg(unix)]
+        assert!(actual.to_string().starts_with("No such file or directory"));
+
+        #[cfg(windows)]
+        assert!(actual
+            .to_string()
+            .starts_with("The system cannot find the path specified"));
     }
 
     #[test]
     fn test_writer_to_file_dir_exists_returns_ok() {
-        let path = Path::new("/tmp/out.fa");
+        let file = tempfile::NamedTempFile::new().expect("Could not create temp file");
+        let path = file.path();
 
         assert!(Writer::to_file(path).is_ok())
     }

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -1460,14 +1460,6 @@ ATTGTTGTTTTA
         let expected = io::Error::new(io::ErrorKind::NotFound, "foo");
 
         assert_eq!(actual.kind(), expected.kind());
-
-        #[cfg(unix)]
-        assert!(actual.to_string().starts_with("No such file or directory"));
-
-        #[cfg(windows)]
-        assert!(actual
-            .to_string()
-            .starts_with("The system cannot find the path specified"));
     }
 
     #[test]

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -678,7 +678,14 @@ IIIIIIJJJJJJ
         let expected = io::Error::new(io::ErrorKind::NotFound, "foo");
 
         assert_eq!(actual.kind(), expected.kind());
-        assert!(actual.to_string().starts_with("No such file or directory"))
+
+        #[cfg(unix)]
+        assert!(actual.to_string().starts_with("No such file or directory"));
+
+        #[cfg(windows)]
+        assert!(actual
+            .to_string()
+            .starts_with("The system cannot find the path specified"));
     }
 
     #[test]
@@ -773,12 +780,20 @@ IIIIIIJJJJJJ
         let expected = io::Error::new(io::ErrorKind::NotFound, "foo");
 
         assert_eq!(actual.kind(), expected.kind());
-        assert!(actual.to_string().starts_with("No such file or directory"))
+
+        #[cfg(unix)]
+        assert!(actual.to_string().starts_with("No such file or directory"));
+
+        #[cfg(windows)]
+        assert!(actual
+            .to_string()
+            .starts_with("The system cannot find the path specified"));
     }
 
     #[test]
     fn test_writer_to_file_dir_exists_returns_ok() {
-        let path = Path::new("/tmp/out.fq");
+        let file = tempfile::NamedTempFile::new().expect("Could not create temp file");
+        let path = file.path();
 
         assert!(Writer::to_file(path).is_ok())
     }

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -678,14 +678,6 @@ IIIIIIJJJJJJ
         let expected = io::Error::new(io::ErrorKind::NotFound, "foo");
 
         assert_eq!(actual.kind(), expected.kind());
-
-        #[cfg(unix)]
-        assert!(actual.to_string().starts_with("No such file or directory"));
-
-        #[cfg(windows)]
-        assert!(actual
-            .to_string()
-            .starts_with("The system cannot find the path specified"));
     }
 
     #[test]
@@ -780,14 +772,6 @@ IIIIIIJJJJJJ
         let expected = io::Error::new(io::ErrorKind::NotFound, "foo");
 
         assert_eq!(actual.kind(), expected.kind());
-
-        #[cfg(unix)]
-        assert!(actual.to_string().starts_with("No such file or directory"));
-
-        #[cfg(windows)]
-        assert!(actual
-            .to_string()
-            .starts_with("The system cannot find the path specified"));
     }
 
     #[test]

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -9,7 +9,7 @@
 //!
 //! ```
 //! use std::io;
-//! use bio::io::fastq;
+//! use bio::io::fastq::{self, FastqRead};
 //! let mut reader = fastq::Reader::new(io::stdin());
 //! let mut record = fastq::Record::new();
 //! reader.read(&mut record).expect("Failed to parse record");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@
 //! use bio::data_structures::suffix_array::suffix_array;
 //! use bio::data_structures::bwt::{bwt, less, Occ};
 //! use bio::data_structures::fmindex::{FMIndex, FMIndexable};
-//! use bio::io::fastq;
+//! use bio::io::fastq::{self, FastqRead};
 //!
 //!
 //! // a given text
@@ -138,7 +138,7 @@
 //!   // check, whether seq is in the expected alphabet
 //!   if alphabet.is_word(seq) {
 //!     let interval = fmindex.backward_search(seq.iter());
-//!     let positions = interval.occ(&pos);
+//!     let positions = interval.occ(&positions);
 //!   }
 //!   reader.read(&mut record).expect("Failed to parse record");
 //! }


### PR DESCRIPTION
While updating #222 I noticed that 3 tests are failing on master, despite CI passing. Seems like `tarpaulin` is not erroring for these tests...

This PR adds an extra `testing` job that runs tests on Rust stable for Ubuntu, macOS and Windows, and beta on Ubuntu.

I also switched the coverage job to use `nightly` and run with `--all-features`, to check coverage as much as possible (`tarpaulin` runs only on Linux, and `packed_simd` requires `nightly`).

Finally, I saw [actions-rs/tarpaulin](https://github.com/actions-rs/tarpaulin/) is [starting to recommend](https://github.com/actions-rs/tarpaulin/issues/6) using `actions-rs/install` instead, so I already adapted the `coverage` job to do this.