### PR TITLE
Fix doctest/example for ArrayBackedIntervalTree

### DIFF
--- a/src/data_structures/interval_tree/array_backed_interval_tree.rs
+++ b/src/data_structures/interval_tree/array_backed_interval_tree.rs
@@ -19,15 +19,15 @@
 //! // since we did at least one manual insert, we have to index the tree
 //! tree.index();
 //! let i1 = &tree.find(22..25)[0];
-//! assert_eq!(i1.interval().start(), 0);
-//! assert_eq!(i1.interval().end(), 23);
+//! assert_eq!(i1.interval().start, 0);
+//! assert_eq!(i1.interval().end, 23);
 //! assert_eq!(i1.data(), 1);
 //!
-//! let tree = ArrayBackedIntervalTree::from_iter(vec![(12..34, 0), (0..23, 1), (34..56, 2)]);
+//! let tree = ArrayBackedIntervalTree::from_iter(&vec![(12..34, 0), (0..23, 1), (34..56, 2)]);
 //! // no call to `index` needed here, since that happens in `from_iter` already
 //! let i2 = &tree.find(22..25)[1];
-//! assert_eq!(i1.interval().start(), 12);
-//! assert_eq!(i1.interval().end(), 34);
+//! assert_eq!(i1.interval().start, 12);
+//! assert_eq!(i1.interval().end, 34);
 //! assert_eq!(i1.data(), 0);
 //!
 //! ```


### PR DESCRIPTION
The example given in `ArrayBackedIntervalTree` had errors. Fixed those ;)