### PR TITLE
Fix doctests

### DIFF
--- a/src/data_structures/interval_tree/array_backed_interval_tree.rs
+++ b/src/data_structures/interval_tree/array_backed_interval_tree.rs
@@ -11,6 +11,7 @@
 //! ```
 //! use bio::data_structures::interval_tree::ArrayBackedIntervalTree;
 //! use bio::utils::Interval;
+//! use std::iter::FromIterator;
 //!
 //! let mut tree = ArrayBackedIntervalTree::new();
 //! tree.insert(12..34, 0);
@@ -21,14 +22,14 @@
 //! let i1 = &tree.find(22..25)[0];
 //! assert_eq!(i1.interval().start, 0);
 //! assert_eq!(i1.interval().end, 23);
-//! assert_eq!(i1.data(), 1);
+//! assert_eq!(i1.data(), &1);
 //!
-//! let tree = ArrayBackedIntervalTree::from_iter(&vec![(12..34, 0), (0..23, 1), (34..56, 2)]);
+//! let tree = ArrayBackedIntervalTree::from_iter(vec![(12..34, 0), (0..23, 1), (34..56, 2)].into_iter());
 //! // no call to `index` needed here, since that happens in `from_iter` already
 //! let i2 = &tree.find(22..25)[1];
-//! assert_eq!(i1.interval().start, 12);
-//! assert_eq!(i1.interval().end, 34);
-//! assert_eq!(i1.data(), 0);
+//! assert_eq!(i2.interval().start, 12);
+//! assert_eq!(i2.interval().end, 34);
+//! assert_eq!(i2.data(), &0);
 //!
 //! ```
 //!

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -10,6 +10,7 @@
 //! ```
 //! use std::io;
 //! use bio::io::fastq;
+//! use bio::io::fastq::FastqRead;
 //! let mut reader = fastq::Reader::new(io::stdin());
 //! let mut record = fastq::Record::new();
 //! reader.read(&mut record).expect("Failed to parse record");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@
 //!   // check, whether seq is in the expected alphabet
 //!   if alphabet.is_word(seq) {
 //!     let interval = fmindex.backward_search(seq.iter());
-//!     let positions = interval.occ(&pos);
+//!     let positions = interval.occ(&sa);
 //!   }
 //!   reader.read(&mut record).expect("Failed to parse record");
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@
 //! use bio::data_structures::bwt::{bwt, less, Occ};
 //! use bio::data_structures::fmindex::{FMIndex, FMIndexable};
 //! use bio::io::fastq;
+//! use bio::io::fastq::FastqRead;
 //!
 //!
 //! // a given text


### PR DESCRIPTION
Some doctests were failing (because of unresolved imports, wrong variable references, ...) -- they shouldn't fail anymore, now