### PR TITLE
Alphabets documentation

### DIFF
--- a/src/alphabets/dna.rs
+++ b/src/alphabets/dna.rs
@@ -54,13 +54,13 @@ lazy_static! {
 /// All `N`s remain as they are.
 ///
 /// ```
-/// use bio::alphabets::dna::complement;
+/// use bio::alphabets::dna;
 ///
-/// assert_eq!(complement(65), 84);   // A → T
-/// assert_eq!(complement(99), 103);  // c → g
-/// assert_eq!(complement(78), 78);   // N → N
-/// assert_eq!(complement(89), 82);   // Y → R
-/// assert_eq!(complement(115), 115); // s → s
+/// assert_eq!(dna::complement(65), 84);   // A → T
+/// assert_eq!(dna::complement(99), 103);  // c → g
+/// assert_eq!(dna::complement(78), 78);   // N → N
+/// assert_eq!(dna::complement(89), 82);   // Y → R
+/// assert_eq!(dna::complement(115), 115); // s → s
 /// ```
 pub fn complement(a: u8) -> u8 {
     COMPLEMENT[a as usize]
@@ -72,11 +72,11 @@ pub fn complement(a: u8) -> u8 {
 /// All `N`s remain as they are.
 ///
 /// ```
-/// use bio::alphabets::dna::revcomp;
+/// use bio::alphabets::dna;
 ///
-/// assert_eq!(revcomp(b"ACGTN"), b"NACGT");
-/// assert_eq!(revcomp(b"GaTtaCA"), b"TGtaAtC");
-/// assert_eq!(revcomp(b"AGCTYRWSKMDVHBN"), b"NVDBHKMSWYRAGCT");
+/// assert_eq!(dna::revcomp(b"ACGTN"), b"NACGT");
+/// assert_eq!(dna::revcomp(b"GaTtaCA"), b"TGtaAtC");
+/// assert_eq!(dna::revcomp(b"AGCTYRWSKMDVHBN"), b"NVDBHKMSWYRAGCT");
 /// ```
 pub fn revcomp<C, T>(text: T) -> Vec<u8>
 where

--- a/src/alphabets/dna.rs
+++ b/src/alphabets/dna.rs
@@ -113,5 +113,4 @@ mod tests {
     fn number_is_no_word() {
         assert!(!alphabet().is_word(b"42"));
     }
-
 }

--- a/src/alphabets/dna.rs
+++ b/src/alphabets/dna.rs
@@ -49,11 +49,33 @@ lazy_static! {
 }
 
 /// Return complement of given DNA alphabet character (IUPAC alphabet supported).
+///
+/// Casing of input character is preserved, e.g. `t` → `a`, but `T` → `A`.
+/// All `N`s remain as they are.
+///
+/// ```
+/// use bio::alphabets::dna::complement;
+/// assert_eq!(complement(65), 84);   // A → T
+/// assert_eq!(complement(99), 103);  // c → g
+/// assert_eq!(complement(78), 78);   // N → N
+/// assert_eq!(complement(89), 82);   // Y → R
+/// assert_eq!(complement(115), 115); // s → s
+/// ```
 pub fn complement(a: u8) -> u8 {
     COMPLEMENT[a as usize]
 }
 
 /// Calculate reverse complement of given text (IUPAC alphabet supported).
+///
+/// Casing of characters is preserved, e.g. `b"NaCgT"` → `b"aCgTN"`.
+/// All `N`s remain as they are.
+///
+/// ```
+/// use bio::alphabets::dna::revcomp;
+/// assert_eq!(revcomp(b"ACGTN"), b"NACGT");
+/// assert_eq!(revcomp(b"GaTtaCA"), b"TGtaAtC");
+/// assert_eq!(revcomp(b"AGCTYRWSKMDVHBN"), b"NVDBHKMSWYRAGCT");
+/// ```
 pub fn revcomp<C, T>(text: T) -> Vec<u8>
 where
     C: Borrow<u8>,

--- a/src/alphabets/dna.rs
+++ b/src/alphabets/dna.rs
@@ -55,6 +55,7 @@ lazy_static! {
 ///
 /// ```
 /// use bio::alphabets::dna::complement;
+///
 /// assert_eq!(complement(65), 84);   // A → T
 /// assert_eq!(complement(99), 103);  // c → g
 /// assert_eq!(complement(78), 78);   // N → N
@@ -72,6 +73,7 @@ pub fn complement(a: u8) -> u8 {
 ///
 /// ```
 /// use bio::alphabets::dna::revcomp;
+///
 /// assert_eq!(revcomp(b"ACGTN"), b"NACGT");
 /// assert_eq!(revcomp(b"GaTtaCA"), b"TGtaAtC");
 /// assert_eq!(revcomp(b"AGCTYRWSKMDVHBN"), b"NVDBHKMSWYRAGCT");

--- a/src/alphabets/dna.rs
+++ b/src/alphabets/dna.rs
@@ -87,3 +87,29 @@ where
         .map(|a| complement(*a.borrow()))
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_word() {
+        assert!(alphabet().is_word(b"GATTACA"));
+    }
+
+    #[test]
+    fn is_no_word() {
+        assert!(!alphabet().is_word(b"gaUUaca"));
+    }
+
+    #[test]
+    fn symbol_is_no_word() {
+        assert!(!alphabet().is_word(b"#"));
+    }
+
+    #[test]
+    fn number_is_no_word() {
+        assert!(!alphabet().is_word(b"42"));
+    }
+
+}

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -37,6 +37,7 @@ impl Alphabet {
     /// ```
     /// use bio::alphabets;
     ///
+    /// // Create an alphabet (note that a DNA alphabet is already available in bio::alphabets::dna).
     /// let dna_alphabet = alphabets::Alphabet::new(b"ACGTacgt");
     /// assert!(dna_alphabet.is_word(b"GAttACA"));
     /// ```

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -39,6 +39,7 @@ impl Alphabet {
     ///
     /// // Create an alphabet (note that a DNA alphabet is already available in bio::alphabets::dna).
     /// let dna_alphabet = alphabets::Alphabet::new(b"ACGTacgt");
+    /// // Check whether a given text is a word over the alphabet.
     /// assert!(dna_alphabet.is_word(b"GAttACA"));
     /// ```
     pub fn new<C, T>(symbols: T) -> Self

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -144,8 +144,6 @@ impl RankTransform {
     ///
     /// let dna_alphabet = alphabets::Alphabet::new(b"acgtACGT");
     /// let dna_ranks = alphabets::RankTransform::new(&dna_alphabet);
-    /// assert_eq!(dna_ranks.get(65), 0);  // "A"
-    /// assert_eq!(dna_ranks.get(116), 7); // "t"
     /// ```
     pub fn new(alphabet: &Alphabet) -> Self {
         let mut ranks = VecMap::new();

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -33,6 +33,13 @@ pub struct Alphabet {
 
 impl Alphabet {
     /// Create new alphabet from given symbols.
+    ///
+    /// ```
+    /// use bio::alphabets;
+    ///
+    /// let dna_alphabet = alphabets::Alphabet::new(b"ACGTacgt");
+    /// assert!(dna_alphabet.is_word(b"GAttACA"));
+    /// ```
     pub fn new<C, T>(symbols: T) -> Self
     where
         C: Borrow<u8>,
@@ -45,11 +52,27 @@ impl Alphabet {
     }
 
     /// Insert symbol into alphabet.
+    ///
+    /// ```
+    /// use bio::alphabets;
+    ///
+    /// let mut dna_alphabet = alphabets::Alphabet::new(b"ACGTacgt");
+    /// assert!(!dna_alphabet.is_word(b"N"));
+    /// dna_alphabet.insert(78);
+    /// assert!(dna_alphabet.is_word(b"N"));
+    /// ```
     pub fn insert(&mut self, a: u8) {
         self.symbols.insert(a as usize);
     }
 
     /// Check if given text is a word over the alphabet.
+    ///
+    /// ```
+    /// use bio::alphabets;
+    /// let dna_alphabet = alphabets::Alphabet::new(b"ACGTacgt");
+    /// assert!(dna_alphabet.is_word(b"GAttACA"));
+    /// assert!(!dna_alphabet.is_word(b"42"));
+    /// ```
     pub fn is_word<C, T>(&self, text: T) -> bool
     where
         C: Borrow<u8>,
@@ -60,16 +83,41 @@ impl Alphabet {
     }
 
     /// Return lexicographically maximal symbol.
+    ///
+    /// ```
+    /// use bio::alphabets;
+    /// let dna_alphabet = alphabets::Alphabet::new(b"acgtACGT");
+    /// assert_eq!(dna_alphabet.max_symbol(), Some(116));  // max symbol is "t"
+    /// let empty_alphabet = alphabets::Alphabet::new(b"");
+    /// assert_eq!(empty_alphabet.max_symbol(), None);
+    /// ```
     pub fn max_symbol(&self) -> Option<u8> {
         self.symbols.iter().max().map(|a| a as u8)
     }
 
     /// Return size of the alphabet.
+    ///
+    /// Upper and lower case representations of the same character
+    /// are counted as distinct characters.
+    ///
+    /// ```
+    /// use bio::alphabets;
+    /// let dna_alphabet = alphabets::Alphabet::new(b"acgtACGT");
+    /// assert_eq!(dna_alphabet.len(), 8);
+    /// ```
     pub fn len(&self) -> usize {
         self.symbols.len()
     }
 
     /// Is this alphabet empty?
+    ///
+    /// ```
+    /// use bio::alphabets;
+    /// let dna_alphabet = alphabets::Alphabet::new(b"acgtACGT");
+    /// assert!(!dna_alphabet.is_empty());
+    /// let empty_alphabet = alphabets::Alphabet::new(b"");
+    /// assert!(empty_alphabet.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.symbols.is_empty()
     }

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -138,6 +138,15 @@ pub struct RankTransform {
 
 impl RankTransform {
     /// Construct a new `RankTransform`.
+    ///
+    /// ```
+    /// use bio::alphabets;
+    ///
+    /// let dna_alphabet = alphabets::Alphabet::new(b"acgtACGT");
+    /// let dna_ranks = alphabets::RankTransform::new(&dna_alphabet);
+    /// assert_eq!(dna_ranks.get(65), 0);  // "A"
+    /// assert_eq!(dna_ranks.get(116), 7); // "t"
+    /// ```
     pub fn new(alphabet: &Alphabet) -> Self {
         let mut ranks = VecMap::new();
         for (r, c) in alphabet.symbols.iter().enumerate() {
@@ -148,11 +157,31 @@ impl RankTransform {
     }
 
     /// Get the rank of symbol `a`.
+    ///
+    /// This method panics for characters not contained in the alphabet.
+    ///
+    /// ```
+    /// use bio::alphabets;
+    ///
+    /// let dna_alphabet = alphabets::Alphabet::new(b"acgtACGT");
+    /// let dna_ranks = alphabets::RankTransform::new(&dna_alphabet);
+    /// assert_eq!(dna_ranks.get(65), 0);  // "A"
+    /// assert_eq!(dna_ranks.get(116), 7); // "t"
+    /// ```
     pub fn get(&self, a: u8) -> u8 {
         *self.ranks.get(a as usize).expect("Unexpected character.")
     }
 
     /// Transform a given `text`.
+    ///
+    /// ```
+    /// use bio::alphabets;
+    ///
+    /// let dna_alphabet = alphabets::Alphabet::new(b"ACGTacgt");
+    /// let dna_ranks = alphabets::RankTransform::new(&dna_alphabet);
+    /// let text = b"aAcCgGtT";
+    /// assert_eq!(dna_ranks.transform(text), vec![4, 0, 5, 1, 6, 2, 7, 3]);
+    /// ```
     pub fn transform<C, T>(&self, text: T) -> Vec<u8>
     where
         C: Borrow<u8>,
@@ -172,6 +201,16 @@ impl RankTransform {
     /// as `usize` by storing the symbol ranks in log2(|A|) bits (with |A| being the alphabet size).
     ///
     /// If q is larger than usize::BITS / log2(|A|), this method fails with an assertion.
+    ///
+    /// ```
+    /// use bio::alphabets;
+    ///
+    /// let dna_alphabet = alphabets::Alphabet::new(b"ACGTacgt");
+    /// let dna_ranks = alphabets::RankTransform::new(&dna_alphabet);
+    ///
+    /// let q_grams: Vec<usize> = dna_ranks.qgrams(2, b"ACGT").collect();
+    /// assert_eq!(q_grams, vec![1, 10, 19]);
+    /// ```
     pub fn qgrams<C, T>(&self, q: u32, text: T) -> QGrams<'_, C, T::IntoIter>
     where
         C: Borrow<u8>,
@@ -199,6 +238,14 @@ impl RankTransform {
     }
 
     /// Restore alphabet from transform.
+    ///
+    /// ```
+    /// use bio::alphabets;
+    ///
+    /// let dna_alphabet = alphabets::Alphabet::new(b"acgtACGT");
+    /// let dna_ranks = alphabets::RankTransform::new(&dna_alphabet);
+    /// assert_eq!(dna_ranks.alphabet().symbols, dna_alphabet.symbols);
+    /// ```
     pub fn alphabet(&self) -> Alphabet {
         let mut symbols = BitSet::with_capacity(self.ranks.len());
         symbols.extend(self.ranks.keys());

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -69,6 +69,7 @@ impl Alphabet {
     ///
     /// ```
     /// use bio::alphabets;
+    ///
     /// let dna_alphabet = alphabets::Alphabet::new(b"ACGTacgt");
     /// assert!(dna_alphabet.is_word(b"GAttACA"));
     /// assert!(!dna_alphabet.is_word(b"42"));
@@ -86,6 +87,7 @@ impl Alphabet {
     ///
     /// ```
     /// use bio::alphabets;
+    ///
     /// let dna_alphabet = alphabets::Alphabet::new(b"acgtACGT");
     /// assert_eq!(dna_alphabet.max_symbol(), Some(116));  // max symbol is "t"
     /// let empty_alphabet = alphabets::Alphabet::new(b"");
@@ -102,6 +104,7 @@ impl Alphabet {
     ///
     /// ```
     /// use bio::alphabets;
+    ///
     /// let dna_alphabet = alphabets::Alphabet::new(b"acgtACGT");
     /// assert_eq!(dna_alphabet.len(), 8);
     /// ```
@@ -113,6 +116,7 @@ impl Alphabet {
     ///
     /// ```
     /// use bio::alphabets;
+    ///
     /// let dna_alphabet = alphabets::Alphabet::new(b"acgtACGT");
     /// assert!(!dna_alphabet.is_empty());
     /// let empty_alphabet = alphabets::Alphabet::new(b"");
@@ -124,6 +128,9 @@ impl Alphabet {
 }
 
 /// Tools based on transforming the alphabet symbols to their lexicographical ranks.
+///
+/// Lexicographical rank is computed using `u8` representations,
+/// i.e. ASCII codes, of the input characters.
 #[derive(Serialize, Deserialize)]
 pub struct RankTransform {
     pub ranks: SymbolRanks,
@@ -217,6 +224,7 @@ where
     C: Borrow<u8>,
     T: Iterator<Item = C>,
 {
+    /// Push a new character into the current qgram.
     fn qgram_push(&mut self, a: u8) {
         self.qgram <<= self.bits;
         self.qgram |= a as usize;

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -133,10 +133,10 @@ impl Alphabet {
 ///
 /// Lexicographical rank is computed using `u8` representations,
 /// i.e. ASCII codes, of the input characters.
-/// For example, assuming that the alphabet consists of the symbols `A`, `C`, `G`, and `T`, this 
+/// For example, assuming that the alphabet consists of the symbols `A`, `C`, `G`, and `T`, this
 /// will yield ranks `0`, `1`, `2`, `3` for them, respectively.
 ///
-/// `RankTransform` can be used in to perform bit encoding for texts over a 
+/// `RankTransform` can be used in to perform bit encoding for texts over a
 /// given alphabet via `bio::data_structures::bitenc`.
 #[derive(Serialize, Deserialize)]
 pub struct RankTransform {

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -133,6 +133,11 @@ impl Alphabet {
 ///
 /// Lexicographical rank is computed using `u8` representations,
 /// i.e. ASCII codes, of the input characters.
+/// For example, assuming that the alphabet consists of the symbols `A`, `C`, `G`, and `T`, this 
+/// will yield ranks `0`, `1`, `2`, `3` for them, respectively.
+///
+/// `RankTransform` can be used in to perform bit encoding for texts over a 
+/// given alphabet via `bio::data_structures::bitenc`.
 #[derive(Serialize, Deserialize)]
 pub struct RankTransform {
     pub ranks: SymbolRanks,

--- a/src/alphabets/rna.rs
+++ b/src/alphabets/rna.rs
@@ -54,13 +54,13 @@ lazy_static! {
 /// All `N`s and `Z`s remain as they are.
 ///
 /// ```
-/// use bio::alphabets::rna::complement;
+/// use bio::alphabets::rna;
 ///
-/// assert_eq!(complement(65), 85);   // A → U
-/// assert_eq!(complement(103), 99);  // g → c
-/// assert_eq!(complement(89), 82);   // Y → R
-/// assert_eq!(complement(115), 115); // s → s
-/// assert_eq!(complement(78), 78);   // N → N
+/// assert_eq!(rna::complement(65), 85);   // A → U
+/// assert_eq!(rna::complement(103), 99);  // g → c
+/// assert_eq!(rna::complement(89), 82);   // Y → R
+/// assert_eq!(rna::complement(115), 115); // s → s
+/// assert_eq!(rna::complement(78), 78);   // N → N
 /// ```
 pub fn complement(a: u8) -> u8 {
     COMPLEMENT[a as usize]
@@ -72,11 +72,11 @@ pub fn complement(a: u8) -> u8 {
 /// All `N`s and `Z`s remain as they are.
 ///
 /// ```
-/// use bio::alphabets::rna::revcomp;
+/// use bio::alphabets::rna;
 ///
-/// assert_eq!(revcomp(b"ACGUN"), b"NACGU");
-/// assert_eq!(revcomp(b"GaUuaCA"), b"UGuaAuC");
-/// assert_eq!(revcomp(b"AGCUYRWSKMDVHBNZ"), b"ZNVDBHKMSWYRAGCU");
+/// assert_eq!(rna::revcomp(b"ACGUN"), b"NACGU");
+/// assert_eq!(rna::revcomp(b"GaUuaCA"), b"UGuaAuC");
+/// assert_eq!(rna::revcomp(b"AGCUYRWSKMDVHBNZ"), b"ZNVDBHKMSWYRAGCU");
 pub fn revcomp<C, T>(text: T) -> Vec<u8>
 where
     C: Borrow<u8>,

--- a/src/alphabets/rna.rs
+++ b/src/alphabets/rna.rs
@@ -49,11 +49,32 @@ lazy_static! {
 }
 
 /// Return complement of given RNA alphabet character (IUPAC alphabet supported).
+///
+/// Casing of input character is preserved, e.g. `u` → `a`, but `U` → `A`.
+/// All `N`s and `Z`s remain as they are.
+///
+/// ```
+/// use bio::alphabets::rna::complement;
+/// assert_eq!(complement(65), 85);   // A → U
+/// assert_eq!(complement(103), 99);  // g → c
+/// assert_eq!(complement(89), 82);   // Y → R
+/// assert_eq!(complement(115), 115); // s → s
+/// assert_eq!(complement(78), 78);   // N → N
+/// ```
 pub fn complement(a: u8) -> u8 {
     COMPLEMENT[a as usize]
 }
 
 /// Calculate reverse complement of given text (IUPAC alphabet supported).
+///
+/// Casing of characters is preserved, e.g. `b"uAGg"` → `b"cCUa"`.
+/// All `N`s and `Z`s remain as they are.
+///
+/// ```
+/// use bio::alphabets::rna::revcomp;
+/// assert_eq!(revcomp(b"ACGUN"), b"NACGU");
+/// assert_eq!(revcomp(b"GaUuaCA"), b"UGuaAuC");
+/// assert_eq!(revcomp(b"AGCUYRWSKMDVHBNZ"), b"ZNVDBHKMSWYRAGCU");
 pub fn revcomp<C, T>(text: T) -> Vec<u8>
 where
     C: Borrow<u8>,

--- a/src/alphabets/rna.rs
+++ b/src/alphabets/rna.rs
@@ -55,6 +55,7 @@ lazy_static! {
 ///
 /// ```
 /// use bio::alphabets::rna::complement;
+///
 /// assert_eq!(complement(65), 85);   // A → U
 /// assert_eq!(complement(103), 99);  // g → c
 /// assert_eq!(complement(89), 82);   // Y → R
@@ -72,6 +73,7 @@ pub fn complement(a: u8) -> u8 {
 ///
 /// ```
 /// use bio::alphabets::rna::revcomp;
+///
 /// assert_eq!(revcomp(b"ACGUN"), b"NACGU");
 /// assert_eq!(revcomp(b"GaUuaCA"), b"UGuaAuC");
 /// assert_eq!(revcomp(b"AGCUYRWSKMDVHBNZ"), b"ZNVDBHKMSWYRAGCU");


### PR DESCRIPTION
This PR adds doctests for all public functions and methods in the alphabets module.
Additionally, it adds module tests for `dna` alphabets, which test if methods of `Alphabet` behave as expected when working with `dna`.