### PR TITLE
Update actions-rs/tarpaulin from v0.1 -> v0.1.2 to get Doctests to run.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1.2
         with:
-          args: '--out Lcov -- --test-threads 1'
+          args: '--run-types AllTargets --out Lcov -- --test-threads 1'
 
       - name: Upload coverage
         uses: coverallsapp/github-action@master

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
           override: true
 
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+        uses: actions-rs/tarpaulin@v0.1.2
         with:
           args: '--out Lcov -- --test-threads 1'
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1.2
         with:
-          args: '--run-types AllTargets --out Lcov -- --test-threads 1'
+          args: '--run-types Tests,Doctests --out Lcov -- --test-threads 1'
 
       - name: Upload coverage
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
This is an attempt to get tarpaulin to also run Doctests.