### PR TITLE
Add rustfmt and cargo check pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: master
+    hooks:
+      - id: fmt
+      - id: cargo-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,15 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+      - id: check-byte-order-marker
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
   - repo: https://github.com/doublify/pre-commit-rust
     rev: master
     hooks:


### PR DESCRIPTION
In order to reduce the number of "fmt" commits (and hence reduce the number of CI triggers), this PR adds a `.pre-commit-config.yaml` for use with [pre-commit](https://pre-commit.com/).
In order to use this:
1. install `pre-commit` (see [pre-commit.com/#installation)](https://pre-commit.com/#installation)
2. run `pre-commit install` in the rust-bio base dir

and henceforth every time you commit, *changes* will be formatted with rustftm and checked with cargo check!