### PR TITLE
Improve docs: data_structures::annot_map

### DIFF
--- a/src/data_structures/annot_map.rs
+++ b/src/data_structures/annot_map.rs
@@ -1,5 +1,25 @@
 //! Efficient container for locations annotated across a set of named
 //! reference sequences.
+//!
+//! # Example
+//!
+//! ```
+//! extern crate bio_types;
+//! use bio_types::strand::ReqStrand;
+//! use bio_types::annot::contig::Contig;
+//! use bio::data_structures::annot_map::AnnotMap;
+//!
+//! let mut genes: AnnotMap<String,String> = AnnotMap::new();
+//! let tma19 = Contig::new("chrXI".to_owned(), 334412, (334916 - 334412), ReqStrand::Reverse);
+//! let tma22 = Contig::new("chrX".to_owned(), 461829, 462426 - 461829, ReqStrand::Forward);
+//! genes.insert_at("TMA19".to_owned(), &tma19);
+//! genes.insert_at("TMA22".to_owned(), &tma22);
+//!
+//! let query = Contig::new("chrX".to_owned(), 462400, 100, ReqStrand::Forward);
+//! let hits: Vec<&String> = genes.find(&query).map(|e| e.data()).collect();
+//! assert_eq!(hits, vec!["TMA22"]);
+//! ```
+
 use std::collections::HashMap;
 use std::hash::Hash;
 
@@ -45,10 +65,9 @@ impl<R, T> AnnotMap<R, T>
 where
     R: Eq + Hash,
 {
-    /// Creates a new, empty `AnnotMap`.
+    /// Create a new, empty `AnnotMap`.
     ///
     /// ```
-    /// extern crate bio;
     /// use bio::data_structures::annot_map::AnnotMap;
     /// let mut genes: AnnotMap<String,String> = AnnotMap::new();
     /// ```
@@ -56,25 +75,17 @@ where
         Default::default()
     }
 
-    /// Inserts an object into the container at a specified location.
-    ///
-    /// # Arguments
-    ///
-    /// `data` is the data item to be inserted into the annotation map
-    ///
-    /// `location` is the location associated with the data item.
+    /// Insert an object into the container at a specified location.
     ///
     /// ```
     /// extern crate bio_types;
-    /// extern crate bio;
     /// use bio_types::strand::ReqStrand;
     /// use bio_types::annot::contig::Contig;
     /// use bio::data_structures::annot_map::AnnotMap;
+    ///
     /// let mut genes: AnnotMap<String,String> = AnnotMap::new();
     /// let tma22 = Contig::new("chrX".to_owned(), 461829, 462426 - 461829, ReqStrand::Forward);
     /// genes.insert_at("TMA22".to_owned(), &tma22);
-    /// let tma19 = Contig::new("chrXI".to_owned(), 334412, (334916 - 334412), ReqStrand::Reverse);
-    /// genes.insert_at("TMA19".to_owned(), &tma19);
     /// ```
     pub fn insert_at<L>(&mut self, data: T, location: &L)
     where
@@ -89,33 +100,8 @@ where
         itree.insert(rng, data);
     }
 
-    /// Creates an `Iterator` that will visit all entries that overlap
+    /// Create an `Iterator` that will visit all entries that overlap
     /// a query location.
-    ///
-    ///
-    /// # Arguments
-    ///
-    /// `location` is the annotation location to be searched for
-    /// overlapping data items.
-    ///
-    /// ```
-    /// extern crate bio_types;
-    /// extern crate bio;
-    /// use bio_types::strand::ReqStrand;
-    /// use bio_types::annot::contig::Contig;
-    /// use bio::data_structures::annot_map::AnnotMap;
-    /// let mut genes: AnnotMap<String,String> = AnnotMap::new();
-    /// let tma22 = Contig::new("chrX".to_owned(), 461829, 462426 - 461829, ReqStrand::Forward);
-    /// genes.insert_at("TMA22".to_owned(), &tma22);
-    /// let tma19 = Contig::new("chrXI".to_owned(), 334412, (334916 - 334412), ReqStrand::Reverse);
-    /// genes.insert_at("TMA19".to_owned(), &tma19);
-    /// let query = Contig::new("chrX".to_owned(), 462400, 100, ReqStrand::Forward);
-    /// let hits: Vec<&String> = genes.find(&query).map(|e| e.data()).collect();
-    /// assert_eq!(hits, vec!["TMA22"]);
-    /// let query = Contig::new("chrXI".to_owned(), 334400, 100, ReqStrand::Forward);
-    /// let hits: Vec<&String> = genes.find(&query).map(|e| e.data()).collect();
-    /// assert_eq!(hits, vec!["TMA19"]);
-    /// ```
     pub fn find<'a, L>(&'a self, location: &'a L) -> AnnotMapIterator<'a, R, T>
     where
         L: Loc<RefID = R>,
@@ -141,13 +127,8 @@ where
     R: Eq + Hash + Clone,
     T: Loc<RefID = R>,
 {
-    /// Inserts an object with the `Loc` trait into the container at
+    /// Insert an object with the `Loc` trait into the container at
     /// its location.
-    ///
-    /// # Argument
-    ///
-    /// `data` is the data to be inserted based on its location.
-    ///
     /// Equivalent to inserting `data` at `data.contig()`.
     pub fn insert_loc(&mut self, data: T) {
         let itree = self
@@ -173,17 +154,17 @@ impl<'a, R, T> Entry<'a, R, T>
 where
     R: Eq + Hash,
 {
-    /// Returns a reference to the data value in the `AnnotMap`.
+    /// Return a reference to the data value in the `AnnotMap`.
     pub fn data(&self) -> &'a T {
         self.itree_entry.data()
     }
 
-    /// Returns a reference to the interval spanned by the annotation.
+    /// Return a reference to the interval spanned by the annotation.
     pub fn interval(&self) -> &'a Interval<isize> {
         self.itree_entry.interval()
     }
 
-    /// Returns a reference to the identifier of the annotated reference sequence.
+    /// Return a reference to the identifier of the annotated reference sequence.
     pub fn refid(&self) -> &'a R {
         self.refid
     }

--- a/src/data_structures/annot_map.rs
+++ b/src/data_structures/annot_map.rs
@@ -70,12 +70,8 @@ impl<R, T> AnnotMap<R, T>
 where
     R: Eq + Hash,
 {
-    /// Create a new, empty `AnnotMap`.
-    ///
-    /// ```
-    /// use bio::data_structures::annot_map::AnnotMap;
-    /// let mut genes: AnnotMap<String, String> = AnnotMap::new();
-    /// ```
+    /// Create a new, empty `AnnotMap`. Used in conjunction with `insert_at`
+    /// or `insert_loc`.
     pub fn new() -> Self {
         Default::default()
     }
@@ -170,7 +166,7 @@ where
     /// gene_locs.insert_loc(tma19);
     /// // Find annotations that overlap a specific query
     /// let query = Contig::new(String::from("chrXI"), 334400, 100, ReqStrand::Reverse);
-    /// let hits: Vec<&Contig<String,ReqStrand>> = gene_locs.find(&query).map(|e| e.data()).collect();
+    /// let hits: Vec<&Contig<String, ReqStrand>> = gene_locs.find(&query).map(|e| e.data()).collect();
     /// assert_eq!(hits, vec![&assert_copy]);
     /// ```
     pub fn insert_loc(&mut self, data: T) {

--- a/src/data_structures/annot_map.rs
+++ b/src/data_structures/annot_map.rs
@@ -84,7 +84,7 @@ where
     ///
     /// # Arguments
     ///
-    /// * `data` - any type of data the inserted location / region
+    /// * `data` - any type of data to be inserted at the location / region
     /// * `location` - any object with the `Loc` trait implemented, determining
     ///   the Range at which to insert the `data`
     ///

--- a/src/data_structures/annot_map.rs
+++ b/src/data_structures/annot_map.rs
@@ -9,22 +9,27 @@
 //! use bio_types::annot::contig::Contig;
 //! use bio_types::strand::ReqStrand;
 //!
-//! let mut genes: AnnotMap<String, String> = AnnotMap::new();
+//! // Insert an object with the `Loc` trait into the container at its location.
+//! let mut gene_locs = AnnotMap::new();
 //! let tma19 = Contig::new(
 //!     "chrXI".to_owned(),
 //!     334412,
 //!     (334916 - 334412),
 //!     ReqStrand::Reverse,
 //! );
+//! gene_locs.insert_loc(tma19);
+//!
+//! // Alternatively, insert an object into the container at a specified location.
+//! let mut genes: AnnotMap<String, String> = AnnotMap::new();
 //! let tma22 = Contig::new(
 //!     "chrX".to_owned(),
 //!     461829,
 //!     462426 - 461829,
 //!     ReqStrand::Forward,
 //! );
-//! genes.insert_at("TMA19".to_owned(), &tma19);
 //! genes.insert_at("TMA22".to_owned(), &tma22);
 //!
+//! // Find annotations that overlap a specific query
 //! let query = Contig::new("chrX".to_owned(), 462400, 100, ReqStrand::Forward);
 //! let hits: Vec<&String> = genes.find(&query).map(|e| e.data()).collect();
 //! assert_eq!(hits, vec!["TMA22"]);

--- a/src/data_structures/annot_map.rs
+++ b/src/data_structures/annot_map.rs
@@ -9,17 +9,7 @@
 //! use bio_types::annot::contig::Contig;
 //! use bio_types::strand::ReqStrand;
 //!
-//! // Insert an object with the `Loc` trait into the container at its location.
-//! let mut gene_locs = AnnotMap::new();
-//! let tma19 = Contig::new(
-//!     "chrXI".to_owned(),
-//!     334412,
-//!     (334916 - 334412),
-//!     ReqStrand::Reverse,
-//! );
-//! gene_locs.insert_loc(tma19);
-//!
-//! // Alternatively, insert an object into the container at a specified location.
+//! // Insert a String annotation into the annotation map at a specified location.
 //! let mut genes: AnnotMap<String, String> = AnnotMap::new();
 //! let tma22 = Contig::new(
 //!     "chrX".to_owned(),
@@ -90,7 +80,15 @@ where
         Default::default()
     }
 
-    /// Insert an object into the container at a specified location.
+    /// Insert an object into the container at a specified location (`Loc`).
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - any type of data the inserted location / region
+    /// * `location` - any object with the `Loc` trait implemented, determining
+    ///   the Range at which to insert the `data`
+    ///
+    /// # Example
     ///
     /// ```
     /// extern crate bio_types;
@@ -149,7 +147,32 @@ where
 {
     /// Insert an object with the `Loc` trait into the container at
     /// its location.
-    /// Equivalent to inserting `data` at `data.contig()`.
+    ///
+    /// This inserts all of `data` at the Range of length `data.length()`
+    /// that starts at `data.start()`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// extern crate bio_types;
+    /// use bio::data_structures::annot_map::AnnotMap;
+    /// use bio_types::annot::contig::Contig;
+    /// use bio_types::strand::ReqStrand;
+    ///
+    /// let mut gene_locs = AnnotMap::new();
+    /// let tma19 = Contig::new(
+    ///     String::from("chrXI"),
+    ///     334412,
+    ///     (334916 - 334412),
+    ///     ReqStrand::Reverse,
+    /// );
+    /// let assert_copy = tma19.clone();
+    /// gene_locs.insert_loc(tma19);
+    /// // Find annotations that overlap a specific query
+    /// let query = Contig::new(String::from("chrXI"), 334400, 100, ReqStrand::Reverse);
+    /// let hits: Vec<&Contig<String,ReqStrand>> = gene_locs.find(&query).map(|e| e.data()).collect();
+    /// assert_eq!(hits, vec![&assert_copy]);
+    /// ```
     pub fn insert_loc(&mut self, data: T) {
         let itree = self
             .refid_itrees


### PR DESCRIPTION
Reorganizes and cleans up `data_structures::annot_map` docs as part of #283 