### PR TITLE
Additional traits for BitEnc

### DIFF
--- a/src/data_structures/bitenc.rs
+++ b/src/data_structures/bitenc.rs
@@ -19,7 +19,7 @@
 //! ```
 
 /// A sequence of bitencoded values.
-#[derive(Serialize, Deserialize, PartialEq, PartialOrd)]
+#[derive(Serialize, Deserialize, PartialEq, Hash)]
 pub struct BitEnc {
     storage: Vec<u32>,
     width: usize,
@@ -27,6 +27,8 @@ pub struct BitEnc {
     len: usize,
     bits: usize,
 }
+
+impl Eq for BitEnc {}
 
 fn mask(width: usize) -> u32 {
     (1 << width) - 1

--- a/src/data_structures/bitenc.rs
+++ b/src/data_structures/bitenc.rs
@@ -19,7 +19,7 @@
 //! ```
 
 /// A sequence of bitencoded values.
-#[derive(Serialize, Deserialize, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct BitEnc {
     storage: Vec<u32>,
     width: usize,

--- a/src/data_structures/bitenc.rs
+++ b/src/data_structures/bitenc.rs
@@ -19,7 +19,7 @@
 //! ```
 
 /// A sequence of bitencoded values.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd)]
 pub struct BitEnc {
     storage: Vec<u32>,
     width: usize,

--- a/src/data_structures/bitenc.rs
+++ b/src/data_structures/bitenc.rs
@@ -28,8 +28,6 @@ pub struct BitEnc {
     bits: usize,
 }
 
-impl Eq for BitEnc {}
-
 fn mask(width: usize) -> u32 {
     (1 << width) - 1
 }


### PR DESCRIPTION
This PR implements the traits Hash, Eq and PartialEq für die BitEnc struct.
These are required for including a BitEnc object into a HashMap and for (de)serializing using serde.