### PR TITLE
Improve error message for fasta reader

### DIFF
--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -483,7 +483,7 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
             Some(rid) => self.idx_by_rid(*rid),
             None => Err(io::Error::new(
                 io::ErrorKind::Other,
-                "Unknown sequence name.",
+                format!("Unknown sequence name: {}.", seqname),
             )),
         }
     }


### PR DESCRIPTION
This PR adds the actual sequence name that was not found to the error message of the fasta reader.