### PR TITLE
Using KaTeX in docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,7 @@ features = ["stable_graph"]
 [dev-dependencies]
 proptest = "0.10"
 tempfile = "3.1.0"
+
+[package.metadata.docs.rs]
+rustdoc-args = [ "--html-in-header", "katex-header.html" ]
+

--- a/katex-header.html
+++ b/katex-header.html
@@ -1,0 +1,15 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.css" integrity="sha384-9eLZqc9ds8eNjO3TmqPeYcDj8n+Qfa4nuSiGYa6DjLNcv9BtN69ZIulL9+8CqC9Y" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.js"                  integrity="sha384-K3vbOmF2BtaVai+Qk37uypf7VrgBubhQreNQe9aGsz9lB63dIFiQVlJbr92dw2Lx" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/contrib/auto-render.min.js"    integrity="sha384-kmZOZB5ObwgQnS/DuDg6TScgOiWWBiVt0plIRkZCmE6rDZGrEOQeHM5PcHi+nyqe" crossorigin="anonymous"></script>
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        renderMathInElement(document.body, {
+            delimiters: [
+                {left: "$$", right: "$$", display: true},
+                {left: "\\(", right: "\\)", display: false},
+                {left: "$", right: "$", display: false},
+                {left: "\\[", right: "\\]", display: true}
+            ]
+        });
+    });
+</script>

--- a/src/alignment/distance.rs
+++ b/src/alignment/distance.rs
@@ -135,12 +135,12 @@ pub mod simd {
     }
 
     /// SIMD-accelerated Levenshtein (or Edit) distance between two strings. Complexity:
-    /// O(k / w * (n + m)), with n and m being the length of the given texts, k being the
-    /// number of edits, and w being the length of the SIMD vectors (usually w = 16 or
-    /// w = 32).
+    /// $O\left(\frac{k}{w(n+m)}\right)$, with $n$ and $m$ being the length of the given texts, $k$ being the
+    /// number of edits, and $w$ being the length of the SIMD vectors (usually $w = 16$ or
+    /// $w = 32$).
     ///
     /// Uses exponential search, which is approximately two times slower than the usual
-    /// O(n * m) implementation if the number of edits between the two strings is very large,
+    /// $O(nm)$ implementation if the number of edits between the two strings is very large,
     /// but much faster for cases where the edit distance is low (when less than half of the
     /// characters in the strings differ).
     ///


### PR DESCRIPTION
Using KaTeX in docs, as suggested in isuue #349 

For local preview, use `RUSTDOCFLAGS="--html-in-header katex-header.html" cargo doc`

<img width="1164" alt="スクリーンショット 2020-09-07 9 07 04" src="https://user-images.githubusercontent.com/38644266/92339614-a4229f00-f0e9-11ea-83c2-947c05fb6032.png">
