### PR TITLE
Package only files that are needed.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,16 @@ readme = "README.md"
 license = "MIT"
 build = "build.rs"
 edition = "2018"
+include = [
+    "src/",
+    "tests/",
+    "benches/",
+    "Cargo.toml",
+    "build.rs",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+]
 
 [package.metadata.release]
 pre-release-commit-message = "release version {{version}}"


### PR DESCRIPTION
When publishing to crates.io, by default files specified in `.gitignore` are ignored. Thus, some unnecessary files like `.github/*` are also packaged. Explicitly specifying files to include makes our crate cleaner.

See: https://doc.rust-lang.org/cargo/reference/publishing.html