### PR TITLE
update triple_accel version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ strum_macros = ">= 0.16, <= 0.18"
 snafu = ">= 0.5, <= 0.6"
 getset = "0.0.9"
 enum-map = "0.6"
-triple_accel = "0.3.4"
+triple_accel = "0.3"
 
 [dependencies.vec_map]
 version = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ strum_macros = ">= 0.16, <= 0.18"
 snafu = ">= 0.5, <= 0.6"
 getset = "0.0.9"
 enum-map = "0.6"
-triple_accel = "0.3.2"
+triple_accel = "0.3.4"
 
 [dependencies.vec_map]
 version = "0.8"


### PR DESCRIPTION
`triple_accel` version 0.3.2 causes `bio` fail to compile with `cargo 1.48.0-nightly (875e01232 2020-09-08)`. This has been fixed in the latest [v0.3.4 on 2020-09-17](https://crates.io/crates/triple_accel/0.3.4) thanks to @Daniel-Liu-c0deb0t : https://github.com/Daniel-Liu-c0deb0t/triple_accel/issues/3