### PR TITLE
Add PartialEq and Debug impls for Alphabet.

### DIFF
--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -27,9 +27,33 @@ pub mod rna;
 pub type SymbolRanks = VecMap<u8>;
 
 /// Representation of an alphabet.
+#[derive(Debug)]
 pub struct Alphabet {
     pub symbols: BitSet,
 }
+
+/// Implement partial equality for an Alphabet such that two alphabets are equal if their symbols
+/// are equal.
+impl PartialEq for Alphabet {
+    /// Checks that an alphabet and the other have the same symbols, if so, return true.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bio::alphabets::Alphabet;
+    ///
+    /// assert_eq!(Alphabet::new(b"ATCG"), Alphabet::new(b"ATCG"));
+    /// assert_eq!(Alphabet::new(b"ATCG"), Alphabet::new(b"TAGC"));
+    ///
+    /// assert_ne!(Alphabet::new(b"ATCG"), Alphabet::new(b"ATCC"));
+    ///
+    /// ```
+    fn eq(&self, other: &Self) -> bool {
+        self.symbols == other.symbols
+    }
+}
+
+impl Eq for Alphabet {}
 
 impl Alphabet {
     /// Create new alphabet from given symbols.

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -27,33 +27,10 @@ pub mod rna;
 pub type SymbolRanks = VecMap<u8>;
 
 /// Representation of an alphabet.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Alphabet {
     pub symbols: BitSet,
 }
-
-/// Implement partial equality for an Alphabet such that two alphabets are equal if their symbols
-/// are equal.
-impl PartialEq for Alphabet {
-    /// Checks that an alphabet and the other have the same symbols, if so, return true.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use bio::alphabets::Alphabet;
-    ///
-    /// assert_eq!(Alphabet::new(b"ATCG"), Alphabet::new(b"ATCG"));
-    /// assert_eq!(Alphabet::new(b"ATCG"), Alphabet::new(b"TAGC"));
-    ///
-    /// assert_ne!(Alphabet::new(b"ATCG"), Alphabet::new(b"ATC"));
-    ///
-    /// ```
-    fn eq(&self, other: &Self) -> bool {
-        self.symbols == other.symbols
-    }
-}
-
-impl Eq for Alphabet {}
 
 impl Alphabet {
     /// Create new alphabet from given symbols.

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -374,13 +374,14 @@ where
     }
 }
 
-#[cfg(tests)]
+#[cfg(test)]
 mod tests {
-    #[test]
-    fn test_serde() {
-        use serde::{Deserialize, Serialize};
-        fn impls_serde_traits<S: Serialize + Deserialize>() {}
+    use super::*;
 
-        impls_serde_traits::<RankTransform>();
+    #[test]
+    fn test_alphabet_eq() {
+        assert_eq!(Alphabet::new(b"ATCG"), Alphabet::new(b"ATCG"));
+        assert_eq!(Alphabet::new(b"ATCG"), Alphabet::new(b"TAGC"));
+        assert_ne!(Alphabet::new(b"ATCG"), Alphabet::new(b"ATC"));
     }
 }

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -45,7 +45,7 @@ impl PartialEq for Alphabet {
     /// assert_eq!(Alphabet::new(b"ATCG"), Alphabet::new(b"ATCG"));
     /// assert_eq!(Alphabet::new(b"ATCG"), Alphabet::new(b"TAGC"));
     ///
-    /// assert_ne!(Alphabet::new(b"ATCG"), Alphabet::new(b"ATCC"));
+    /// assert_ne!(Alphabet::new(b"ATCG"), Alphabet::new(b"ATC"));
     ///
     /// ```
     fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
Fairly minor change, but this makes it possible to compare two alphabets for equality. This assumes two alphabets are equal if their BitSets are equal.