### PR TITLE
add Discord server to Contribution section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ If you **find a bug** and don't have the time or in-depth knowledge to fix it, j
 If you want to contribute fixes, documentation or new code, please [open a pull request](https://github.com/rust-bio/rust-bio/compare).
 You have two options to do this:
 1. For one-time contributions, simply [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the repository, apply your changes to a branch in your fork and then open a pull request.
-2. If you plan on contributing more than once, become a contributor by saying hi in the [`Join the team!` issue](https://github.com/rust-bio/rust-bio/issues/27), we'll add you to the team.
+2. If you plan on contributing more than once, become a contributor by saying hi in the [`Join the team!` issue](https://github.com/rust-bio/rust-bio/issues/27) or [on the `rust-bio` Discord server](https://discord.gg/rssQABT).
+    We'll add you to the team.
     Then, you don't have to create a fork, but can simply push new branches into the main repository and open pull requests there.
  
 If you want to contribute and don't know where to start, have a look at the [roadmap](https://github.com/rust-bio/rust-bio/issues/3).


### PR DESCRIPTION
Now that we are permanently using the Discord server (which was initially created for the 2020 Docathon), we might as well add the invite link to the main README.md to make it more accessible.