### PR TITLE
add github issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+### Setup
+
+I am reporting a problem with:
+
+- **rust-bio** version:
+- cargo version: (run `cargo -V`)
+- operating system:
+
+### Expected behaviour
+
+<!---  (*Please fill this in*) -->
+
+### Actual behaviour
+
+<!---  (*Please fill this in, and provide any error message in full*) -->
+
+### Steps to reproduce
+
+<!---  (*Please fill this in*) -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+This pull request addresses issue #...
+
+<!--- Please read each of the following items and confirm by replacing
+ !--the [ ] with a [X] --->
+
+- [ ] I hereby agree to licence this and any previous contributions under the **MIT LICENSE**.
+- [ ] I have read the `CONTRIBUTING.md` file and fixed any warnings produced by `cargo fmt` and `cargo clippy`.
+- [ ] I have added my name to the alphabetical contributors listings in the files
+``CHANGELOG.md`` and ``CONTRIB.md`` as part of this pull request, am listed
+already, or do not wish to be listed. (*This acknowledgement is optional.*)


### PR DESCRIPTION
The templates are adapted from BioPython. They help to improve the efficiency of dealing with issues and PRs.

To see how it looks, you can try [opening a new issue in BioPython](https://github.com/biopython/biopython/issues/new).