### PR TITLE
Wrap comments

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,3 @@
 unstable_features = true
 format_code_in_doc_comments = true
+wrap_comments = true

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,4 @@
 unstable_features = true
 format_code_in_doc_comments = true
 wrap_comments = true
+comment_width = 100

--- a/benches/approximate_matching.rs
+++ b/benches/approximate_matching.rs
@@ -220,8 +220,9 @@ ACCATCCTCCGTGAAATCAATATCCCGCACAAGAGTGCTACTCTCCTCGCTCCGGGCCCATAACACTTGGGGGTAGCTA\
 AAGTGAACTGTATCCGACATCTGGTTCCTACTTCAGGGTCATAAAGCCTAAATAGCCCACACGTTCCCCTTAAATAAGA\
 CATCACGATG";
 
-// Pattern has same length as in pattern_matching.rs, but 2 differences to best match.
-// With k = 5 there are 14 hits, with k = 6, there are 78 hits (most are overlapping)
+// Pattern has same length as in pattern_matching.rs, but 2 differences to best
+// match. With k = 5 there are 14 hits, with k = 6, there are 78 hits (most are
+// overlapping)
 static PATTERN: &'static [u8] = b"GCGCGTCCACACCGCTCG";
 
 static K: u8 = 6;

--- a/src/alignment/distance.rs
+++ b/src/alignment/distance.rs
@@ -41,8 +41,8 @@ pub fn hamming(alpha: TextSlice<'_>, beta: TextSlice<'_>) -> u64 {
     dist
 }
 
-/// Compute the Levenshtein (or Edit) distance between two strings. Complexity: O(n * m) with
-/// n and m being the length of the given texts.
+/// Compute the Levenshtein (or Edit) distance between two strings. Complexity:
+/// O(n * m) with n and m being the length of the given texts.
 ///
 /// # Example
 ///
@@ -86,29 +86,31 @@ pub fn levenshtein(alpha: TextSlice<'_>, beta: TextSlice<'_>) -> u32 {
 }
 
 pub mod simd {
-    //! String distance routines accelerated with Single Instruction Multiple Data (SIMD)
-    //! intrinsics.
+    //! String distance routines accelerated with Single Instruction Multiple
+    //! Data (SIMD) intrinsics.
     //!
-    //! These routines will automatically fallback to scalar versions if AVX2 or SSE4.1 is
-    //! not supported by the CPU.
+    //! These routines will automatically fallback to scalar versions if AVX2 or
+    //! SSE4.1 is not supported by the CPU.
     //!
-    //! With AVX2, SIMD-accelerated Hamming distance can reach up to 40 times faster than
-    //! the scalar version on strings that are long enough.
+    //! With AVX2, SIMD-accelerated Hamming distance can reach up to 40 times
+    //! faster than the scalar version on strings that are long enough.
     //!
-    //! The performance of SIMD-accelerated Levenshtein distance depends on the number of
-    //! edits between two strings, so it can perform anywhere from 2 times to nearly 1000
-    //! times faster than the scalar version. When the two strings are completely different,
-    //! there could be no speedup at all. It is important to note that the algorithms work
-    //! best when the number of edits is known to be small compared to the length of the
-    //! strings (for example, 10% difference). This should be applicable in many situations.
+    //! The performance of SIMD-accelerated Levenshtein distance depends on the
+    //! number of edits between two strings, so it can perform anywhere from
+    //! 2 times to nearly 1000 times faster than the scalar version. When
+    //! the two strings are completely different, there could be no speedup
+    //! at all. It is important to note that the algorithms work
+    //! best when the number of edits is known to be small compared to the
+    //! length of the strings (for example, 10% difference). This should be
+    //! applicable in many situations.
     //!
-    //! If AVX2 support is not available, there is a speed penalty for using SSE4.1 with
-    //! smaller vectors.
+    //! If AVX2 support is not available, there is a speed penalty for using
+    //! SSE4.1 with smaller vectors.
 
     use crate::utils::TextSlice;
 
-    /// SIMD-accelerated Hamming distance between two strings. Complexity: O(n / w), for
-    /// SIMD vectors of length w (usually w = 16 or w = 32).
+    /// SIMD-accelerated Hamming distance between two strings. Complexity: O(n /
+    /// w), for SIMD vectors of length w (usually w = 16 or w = 32).
     ///
     /// # Example
     ///
@@ -134,15 +136,16 @@ pub mod simd {
         triple_accel::hamming(alpha, beta) as u64
     }
 
-    /// SIMD-accelerated Levenshtein (or Edit) distance between two strings. Complexity:
-    /// O(k / w * (n + m)), with n and m being the length of the given texts, k being the
-    /// number of edits, and w being the length of the SIMD vectors (usually w = 16 or
-    /// w = 32).
+    /// SIMD-accelerated Levenshtein (or Edit) distance between two strings.
+    /// Complexity: O(k / w * (n + m)), with n and m being the length of the
+    /// given texts, k being the number of edits, and w being the length of
+    /// the SIMD vectors (usually w = 16 or w = 32).
     ///
-    /// Uses exponential search, which is approximately two times slower than the usual
-    /// O(n * m) implementation if the number of edits between the two strings is very large,
-    /// but much faster for cases where the edit distance is low (when less than half of the
-    /// characters in the strings differ).
+    /// Uses exponential search, which is approximately two times slower than
+    /// the usual O(n * m) implementation if the number of edits between the
+    /// two strings is very large, but much faster for cases where the edit
+    /// distance is low (when less than half of the characters in the
+    /// strings differ).
     ///
     /// # Example
     ///
@@ -161,14 +164,15 @@ pub mod simd {
         triple_accel::levenshtein_exp(alpha, beta)
     }
 
-    /// SIMD-accelerated bounded Levenshtein (or Edit) distance between two strings.
-    /// Complexity: O(k / w * (n + m)), with n and m being the length of the given texts,
-    /// k being the threshold on the number of edits, and w being the length of the SIMD vectors
-    /// (usually w = 16 or w = 32).
+    /// SIMD-accelerated bounded Levenshtein (or Edit) distance between two
+    /// strings. Complexity: O(k / w * (n + m)), with n and m being the
+    /// length of the given texts, k being the threshold on the number of
+    /// edits, and w being the length of the SIMD vectors (usually w = 16 or
+    /// w = 32).
     ///
-    /// If the Levenshtein distance between two strings is greater than the threshold k, then
-    /// `None` is returned. This is useful for efficiently calculating whether two strings
-    /// are similar.
+    /// If the Levenshtein distance between two strings is greater than the
+    /// threshold k, then `None` is returned. This is useful for efficiently
+    /// calculating whether two strings are similar.
     ///
     /// # Example
     ///

--- a/src/alignment/pairwise/banded.rs
+++ b/src/alignment/pairwise/banded.rs
@@ -11,8 +11,8 @@
 //! alignment if a) there is a reasonable density of exact k-mer matches
 //! between the sequences, and b) the width parameter w is larger than the
 //! excursion of the alignment path from diagonal between successive kmer
-//! matches.  This technique is employed in long-read aligners (e.g. BLASR and BWA)
-//! to drastically reduce runtime compared to Smith Waterman.
+//! matches.  This technique is employed in long-read aligners (e.g. BLASR and
+//! BWA) to drastically reduce runtime compared to Smith Waterman.
 //! Complexity roughly O(min(m,n) * w)
 //!
 //! # Example
@@ -95,18 +95,20 @@ const MAX_CELLS: usize = 5_000_000;
 const DEFAULT_MATCH_SCORE: i32 = 2;
 
 /// A banded implementation of Smith-Waterman aligner (SWA).
-/// Unlike the full SWA, this implementation computes the alignment between a pair of sequences
-/// only inside a 'band' withing the dynamic programming matrix. The band is constructed using the
-/// Sparse DP routine (see sparse::sdpkpp), which uses kmer matches to build the best common
-/// subsequence (including gap penalties) between the two strings. The band is constructed around
-/// this subsequence (using the window length 'w'), filling in the gaps.
+/// Unlike the full SWA, this implementation computes the alignment between a
+/// pair of sequences only inside a 'band' withing the dynamic programming
+/// matrix. The band is constructed using the Sparse DP routine (see
+/// sparse::sdpkpp), which uses kmer matches to build the best common
+/// subsequence (including gap penalties) between the two strings. The band is
+/// constructed around this subsequence (using the window length 'w'), filling
+/// in the gaps.
 ///
-/// In the case where there are no k-mer matches, the  aligner will fall back to a full alignment,
-/// by setting the band to contain the full matrix.
+/// In the case where there are no k-mer matches, the  aligner will fall back to
+/// a full alignment, by setting the band to contain the full matrix.
 ///
-/// Banded aligner will proceed to compute the alignment only when the total number of cells
-/// in the band is less than MAX_CELLS (currently set to 10 million), otherwise it returns an
-/// empty alignment
+/// Banded aligner will proceed to compute the alignment only when the total
+/// number of cells in the band is less than MAX_CELLS (currently set to 10
+/// million), otherwise it returns an empty alignment
 #[allow(non_snake_case)]
 pub struct Aligner<F: MatchFunc> {
     S: [Vec<i32>; 2],
@@ -184,8 +186,8 @@ impl<F: MatchFunc> Aligner<F> {
         }
     }
 
-    /// Create new aligner instance with scoring and size hint. The size hints help to
-    /// avoid unnecessary memory allocations.
+    /// Create new aligner instance with scoring and size hint. The size hints
+    /// help to avoid unnecessary memory allocations.
     ///
     /// # Arguments
     ///
@@ -235,8 +237,8 @@ impl<F: MatchFunc> Aligner<F> {
         }
     }
 
-    /// Create new aligner instance with scoring and size hint. The size hints help to
-    /// avoid unnecessary memory allocations.
+    /// Create new aligner instance with scoring and size hint. The size hints
+    /// help to avoid unnecessary memory allocations.
     ///
     /// # Arguments
     ///
@@ -273,8 +275,8 @@ impl<F: MatchFunc> Aligner<F> {
         self.compute_alignment(x, y)
     }
 
-    /// Compute the alignment with custom clip penalties with 'y' being pre-hashed
-    /// (see sparse::hash_kmers)
+    /// Compute the alignment with custom clip penalties with 'y' being
+    /// pre-hashed (see sparse::hash_kmers)
     ///
     /// # Arguments
     ///
@@ -1058,8 +1060,8 @@ impl Band {
         }
     }
 
-    // Add cells around a kmer of length 'k', starting at 'start', which are within a
-    // distance of 'w' in x or y directions to the band.
+    // Add cells around a kmer of length 'k', starting at 'start', which are within
+    // a distance of 'w' in x or y directions to the band.
     fn add_kmer(&mut self, start: (u32, u32), k: usize, w: usize) {
         let (r, c) = (start.0 as usize, start.1 as usize);
         // println!("{} {} {}", r, k, self.rows);
@@ -1098,8 +1100,8 @@ impl Band {
         }
     }
 
-    // Add cells around a specific position to the band. An cell which is within 'w' distance
-    // in x or y directions are added
+    // Add cells around a specific position to the band. An cell which is within 'w'
+    // distance in x or y directions are added
     fn add_entry(&mut self, pos: (u32, u32), w: usize) {
         let (r, c) = (pos.0 as usize, pos.1 as usize);
 
@@ -1128,13 +1130,14 @@ impl Band {
         }
     }
 
-    // The band needs to start either at (0,0) or at a point that is zero score from (0,0).
-    // This naturally sets the start positions correctly for global, semiglobal and local
-    // modes. Similarly the band has to either end at (m,n) or at a point from which there is
-    // a zero score path to (m,n).
+    // The band needs to start either at (0,0) or at a point that is zero score from
+    // (0,0). This naturally sets the start positions correctly for global,
+    // semiglobal and local modes. Similarly the band has to either end at (m,n)
+    // or at a point from which there is a zero score path to (m,n).
     //
-    // At the minimum, irrespective of the score (0,0)->start or end->(m,n), we extend the band
-    // diagonally for a length "lazy_extend"(2k) or when it hits the corner, whichever happens first
+    // At the minimum, irrespective of the score (0,0)->start or end->(m,n), we
+    // extend the band diagonally for a length "lazy_extend"(2k) or when it hits
+    // the corner, whichever happens first
     //
     // start - the index of the first matching kmer in LCSk++
     // end - the index of the last matching kmer in LCSk++
@@ -1744,9 +1747,11 @@ mod banded {
 
     // #[test]
     // fn test_failure() {
-    //     let x = b"AGAATTTTAGTGATCATATCGTTAACAGCTCCTGAGGGGACTTGGCCCAGCTGGAATAGCTACATGGCAGATTTTTCGTTCACGTTTTCTCTTCGCGATGTTCATCACTGCTTCTACCATATCGAGACCCGTTTATTGACTTCAGACAATGAGGAGCAATTAGGACGTTTATACGATGTTAGCGCGTTTAATAACTCACTGATATGCCACAGGCGCAGGCCTGACAAAGTTTATCCGGGGTCGGGAAAGCTGTGCCCTCATCCAAGTGCTCAGCTAACCAGCAACTGTCGGCTAATTCTTAGATATACCGGATTTATTAACACTGGCCTGACATCCTATACCGAGTAGGCCCCCAAAGTAATTGATGTTCCCGCAACTACTACTCCCGAGGCTAGGTCGAGTCCTACTCCAAGACATCCTGCGTAAAGACAAGGCGCTGACTTGACGTAGTAAAGACCTGGCGCGGGATACACACAGCATAGCGTGAAGCACAGACAAACTGAAGTGGCCGAAGAGAATCTAACAATGGTAC";
-    //     let y = b"GTTTCGATGCTCACTGAACAGTAGAGTTTACGCCCAACGGTTAGTACCTCGCTAAGGGAGTGGGTGTCCGGGCAGAATTTTAGTGATCATATCGTTAACAGCTCCTGAGGGGACTTGGCCCAGCTGGAATAGCTACATGGCAGATTTTTCGTTCACGTTTTCTCTTCCCGATGTTCATCACTGCTTCTACCATATCGCATCCAAGTGCTCAGCTAACCAGCAACTGTCGGCTAATTCTTAGATATACCGGATTTATTAACACTGGCCTGACATCCTATACCGAGTAGGCCCCCAAAGTAATTGATGTTCCCGCAACTACTACTCCCGAGGCTAGGTATTTGTACCTGTTGCCGCCACGTATCGGGGGCGCTACGGGCGGCACGGCCCGATGCCTTGCTTCCCAGGGTGTTTTTTAGGATTCGATTCAGTGGTCGGTCGGGCTTTAAGCGGTCCAGATCTTAGCTGTATCTCGAGTCCTACTCCAAGACGTCCTGCGTAAAGACAAGGCGCTGACTTGACGTAGTAAAGACCTGGCGCGGGATACACACAGCATAGCGTGAAGCACAGACAAACTGAAGTGGCCGAAGAGAATCTAACAATGGTACTGACAGG";
-    //     compare_to_full_alignment_semiglobal(x, y);
+    //     let x =
+    // b"AGAATTTTAGTGATCATATCGTTAACAGCTCCTGAGGGGACTTGGCCCAGCTGGAATAGCTACATGGCAGATTTTTCGTTCACGTTTTCTCTTCGCGATGTTCATCACTGCTTCTACCATATCGAGACCCGTTTATTGACTTCAGACAATGAGGAGCAATTAGGACGTTTATACGATGTTAGCGCGTTTAATAACTCACTGATATGCCACAGGCGCAGGCCTGACAAAGTTTATCCGGGGTCGGGAAAGCTGTGCCCTCATCCAAGTGCTCAGCTAACCAGCAACTGTCGGCTAATTCTTAGATATACCGGATTTATTAACACTGGCCTGACATCCTATACCGAGTAGGCCCCCAAAGTAATTGATGTTCCCGCAACTACTACTCCCGAGGCTAGGTCGAGTCCTACTCCAAGACATCCTGCGTAAAGACAAGGCGCTGACTTGACGTAGTAAAGACCTGGCGCGGGATACACACAGCATAGCGTGAAGCACAGACAAACTGAAGTGGCCGAAGAGAATCTAACAATGGTAC"
+    // ;     let y =
+    // b"GTTTCGATGCTCACTGAACAGTAGAGTTTACGCCCAACGGTTAGTACCTCGCTAAGGGAGTGGGTGTCCGGGCAGAATTTTAGTGATCATATCGTTAACAGCTCCTGAGGGGACTTGGCCCAGCTGGAATAGCTACATGGCAGATTTTTCGTTCACGTTTTCTCTTCCCGATGTTCATCACTGCTTCTACCATATCGCATCCAAGTGCTCAGCTAACCAGCAACTGTCGGCTAATTCTTAGATATACCGGATTTATTAACACTGGCCTGACATCCTATACCGAGTAGGCCCCCAAAGTAATTGATGTTCCCGCAACTACTACTCCCGAGGCTAGGTATTTGTACCTGTTGCCGCCACGTATCGGGGGCGCTACGGGCGGCACGGCCCGATGCCTTGCTTCCCAGGGTGTTTTTTAGGATTCGATTCAGTGGTCGGTCGGGCTTTAAGCGGTCCAGATCTTAGCTGTATCTCGAGTCCTACTCCAAGACGTCCTGCGTAAAGACAAGGCGCTGACTTGACGTAGTAAAGACCTGGCGCGGGATACACACAGCATAGCGTGAAGCACAGACAAACTGAAGTGGCCGAAGAGAATCTAACAATGGTACTGACAGG"
+    // ;     compare_to_full_alignment_semiglobal(x, y);
     // }
 
     use crate::alignment::AlignmentOperation::*;

--- a/src/alignment/pairwise/mod.rs
+++ b/src/alignment/pairwise/mod.rs
@@ -3,10 +3,11 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Calculate alignments with a generalized variant of the Smith Waterman algorithm.
-//! Complexity: O(n * m) for strings of length m and n.
+//! Calculate alignments with a generalized variant of the Smith Waterman
+//! algorithm. Complexity: O(n * m) for strings of length m and n.
 //!
-//! For quick computation of alignments and alignment scores there are 6 simple functions.
+//! For quick computation of alignments and alignment scores there are 6 simple
+//! functions.
 //!
 //! # Example
 //!
@@ -187,8 +188,8 @@ impl MatchFunc for MatchParams {
     }
 }
 
-/// The trait Matchfunc is also implemented for Fn(u8, u8) -> i32 so that Scoring
-/// can be instantiated using closures and custom user defined functions
+/// The trait Matchfunc is also implemented for Fn(u8, u8) -> i32 so that
+/// Scoring can be instantiated using closures and custom user defined functions
 impl<F> MatchFunc for F
 where
     F: Fn(u8, u8) -> i32,
@@ -217,7 +218,8 @@ pub struct Scoring<F: MatchFunc> {
 
 impl Scoring<MatchParams> {
     /// Create new Scoring instance with given gap open, gap extend penalties
-    /// match and mismatch scores. The clip penalties are set to `MIN_SCORE` by default
+    /// match and mismatch scores. The clip penalties are set to `MIN_SCORE` by
+    /// default
     ///
     /// # Arguments
     ///
@@ -249,14 +251,15 @@ impl Scoring<MatchParams> {
 
 impl<F: MatchFunc> Scoring<F> {
     /// Create new Scoring instance with given gap open, gap extend penalties
-    /// and the score function. The clip penalties are set to [`MIN_SCORE`](constant.MIN_SCORE.html) by default
+    /// and the score function. The clip penalties are set to
+    /// [`MIN_SCORE`](constant.MIN_SCORE.html) by default
     ///
     /// # Arguments
     ///
     /// * `gap_open` - the score for opening a gap (should not be positive)
     /// * `gap_extend` - the score for extending a gap (should not be positive)
-    /// * `match_fn` - function that returns the score for substitutions
-    ///    (see also [`bio::alignment::pairwise::Scoring`](struct.Scoring.html))
+    /// * `match_fn` - function that returns the score for substitutions (see also
+    ///   [`bio::alignment::pairwise::Scoring`](struct.Scoring.html))
     pub fn new(gap_open: i32, gap_extend: i32, match_fn: F) -> Self {
         assert!(gap_open <= 0, "gap_open can't be positive");
         assert!(gap_extend <= 0, "gap_extend can't be positive");
@@ -399,12 +402,16 @@ impl<F: MatchFunc> Scoring<F> {
 
 /// A generalized Smith-Waterman aligner.
 ///
-/// `M(i,j)` is the best score such that `x[i]` and `y[j]` ends in a match (or substitution)
+/// `M(i,j)` is the best score such that `x[i]` and `y[j]` ends in a match (or
+/// substitution)
+///
 /// ```ignore
 ///              .... A   G  x_i
 ///              .... C   G  y_j
 /// ```
+///
 /// `I(i,j)` is the best score such that `x[i]` is aligned with a gap
+///
 /// ```ignore
 ///              .... A   G  x_i
 ///              .... G  y_j  -
@@ -412,10 +419,12 @@ impl<F: MatchFunc> Scoring<F> {
 /// This is interpreted as an insertion into `x` w.r.t reference `y`
 ///
 /// `D(i,j)` is the best score such that `y[j]` is aligned with a gap
+///
 /// ```ignore
 ///              .... A  x_i  -
 ///              .... G   G  y_j
 /// ```
+///
 /// This is interpreted as a deletion from `x` w.r.t reference `y`
 ///
 /// `S(i,j)` is the best score for prefixes `x[0..i]`, `y[0..j]`
@@ -433,7 +442,8 @@ impl<F: MatchFunc> Scoring<F> {
 /// `Sn` is the last column of the matrix. This is needed to keep track of
 /// suffix clipping scores
 ///
-/// `traceback` - see [`bio::alignment::pairwise::TracebackCell`](struct.TracebackCell.html)
+/// `traceback` - see
+/// [`bio::alignment::pairwise::TracebackCell`](struct.TracebackCell.html)
 ///
 /// `scoring` - see [`bio::alignment::pairwise::Scoring`](struct.Scoring.html)
 #[allow(non_snake_case)]
@@ -458,8 +468,8 @@ impl<F: MatchFunc> Aligner<F> {
     ///
     /// * `gap_open` - the score for opening a gap (should be negative)
     /// * `gap_extend` - the score for extending a gap (should be negative)
-    /// * `match_fn` - function that returns the score for substitutions
-    ///    (see also [`bio::alignment::pairwise::Scoring`](struct.Scoring.html))
+    /// * `match_fn` - function that returns the score for substitutions (see also
+    ///   [`bio::alignment::pairwise::Scoring`](struct.Scoring.html))
     pub fn new(gap_open: i32, gap_extend: i32, match_fn: F) -> Self {
         Aligner::with_capacity(
             DEFAULT_ALIGNER_CAPACITY,
@@ -479,8 +489,8 @@ impl<F: MatchFunc> Aligner<F> {
     /// * `n` - the expected size of y
     /// * `gap_open` - the score for opening a gap (should be negative)
     /// * `gap_extend` - the score for extending a gap (should be negative)
-    /// * `match_fn` - function that returns the score for substitutions
-    ///    (see also [`bio::alignment::pairwise::Scoring`](struct.Scoring.html))
+    /// * `match_fn` - function that returns the score for substitutions (see also
+    ///   [`bio::alignment::pairwise::Scoring`](struct.Scoring.html))
     pub fn with_capacity(m: usize, n: usize, gap_open: i32, gap_extend: i32, match_fn: F) -> Self {
         assert!(gap_open <= 0, "gap_open can't be positive");
         assert!(gap_extend <= 0, "gap_extend can't be positive");
@@ -510,8 +520,8 @@ impl<F: MatchFunc> Aligner<F> {
         )
     }
 
-    /// Create new aligner instance with scoring and size hint. The size hints help to
-    /// avoid unnecessary memory allocations.
+    /// Create new aligner instance with scoring and size hint. The size hints
+    /// help to avoid unnecessary memory allocations.
     ///
     /// # Arguments
     ///
@@ -988,8 +998,8 @@ impl<F: MatchFunc> Aligner<F> {
 /// Packed representation of one cell of a Smith-Waterman traceback matrix.
 /// Stores the I, D and S traceback matrix values in two bytes.
 /// Possible traceback moves include : start, insert, delete, match, substitute,
-/// prefix clip and suffix clip for x & y. So we need 4 bits each for matrices I, D, S
-/// to keep track of these 9 moves.
+/// prefix clip and suffix clip for x & y. So we need 4 bits each for matrices
+/// I, D, S to keep track of these 9 moves.
 #[derive(Copy, Clone)]
 pub struct TracebackCell {
     v: u16,

--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -3,7 +3,8 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Partial-Order Alignment for fast alignment and consensus of multiple homologous sequences.
+//! Partial-Order Alignment for fast alignment and consensus of multiple
+//! homologous sequences.
 //!
 //! For the original concept and theory, see:
 //! * Lee, Christopher, Catherine Grasso, and Mark F. Sharlow. "Multiple sequence alignment using
@@ -32,7 +33,6 @@
 //! // z differs from x and y's partial order alignment by 1 base
 //! assert_eq!(aligner.global(z).alignment().score, 5);
 //! ```
-//!
 
 use std::cmp::{max, Ordering};
 
@@ -231,7 +231,8 @@ impl Traceback {
 
 /// A partially ordered aligner builder
 ///
-/// Uses consuming builder pattern for constructing partial order alignments with method chaining
+/// Uses consuming builder pattern for constructing partial order alignments
+/// with method chaining
 pub struct Aligner<F: MatchFunc> {
     traceback: Traceback,
     query: Vec<u8>,
@@ -283,7 +284,8 @@ pub struct Poa<F: MatchFunc> {
 }
 
 impl<F: MatchFunc> Poa<F> {
-    /// Create a new aligner instance from the directed acyclic graph of another.
+    /// Create a new aligner instance from the directed acyclic graph of
+    /// another.
     ///
     /// # Arguments
     ///
@@ -293,7 +295,8 @@ impl<F: MatchFunc> Poa<F> {
         Poa { scoring, graph }
     }
 
-    /// Create a new POA graph from an initial reference sequence and alignment penalties.
+    /// Create a new POA graph from an initial reference sequence and alignment
+    /// penalties.
     ///
     /// # Arguments
     ///

--- a/src/alignment/sparse.rs
+++ b/src/alignment/sparse.rs
@@ -8,10 +8,10 @@
 //! Complexity: O(n * log(n)) for a pair of strings with n k-kmer matches. This
 //! approach is useful for generating an approximate 'backbone' alignments
 //! between two long sequences, for example in long-read alignment or
-//! genome-genome alignment. The backbone alignment can be used as-is, or can serve
-//! as a guide for a banded alignment.  By tuning k so that len(query) + len(reference) < 4^k,
-//! the number of false positive kmer matches is kept small, resulting in very
-//! fast run times for long strings.
+//! genome-genome alignment. The backbone alignment can be used as-is, or can
+//! serve as a guide for a banded alignment.  By tuning k so that len(query) +
+//! len(reference) < 4^k, the number of false positive kmer matches is kept
+//! small, resulting in very fast run times for long strings.
 //!
 //! # Example
 //!
@@ -38,7 +38,8 @@ pub type HashMapFx<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
 /// Result of a sparse alignment
 #[derive(Debug, PartialEq, Eq)]
 pub struct SparseAlignmentResult {
-    /// LCSk++ path, represented as vector of indices into the input matches vector.
+    /// LCSk++ path, represented as vector of indices into the input matches
+    /// vector.
     pub path: Vec<usize>,
     // Score of the path, which is the number of bases covered by the matched kmers.
     pub score: u32,
@@ -46,9 +47,9 @@ pub struct SparseAlignmentResult {
     pub dp_vector: Vec<(u32, i32)>,
 }
 
-/// Sparse DP routine for Longest Common Subsequence in length k substrings.  Also known of LCSk++
-/// From LCSk++: Practical similarity metric for long strings. Filip Pavetić, Goran Žužić, Mile Šikić
-/// Paper here :https://arxiv.org/abs/1407.2407.  Original implementation here:
+/// Sparse DP routine for Longest Common Subsequence in length k substrings.
+/// Also known of LCSk++ From LCSk++: Practical similarity metric for long
+/// strings. Filip Pavetić, Goran Žužić, Mile Šikić Paper here :https://arxiv.org/abs/1407.2407.  Original implementation here:
 /// https://github.com/fpavetic/lcskpp
 ///
 /// # Arguments
@@ -59,7 +60,8 @@ pub struct SparseAlignmentResult {
 ///
 /// # Return value
 ///
-/// The method returns a `SparseAlignmentResult` struct with the following fields:
+/// The method returns a `SparseAlignmentResult` struct with the following
+/// fields:
 /// * `path` is the LCSk++ path, represented as vector of indices into the input matches vector.
 /// * `score` is the score of the path, which is the number of bases covered by the matched kmers.
 /// * `dp_vector` is the full DP vector, which can generally be ignored. (It may be useful for
@@ -75,7 +77,8 @@ pub fn lcskpp(matches: &[(u32, u32)], k: usize) -> SparseAlignmentResult {
 
     let k = k as u32;
 
-    // incoming matches must be sorted to let us find the predecessor kmers by binary search.
+    // incoming matches must be sorted to let us find the predecessor kmers by
+    // binary search.
     for i in 1..matches.len() {
         assert!(matches[i - 1] < matches[i]);
     }
@@ -163,10 +166,10 @@ impl PrevPtr {
     }
 }
 
-/// Sparse DP routine generalizing LCSk++ method above to penalize alignment gaps.
-/// A gap is an unknown combination of mismatch, insertion and deletions, and incurs
-/// a penalty of gap_open + d * gap_extend, where d is the distance along the diagonal of the gap.
-/// # Arguments
+/// Sparse DP routine generalizing LCSk++ method above to penalize alignment
+/// gaps. A gap is an unknown combination of mismatch, insertion and deletions,
+/// and incurs a penalty of gap_open + d * gap_extend, where d is the distance
+/// along the diagonal of the gap. # Arguments
 ///
 /// * `matches` - a vector of tuples indicating the (string1 position, string2 position) kmer
 ///   matches between the strings
@@ -177,7 +180,8 @@ impl PrevPtr {
 ///
 /// # Return value
 ///
-/// The method returns a `SparseAlignmentResult` struct with the following fields:
+/// The method returns a `SparseAlignmentResult` struct with the following
+/// fields:
 /// * `path` is the SDP path, represented as vector of indices into the input matches vector.
 /// * `score` is the score of the path, which is the number of bases covered by the matched kmers.
 /// * `dp_vector` is the full DP vector, which can generally be ignored. (It may be useful for
@@ -204,7 +208,8 @@ pub fn sdpkpp(
     let _gap_open = (-gap_open) as u32;
     let _gap_extend = (-gap_extend) as u32;
 
-    // incoming matches must be sorted to let us find the predecessor kmers by binary search.
+    // incoming matches must be sorted to let us find the predecessor kmers by
+    // binary search.
     for i in 1..matches.len() {
         assert!(matches[i - 1] < matches[i]);
     }
@@ -328,7 +333,8 @@ pub fn sdpkpp_union_lcskpp_path(
 /// index. For very long reference strings, it may be more efficient to use and
 /// FMD index to generate the matches. Note that this method is mainly for
 /// demonstration & testing purposes.  For aligning many query sequences
-/// against the same reference, you should reuse the QGramIndex of the reference.
+/// against the same reference, you should reuse the QGramIndex of the
+/// reference.
 pub fn find_kmer_matches(seq1: &[u8], seq2: &[u8], k: usize) -> Vec<(u32, u32)> {
     if seq1.len() < seq2.len() {
         let set = hash_kmers(seq1, k);
@@ -339,9 +345,9 @@ pub fn find_kmer_matches(seq1: &[u8], seq2: &[u8], k: usize) -> Vec<(u32, u32)> 
     }
 }
 
-/// Creates a HashMap containing all the k-mers in the sequence. FxHasher is used
-/// as the hash function instead of the inbuilt one. A good rolling hash function
-/// should speed up the code.
+/// Creates a HashMap containing all the k-mers in the sequence. FxHasher is
+/// used as the hash function instead of the inbuilt one. A good rolling hash
+/// function should speed up the code.
 pub fn hash_kmers(seq: &[u8], k: usize) -> HashMapFx<&[u8], Vec<u32>> {
     let slc = seq;
     let mut set: HashMapFx<&[u8], Vec<u32>> = HashMapFx::default();
@@ -442,8 +448,8 @@ pub fn expand_kmer_matches(
             left_expanded_matches.push((curr_pos.0 as u32, curr_pos.1 as u32));
             curr_pos = (curr_pos.0 - 1, curr_pos.1 - 1);
         }
-        // We need to check until 1 position after this match, when we start our search from
-        // the next kmer match along this diagonal
+        // We need to check until 1 position after this match, when we start our search
+        // from the next kmer match along this diagonal
         last_match_along_diagonal.insert(diag, (this_match.0 as i32, this_match.1 as i32));
     }
 
@@ -469,7 +475,8 @@ pub fn expand_kmer_matches(
         let mut curr_pos = (this_match.0 + 1, this_match.1 + 1);
         loop {
             // println!(" This : ({},{}), Current : ({},{}), Next : ({}, {}), Miss : {}",
-            // this_match.0, this_match.1, curr_pos.0, curr_pos.1, next_match.0, next_match.1, n_mismatches);
+            // this_match.0, this_match.1, curr_pos.0, curr_pos.1, next_match.0,
+            // next_match.1, n_mismatches);
             if curr_pos >= next_match {
                 break;
             }
@@ -551,7 +558,8 @@ mod sparse_alignment {
 
         // For debugging:
         //for (idx, (ev, (score, prev))) in evs.iter().zip(dps.clone()).enumerate() {
-        //    println!("idx: {:?}\tev: {:?}\tscore: {:?}\t prev: {:?}", idx, ev, score, prev);
+        //    println!("idx: {:?}\tev: {:?}\tscore: {:?}\t prev: {:?}", idx, ev, score,
+        // prev);
         //}
         //println!("tb: {:?}", tb);
 
@@ -568,8 +576,8 @@ mod sparse_alignment {
 
     #[test]
     pub fn test_lcskpp2() {
-        // Match the same string -- should get a diagonal traceback, despite lots of off-diagonal
-        // homology
+        // Match the same string -- should get a diagonal traceback, despite lots of
+        // off-diagonal homology
         let s1 = b"ACGTACGATAGATCCGACGTACGTACGTTCAGTTATATGACGTACGTACGTAACATTTTTGTA";
         let k = 5;
 
@@ -578,7 +586,8 @@ mod sparse_alignment {
 
         // For debugging:
         //for (idx, (ev, (score, prev))) in evs.iter().zip(dps.clone()).enumerate() {
-        //    println!("idx: {:?}\tev: {:?}\tscore: {:?}\t prev: {:?}", idx, ev, score, prev);
+        //    println!("idx: {:?}\tev: {:?}\tscore: {:?}\t prev: {:?}", idx, ev, score,
+        // prev);
         //}
         //println!("tb: {:?}", tb);
 
@@ -624,14 +633,15 @@ CGGGAGGAGACCTGGGCAGCGGCGGACTCATTGCAGGTCGCTCTGCGGTGAGGACGCCACAGGCAC";
 
         // For debugging:
         //for (idx, (ev, (score, prev))) in evs.iter().zip(dps.clone()).enumerate() {
-        //    println!("idx: {:?}\tev: {:?}\tscore: {:?}\t prev: {:?}", idx, ev, score, prev);
+        //    println!("idx: {:?}\tev: {:?}\tscore: {:?}\t prev: {:?}", idx, ev, score,
+        // prev);
         //}
         //println!("tb: {:?}", tb);
 
         assert_eq!(res.score, QUERY_REPEAT.len() as u32);
 
-        // NOTE -- this test will fail, because LCSk++ introduces a gap in the placement of the TR
-        // Corrected with gap scoring in SDP
+        // NOTE -- this test will fail, because LCSk++ introduces a gap in the
+        // placement of the TR Corrected with gap scoring in SDP
         /*
         for i in 0..res.path.len() {
             assert_eq!(matches[res.path[i] as usize], (i as u32, i as u32));

--- a/src/alphabets/dna.rs
+++ b/src/alphabets/dna.rs
@@ -48,7 +48,8 @@ lazy_static! {
     };
 }
 
-/// Return complement of given DNA alphabet character (IUPAC alphabet supported).
+/// Return complement of given DNA alphabet character (IUPAC alphabet
+/// supported).
 ///
 /// Casing of input character is preserved, e.g. `t` → `a`, but `T` → `A`.
 /// All `N`s remain as they are.

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -153,12 +153,14 @@ impl Alphabet {
     }
 }
 
-/// Tools based on transforming the alphabet symbols to their lexicographical ranks.
+/// Tools based on transforming the alphabet symbols to their lexicographical
+/// ranks.
 ///
 /// Lexicographical rank is computed using `u8` representations,
 /// i.e. ASCII codes, of the input characters.
-/// For example, assuming that the alphabet consists of the symbols `A`, `C`, `G`, and `T`, this
-/// will yield ranks `0`, `1`, `2`, `3` for them, respectively.
+/// For example, assuming that the alphabet consists of the symbols `A`, `C`,
+/// `G`, and `T`, this will yield ranks `0`, `1`, `2`, `3` for them,
+/// respectively.
 ///
 /// `RankTransform` can be used in to perform bit encoding for texts over a
 /// given alphabet via `bio::data_structures::bitenc`.
@@ -238,10 +240,12 @@ impl RankTransform {
             .collect()
     }
 
-    /// Iterate over q-grams (substrings of length q) of given `text`. The q-grams are encoded
-    /// as `usize` by storing the symbol ranks in log2(|A|) bits (with |A| being the alphabet size).
+    /// Iterate over q-grams (substrings of length q) of given `text`. The
+    /// q-grams are encoded as `usize` by storing the symbol ranks in
+    /// log2(|A|) bits (with |A| being the alphabet size).
     ///
-    /// If q is larger than usize::BITS / log2(|A|), this method fails with an assertion.
+    /// If q is larger than usize::BITS / log2(|A|), this method fails with an
+    /// assertion.
     ///
     /// Complexity: O(n), where n is the length of the text.
     ///

--- a/src/alphabets/rna.rs
+++ b/src/alphabets/rna.rs
@@ -48,7 +48,8 @@ lazy_static! {
     };
 }
 
-/// Return complement of given RNA alphabet character (IUPAC alphabet supported).
+/// Return complement of given RNA alphabet character (IUPAC alphabet
+/// supported).
 ///
 /// Casing of input character is preserved, e.g. `u` → `a`, but `U` → `A`.
 /// All `N`s and `Z`s remain as they are.

--- a/src/data_structures/annot_map.rs
+++ b/src/data_structures/annot_map.rs
@@ -81,8 +81,8 @@ where
     /// # Arguments
     ///
     /// * `data` - any type of data to be inserted at the location / region
-    /// * `location` - any object with the `Loc` trait implemented, determining
-    ///   the Range at which to insert the `data`
+    /// * `location` - any object with the `Loc` trait implemented, determining the Range at which
+    ///   to insert the `data`
     ///
     /// # Example
     ///
@@ -203,7 +203,8 @@ where
         self.itree_entry.interval()
     }
 
-    /// Return a reference to the identifier of the annotated reference sequence.
+    /// Return a reference to the identifier of the annotated reference
+    /// sequence.
     pub fn refid(&self) -> &'a R {
         self.refid
     }

--- a/src/data_structures/bit_tree.rs
+++ b/src/data_structures/bit_tree.rs
@@ -4,8 +4,9 @@
 // except according to those terms.
 
 //! BIT-tree (Binary Indexed Trees, aka Fenwick Tree) maintains a prefix-sum or
-//! prefix-max that can be efficiently queried and updated. From: Peter M. Fenwick (1994). "A new data structure for cumulative frequency tables". Software: Practice and Experience. 24 (3): 327–336.
-//! Implementation outlined here: https://www.topcoder.com/community/data-science/data-science-tutorials/binary-indexed-trees/
+//! prefix-max that can be efficiently queried and updated. From: Peter M.
+//! Fenwick (1994). "A new data structure for cumulative frequency tables".
+//! Software: Practice and Experience. 24 (3): 327–336. Implementation outlined here: https://www.topcoder.com/community/data-science/data-science-tutorials/binary-indexed-trees/
 //!
 //! Time Complexity: O(log n) where `n = tree.len()`.
 //! Memory Complexity: O(n) where `n = tree.len()`.
@@ -35,12 +36,12 @@ pub trait PrefixOp<T> {
     fn operation(t1: T, t2: T) -> T;
 }
 
-/// In a max bit tree or Fenwick Tree, get(i) will return the largest element e that has been added
-/// to the bit tree with set(j, e), where j <= i. Initially all positions have
-/// the value T::default(). Note that a set cannot be 'undone' by inserting
-/// a smaller element at the same index.
-/// Time Complexity: O(n) to build a new tree or O(log n) for get() and set() operations,
-/// where `n = tree.len()`.
+/// In a max bit tree or Fenwick Tree, get(i) will return the largest element e
+/// that has been added to the bit tree with set(j, e), where j <= i. Initially
+/// all positions have the value T::default(). Note that a set cannot be
+/// 'undone' by inserting a smaller element at the same index.
+/// Time Complexity: O(n) to build a new tree or O(log n) for get() and set()
+/// operations, where `n = tree.len()`.
 pub struct FenwickTree<T: Default + Ord, Op: PrefixOp<T>> {
     tree: Vec<T>,
     phantom: PhantomData<Op>,

--- a/src/data_structures/bitenc.rs
+++ b/src/data_structures/bitenc.rs
@@ -3,8 +3,9 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! A fixed-width bit encoding implementation. This allows to store a sequence of values over
-//! a reduced alphabet by packing them bit-encoded into a sequence of bytes.
+//! A fixed-width bit encoding implementation. This allows to store a sequence
+//! of values over a reduced alphabet by packing them bit-encoded into a
+//! sequence of bytes.
 //!
 //! Similar behaviour can be achieved using a `PackedVec` from the [packedvec](https://docs.rs/packedvec) crate.
 //!
@@ -40,9 +41,9 @@
 
 /// A sequence of bitencoded values.
 ///
-/// Space complexity: O(⌈(n * width) / k⌉) * 32 bit, where n is the length of the input
-/// sequence and `k = 32 - (32 % width)`  is the number of bits in each
-/// 32-bit block that can be used to store values.
+/// Space complexity: O(⌈(n * width) / k⌉) * 32 bit, where n is the length of
+/// the input sequence and `k = 32 - (32 % width)`  is the number of bits in
+/// each 32-bit block that can be used to store values.
 /// For values that are not a divider of 32, some bits will remain unused.
 /// For example for `width = 7` only `4 * 7 = 28` bits are used.
 /// Five 7-bit values are stored in 2 blocks.
@@ -61,8 +62,9 @@ fn mask(width: usize) -> u32 {
 }
 
 impl BitEnc {
-    /// Create a new instance with a given encoding width (e.g. width=2 for using two bits per value).
-    /// Supports widths up to 8 bits per character, i.e. `1 <= width <= 8`.
+    /// Create a new instance with a given encoding width (e.g. width=2 for
+    /// using two bits per value). Supports widths up to 8 bits per
+    /// character, i.e. `1 <= width <= 8`.
     ///
     /// Complexity: O(1)
     ///
@@ -385,7 +387,7 @@ impl BitEnc {
     /// // Add another 2 to create a second block
     /// bitenc.push(2);
     /// assert_eq!(bitenc.nr_blocks(), 2);
-    /// ```    
+    /// ```
     pub fn nr_blocks(&self) -> usize {
         self.storage.len()
     }
@@ -408,7 +410,7 @@ impl BitEnc {
     /// assert_eq!(bitenc.nr_symbols(), 4);
     /// bitenc.push(2);
     /// assert_eq!(bitenc.nr_symbols(), 5);
-    /// ```    
+    /// ```
     pub fn nr_symbols(&self) -> usize {
         self.len
     }
@@ -434,8 +436,8 @@ impl BitEnc {
     }
 }
 
-/// Iterator over values of a bitencoded sequence (values will be unpacked into bytes).
-/// Used to implement the `iter` method of `BitEnc`.
+/// Iterator over values of a bitencoded sequence (values will be unpacked into
+/// bytes). Used to implement the `iter` method of `BitEnc`.
 pub struct BitEncIter<'a> {
     bitenc: &'a BitEnc,
     i: usize,

--- a/src/data_structures/bwt.rs
+++ b/src/data_structures/bwt.rs
@@ -5,7 +5,8 @@
 
 //! The [Burrows-Wheeler-Transform](https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.37.6774) and related data structures.
 //! The implementation is based on the lecture notes
-//! "Algorithmen auf Sequenzen", Kopczynski, Marschall, Martin and Rahmann, 2008 - 2015.
+//! "Algorithmen auf Sequenzen", Kopczynski, Marschall, Martin and Rahmann, 2008
+//! - 2015.
 
 use std::iter::repeat;
 
@@ -114,7 +115,8 @@ impl Occ {
     pub fn get(&self, bwt: &BWTSlice, r: usize, a: u8) -> usize {
         // NOTE:
         //
-        // Retrieving byte match counts in this function is critical to the performance of FM Index.
+        // Retrieving byte match counts in this function is critical to the performance
+        // of FM Index.
         //
         // The below manual count code is roughly equivalent to:
         // ```
@@ -126,11 +128,11 @@ impl Occ {
         // ```
         //
         // But there are a couple of reasons to do this manually:
-        // 1) As of 2016, versions of rustc/LLVM vectorize this manual loop more reliably
-        //    than the iterator adapter version.
+        // 1) As of 2016, versions of rustc/LLVM vectorize this manual loop more
+        // reliably    than the iterator adapter version.
         // 2) Manually accumulating the byte match count in a single chunk can allows
-        //    us to use a `u32` for that count, which has faster arithmetic on common arches.
-        //    This does necessitate storing `k` as a u32.
+        //    us to use a `u32` for that count, which has faster arithmetic on common
+        // arches.    This does necessitate storing `k` as a u32.
         //
         // See the conversation in these issues for some of the history here:
         //

--- a/src/data_structures/fmindex.rs
+++ b/src/data_structures/fmindex.rs
@@ -4,7 +4,8 @@
 // except according to those terms.
 
 //! The [Full-text index in Minute space index (FM-index)](https://doi.org/10.1109/SFCS.2000.892127) and
-//! the FMD-Index for finding suffix array intervals matching a given pattern in linear time.
+//! the FMD-Index for finding suffix array intervals matching a given pattern in
+//! linear time.
 //!
 //! # Examples
 //!
@@ -27,8 +28,9 @@
 //!
 //! ## Enclose in struct
 //!
-//! `FMIndex` was designed to not forcibly own the BWT and auxiliary data structures.
-//! It can take a reference (`&`), owned structs or any of the more complex pointer types.
+//! `FMIndex` was designed to not forcibly own the BWT and auxiliary data
+//! structures. It can take a reference (`&`), owned structs or any of the more
+//! complex pointer types.
 //!
 //! ```
 //! use bio::alphabets::dna;
@@ -85,8 +87,8 @@ pub trait FMIndexable {
     fn bwt(&self) -> &BWT;
 
     /// Perform backward search, yielding suffix array
-    /// interval denoting exact occurrences of the given pattern of length m in the text.
-    /// Complexity: O(m).
+    /// interval denoting exact occurrences of the given pattern of length m in
+    /// the text. Complexity: O(m).
     ///
     /// # Arguments
     ///
@@ -139,8 +141,8 @@ pub trait FMIndexable {
     }
 }
 
-/// The Fast Index in Minute space (FM-Index, Ferragina and Manzini, 2000) for finding suffix array
-/// intervals matching a given pattern.
+/// The Fast Index in Minute space (FM-Index, Ferragina and Manzini, 2000) for
+/// finding suffix array intervals matching a given pattern.
 #[derive(Serialize, Deserialize)]
 pub struct FMIndex<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> {
     bwt: DBWT,
@@ -176,7 +178,8 @@ impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> FMIndex<DBWT, DL
     }
 }
 
-/// A bi-interval on suffix array of the forward and reverse strand of a DNA text.
+/// A bi-interval on suffix array of the forward and reverse strand of a DNA
+/// text.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct BiInterval {
     lower: usize,
@@ -209,8 +212,8 @@ impl BiInterval {
     }
 }
 
-/// The FMD-Index for linear time search of supermaximal exact matches on forward and reverse
-/// strand of DNA texts (Li, 2012).
+/// The FMD-Index for linear time search of supermaximal exact matches on
+/// forward and reverse strand of DNA texts (Li, 2012).
 #[derive(Serialize, Deserialize)]
 pub struct FMDIndex<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> {
     fmindex: FMIndex<DBWT, DLess, DOcc>,
@@ -236,12 +239,13 @@ impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> FMIndexable
 impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> From<FMIndex<DBWT, DLess, DOcc>>
     for FMDIndex<DBWT, DLess, DOcc>
 {
-    /// Construct a new instance of the FMD index (see Heng Li (2012) Bioinformatics).
-    /// This expects a BWT that was created from a text over the DNA alphabet with N
-    /// (`alphabets::dna::n_alphabet()`) consisting of the
-    /// concatenation with its reverse complement, separated by the sentinel symbol `$`.
-    /// I.e., let T be the original text and R be its reverse complement.
-    /// Then, the expected text is T$R$. Further, multiple concatenated texts are allowed, e.g.
+    /// Construct a new instance of the FMD index (see Heng Li (2012)
+    /// Bioinformatics). This expects a BWT that was created from a text
+    /// over the DNA alphabet with N (`alphabets::dna::n_alphabet()`)
+    /// consisting of the concatenation with its reverse complement,
+    /// separated by the sentinel symbol `$`. I.e., let T be the original
+    /// text and R be its reverse complement. Then, the expected text is
+    /// T$R$. Further, multiple concatenated texts are allowed, e.g.
     /// T1$R1$T2$R2$T3$R3$.
     fn from(fmindex: FMIndex<DBWT, DLess, DOcc>) -> FMDIndex<DBWT, DLess, DOcc> {
         let mut alphabet = dna::n_alphabet();
@@ -256,8 +260,8 @@ impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> From<FMIndex<DBW
 }
 
 impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> FMDIndex<DBWT, DLess, DOcc> {
-    /// Find supermaximal exact matches of given pattern that overlap position i in the pattern.
-    /// Complexity O(m) with pattern of length m.
+    /// Find supermaximal exact matches of given pattern that overlap position i
+    /// in the pattern. Complexity O(m) with pattern of length m.
     ///
     /// # Example
     ///
@@ -301,7 +305,8 @@ impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> FMDIndex<DBWT, D
             if interval.size != forward_interval.size {
                 curr.push(interval);
             }
-            // if new interval size is zero, stop, as no further forward extension is possible
+            // if new interval size is zero, stop, as no further forward extension is
+            // possible
             if forward_interval.size == 0 {
                 break;
             }
@@ -362,7 +367,8 @@ impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> FMDIndex<DBWT, D
         }
     }
 
-    /// Initialize interval for empty pattern. The interval points at the whole suffix array.
+    /// Initialize interval for empty pattern. The interval points at the whole
+    /// suffix array.
     pub fn init_interval(&self) -> BiInterval {
         BiInterval {
             lower: 0,
@@ -377,8 +383,8 @@ impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> FMDIndex<DBWT, D
         let mut s = 0;
         let mut o = 0;
         let mut l = interval.lower_rev;
-        // Interval [l(c(aP)), u(c(aP))] is a subinterval of [l(c(P)), u(c(P))] for each a,
-        // starting with the lexicographically smallest ($),
+        // Interval [l(c(aP)), u(c(aP))] is a subinterval of [l(c(P)), u(c(P))] for each
+        // a, starting with the lexicographically smallest ($),
         // then c(T) = A, c(G) = C, c(C) = G, N, c(A) = T, ...
         // Hence, we calculate lower revcomp bounds by iterating over
         // symbols and updating from previous one.

--- a/src/data_structures/interpolation_table.rs
+++ b/src/data_structures/interpolation_table.rs
@@ -33,9 +33,9 @@ pub fn interpolate(a: f64, b: f64, fraction: f64) -> f64 {
 
 /// Fast lookup table for arbitrary floating point functions.
 /// This can be used to e.g., provide fast lookups of distribution values.
-/// Input values are sampled with a given precision and results are stored in a vector.
-/// During lookup, infimum and supremum of a given value are calculated and the result is
-/// interpolated.
+/// Input values are sampled with a given precision and results are stored in a
+/// vector. During lookup, infimum and supremum of a given value are calculated
+/// and the result is interpolated.
 pub struct InterpolationTable<F: Fn(f64) -> f64> {
     inner: Vec<f64>,
     func: F,
@@ -55,10 +55,11 @@ impl<F: Fn(f64) -> f64> InterpolationTable<F> {
     /// * `frac_digits` - number of fraction digits to store in sample
     /// * `func` - Function to emulate.
     ///
-    /// If given value is outside of min_x and max_x, the lookup falls back to applying the
-    /// function itself.
+    /// If given value is outside of min_x and max_x, the lookup falls back to
+    /// applying the function itself.
     /// The table size grows with the number of fraction digits.
-    /// Space Complexity: O(m * 10^n), where `m = max_x - min_x` and `n = frac_digits`
+    /// Space Complexity: O(m * 10^n), where `m = max_x - min_x` and `n =
+    /// frac_digits`
     pub fn new(min_x: f64, max_x: f64, frac_digits: i32, func: F) -> Self {
         let shift = 10.0_f64.powi(frac_digits);
         let offset = (min_x * shift) as usize;
@@ -87,10 +88,11 @@ impl<F: Fn(f64) -> f64> InterpolationTable<F> {
         (x * self.shift) as usize - self.offset
     }
 
-    /// Lookup given value in table, and interpolate the result between the sampled values if
-    /// necessary. This provides an approximation that is better the more fraction digits are
-    /// used to generate this table.
-    /// Time Complexity for lookup: O(1) if `min_x <= x < max_x` and O(func(x)) otherwise.
+    /// Lookup given value in table, and interpolate the result between the
+    /// sampled values if necessary. This provides an approximation that is
+    /// better the more fraction digits are used to generate this table.
+    /// Time Complexity for lookup: O(1) if `min_x <= x < max_x` and O(func(x))
+    /// otherwise.
     pub fn get(&self, x: f64) -> f64 {
         if x < self.min_x || x >= self.max_x {
             (self.func)(x)

--- a/src/data_structures/interval_tree/array_backed_interval_tree.rs
+++ b/src/data_structures/interval_tree/array_backed_interval_tree.rs
@@ -1,11 +1,13 @@
-//! Interval tree, a data structure for efficiently storing and searching intervals.
+//! Interval tree, a data structure for efficiently storing and searching
+//! intervals.
 //!
-//! This implementation is based on the sorted array version as described/given in
-//! https://github.com/lh3/cgranges / https://github.com/lh3/cgranges/blob/master/cpp/IITree.h
+//! This implementation is based on the sorted array version as described/given
+//! in https://github.com/lh3/cgranges / https://github.com/lh3/cgranges/blob/master/cpp/IITree.h
 //!
-//! It uses the same conventions as `crate::data_structures::interval_tree::IntervalTree`.
-//! Note that if you do not use the `ArrayBackedIntervalTree::from_iter` constructor, you have to call `index(&mut self)`
-//! first before `find()`-ing overlaps.
+//! It uses the same conventions as
+//! `crate::data_structures::interval_tree::IntervalTree`. Note that if you do
+//! not use the `ArrayBackedIntervalTree::from_iter` constructor, you have to
+//! call `index(&mut self)` first before `find()`-ing overlaps.
 //!
 //! # Example
 //! ```
@@ -32,14 +34,14 @@
 //! assert_eq!(i2.interval().end, 34);
 //! assert_eq!(i2.data(), &0u32);
 //! ```
-//!
 
 use crate::utils::Interval;
 use std::cmp::min;
 use std::iter::FromIterator;
 
-/// A `find` query on the interval tree does not directly return references to the intervals in the
-/// tree but wraps the fields `interval` and `data` in an `Entry`.
+/// A `find` query on the interval tree does not directly return references to
+/// the intervals in the tree but wraps the fields `interval` and `data` in an
+/// `Entry`.
 #[derive(PartialEq, Eq, Debug, Clone)]
 struct InternalEntry<N: Ord + Clone + Copy, D> {
     data: D,
@@ -47,8 +49,9 @@ struct InternalEntry<N: Ord + Clone + Copy, D> {
     max: N,
 }
 
-/// A `find` query on the interval tree does not directly return references to the nodes in the tree, but
-/// wraps the fields `interval` and `data` in an `Entry`.
+/// A `find` query on the interval tree does not directly return references to
+/// the nodes in the tree, but wraps the fields `interval` and `data` in an
+/// `Entry`.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Entry<'a, N: Ord + Clone, D> {
     data: &'a D,
@@ -163,11 +166,13 @@ impl<N: Ord + Clone + Copy, D: Clone> ArrayBackedIntervalTree<N, D> {
     }
 
     /// Find overlapping intervals in the index.
-    /// Returns a vector of entries, consisting of the interval and its associated data.
+    /// Returns a vector of entries, consisting of the interval and its
+    /// associated data.
     ///
     /// # Arguments
     ///
-    /// * `interval` - The interval for which overlaps are to be found in the index. Can also be a `Range`.
+    /// * `interval` - The interval for which overlaps are to be found in the index. Can also be a
+    ///   `Range`.
     ///
     /// # Panics
     ///
@@ -182,7 +187,8 @@ impl<N: Ord + Clone + Copy, D: Clone> ArrayBackedIntervalTree<N, D> {
     ///
     /// # Arguments
     ///
-    /// * `interval` - The interval for which overlaps are to be found in the index. Can also be a `Range`.
+    /// * `interval` - The interval for which overlaps are to be found in the index. Can also be a
+    ///   `Range`.
     /// * `results` - A reusable buffer vector for storing the results.
     ///
     /// # Panics

--- a/src/data_structures/interval_tree/avl_interval_tree.rs
+++ b/src/data_structures/interval_tree/avl_interval_tree.rs
@@ -1,14 +1,17 @@
-//! Interval tree, a data structure for efficiently storing and searching intervals.
+//! Interval tree, a data structure for efficiently storing and searching
+//! intervals.
 //!
-//! This data structure uses an `Interval` type to define the intervals. It is implemented by
-//! wrapping the `std::ops::Range` in a newtype. An interval must have a positive with and the interval bounds
-//! may be specified by any type satisfies both the `std::cmp::Ord` and `Clone` trait. Because
-//! `Interval` implements `From<Range>` you can also uses normal `Range` arguments in the
-//! `insert` and `find` functions. This implicit conversion will panic if a negative-width range is
-//! supplied.
+//! This data structure uses an `Interval` type to define the intervals. It is
+//! implemented by wrapping the `std::ops::Range` in a newtype. An interval must
+//! have a positive with and the interval bounds may be specified by any type
+//! satisfies both the `std::cmp::Ord` and `Clone` trait. Because `Interval`
+//! implements `From<Range>` you can also uses normal `Range` arguments in the
+//! `insert` and `find` functions. This implicit conversion will panic if a
+//! negative-width range is supplied.
 //!
-//! Upon inserting an interval may be associated with a data value. The intervals are stored in
-//! an augmented AVL-tree which allows for efficient inserting and querying.
+//! Upon inserting an interval may be associated with a data value. The
+//! intervals are stored in an augmented AVL-tree which allows for efficient
+//! inserting and querying.
 //!
 //! # Example
 //! ```
@@ -25,7 +28,6 @@
 //!     assert_eq!(r.data(), &"Range_1");
 //! }
 //! ```
-//!
 
 use crate::utils::Interval;
 use std::cmp;
@@ -43,8 +45,9 @@ impl<N: Ord + Clone, D> Default for IntervalTree<N, D> {
     }
 }
 
-/// A `find` query on the interval tree does not directly return references to the nodes in the tree, but
-/// wraps the fields `interval` and `data` in an `Entry`.
+/// A `find` query on the interval tree does not directly return references to
+/// the nodes in the tree, but wraps the fields `interval` and `data` in an
+/// `Entry`.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Entry<'a, N: Ord + Clone, D> {
     data: &'a D,
@@ -63,8 +66,8 @@ impl<'a, N: Ord + Clone + 'a, D: 'a> Entry<'a, N, D> {
     }
 }
 
-/// An `IntervalTreeIterator` is returned by `Intervaltree::find` and iterates over the entries
-/// overlapping the query
+/// An `IntervalTreeIterator` is returned by `Intervaltree::find` and iterates
+/// over the entries overlapping the query
 pub struct IntervalTreeIterator<'a, N: Ord + Clone, D> {
     nodes: Vec<&'a Node<N, D>>,
     interval: Interval<N>,
@@ -80,7 +83,8 @@ impl<'a, N: Ord + Clone + 'a, D: 'a> Iterator for IntervalTreeIterator<'a, N, D>
                 Some(node) => node,
             };
 
-            // stop traversal if the query interval is beyond the current node and all children
+            // stop traversal if the query interval is beyond the current node and all
+            // children
             if self.interval.start < candidate.max {
                 if let Some(ref left) = candidate.left {
                     self.nodes.push(left);
@@ -106,9 +110,10 @@ impl<'a, N: Ord + Clone + 'a, D: 'a> Iterator for IntervalTreeIterator<'a, N, D>
     }
 }
 
-/// A `find_mut` query on the interval tree does not directly return references to the nodes in the tree, but
-/// wraps the fields `interval` and `data` in an `EntryMut`. Only the data part can be mutably accessed
-/// using the `data` method
+/// A `find_mut` query on the interval tree does not directly return references
+/// to the nodes in the tree, but wraps the fields `interval` and `data` in an
+/// `EntryMut`. Only the data part can be mutably accessed using the `data`
+/// method
 #[derive(PartialEq, Eq, Debug)]
 pub struct EntryMut<'a, N: Ord + Clone, D> {
     data: &'a mut D,
@@ -127,8 +132,9 @@ impl<'a, N: Ord + Clone + 'a, D: 'a> EntryMut<'a, N, D> {
     }
 }
 
-/// An `IntervalTreeIteratorMut` is returned by `Intervaltree::find_mut` and iterates over the entries
-/// overlapping the query allowing mutable access to the data `D`, not the `Interval`.
+/// An `IntervalTreeIteratorMut` is returned by `Intervaltree::find_mut` and
+/// iterates over the entries overlapping the query allowing mutable access to
+/// the data `D`, not the `Interval`.
 pub struct IntervalTreeIteratorMut<'a, N: Ord + Clone, D> {
     nodes: Vec<&'a mut Node<N, D>>,
     interval: Interval<N>,
@@ -144,13 +150,15 @@ impl<'a, N: Ord + Clone + 'a, D: 'a> Iterator for IntervalTreeIteratorMut<'a, N,
                 Some(node) => node,
             };
 
-            // stop traversal if the query interval is beyond the current node and all children
+            // stop traversal if the query interval is beyond the current node and all
+            // children
             if self.interval.start < candidate.max {
                 if let Some(ref mut left) = candidate.left {
                     self.nodes.push(left);
                 }
 
-                // don't traverse right if the query interval is completely before the current interval
+                // don't traverse right if the query interval is completely before the current
+                // interval
                 if self.interval.end > candidate.interval.start {
                     if let Some(ref mut right) = candidate.right {
                         self.nodes.push(right);
@@ -184,8 +192,8 @@ impl<N: Clone + Ord, D> IntervalTree<N, D> {
         };
     }
 
-    /// Uses the provided `Interval` to find overlapping intervals in the tree and returns an
-    /// `IntervalTreeIterator`
+    /// Uses the provided `Interval` to find overlapping intervals in the tree
+    /// and returns an `IntervalTreeIterator`
     pub fn find<I: Into<Interval<N>>>(&self, interval: I) -> IntervalTreeIterator<'_, N, D> {
         let interval = interval.into();
         match self.root {
@@ -200,8 +208,9 @@ impl<N: Clone + Ord, D> IntervalTree<N, D> {
         }
     }
 
-    /// Uses the provided `Interval` to find overlapping intervals in the tree and returns an
-    /// `IntervalTreeIteratorMut` that allows mutable access to the `data`
+    /// Uses the provided `Interval` to find overlapping intervals in the tree
+    /// and returns an `IntervalTreeIteratorMut` that allows mutable access
+    /// to the `data`
     pub fn find_mut<I: Into<Interval<N>>>(
         &mut self,
         interval: I,

--- a/src/data_structures/qgram_index.rs
+++ b/src/data_structures/qgram_index.rs
@@ -46,15 +46,16 @@ pub struct QGramIndex {
 
 impl QGramIndex {
     /// Create a new q-gram index.
-    /// The q has to be smaller than b / log2(|A|) with |A| being the alphabet size and b the number
-    /// bits with the `usize` data type.
+    /// The q has to be smaller than b / log2(|A|) with |A| being the alphabet
+    /// size and b the number bits with the `usize` data type.
     pub fn new(q: u32, text: &[u8], alphabet: &Alphabet) -> Self {
         QGramIndex::with_max_count(q, text, alphabet, std::usize::MAX)
     }
 
-    /// Create a new q-gram index, only considering q-grams that occur at most `max_count` times.
-    /// The q has to be smaller than b / log2(|A|) with |A| being the alphabet size and b the number
-    /// bits with the `usize` data type.
+    /// Create a new q-gram index, only considering q-grams that occur at most
+    /// `max_count` times. The q has to be smaller than b / log2(|A|) with
+    /// |A| being the alphabet size and b the number bits with the `usize`
+    /// data type.
     pub fn with_max_count(q: u32, text: &[u8], alphabet: &Alphabet, max_count: usize) -> Self {
         let ranks = RankTransform::new(alphabet);
 
@@ -106,7 +107,8 @@ impl QGramIndex {
     }
 
     /// Return matches of the given pattern.
-    /// Complexity O(m + k) for pattern of length m and k being the number of matching q-grams.
+    /// Complexity O(m + k) for pattern of length m and k being the number of
+    /// matching q-grams.
     pub fn matches(&self, pattern: &[u8], min_count: usize) -> Vec<Match> {
         let q = self.q as usize;
         let mut diagonals = collections::HashMap::new();
@@ -143,7 +145,8 @@ impl QGramIndex {
     }
 
     /// Return exact matches (substrings) of the given pattern.
-    /// Complexity O(m + k) for pattern of length m and k being the number of matching q-grams.
+    /// Complexity O(m + k) for pattern of length m and k being the number of
+    /// matching q-grams.
     pub fn exact_matches(&self, pattern: &[u8]) -> Vec<ExactMatch> {
         let q = self.q as usize;
         let mut diagonals = collections::HashMap::new();

--- a/src/data_structures/rank_select.rs
+++ b/src/data_structures/rank_select.rs
@@ -3,8 +3,9 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Rank/Select data structure based on Gonzalez, Grabowski, Mäkinen, Navarro (2005).
-//! This implementation uses only a single level of blocks, and performs well for large n.
+//! Rank/Select data structure based on Gonzalez, Grabowski, Mäkinen, Navarro
+//! (2005). This implementation uses only a single level of blocks, and performs
+//! well for large n.
 //!
 //! Example
 //!
@@ -49,11 +50,11 @@ impl RankSelect {
     /// # Arguments
     ///
     /// * `bits` - A bit vector.
-    /// * `k` - Determines the size (k * 32 bits) of the superblocks.
-    ///   A small k means faster rank query times at the expense of using more
-    ///   space and slower select query times.
-    ///   The data structure needs O(n + n log n / (k * 32)) bits with n being the bits of the given bitvector.
-    ///   The data structure is succinct if k is chosen as a sublinear function of n
+    /// * `k` - Determines the size (k * 32 bits) of the superblocks. A small k means faster rank
+    ///   query times at the expense of using more space and slower select query times. The data
+    ///   structure needs O(n + n log n / (k
+    ///   * 32)) bits with n being the bits of the given bitvector. The data
+    ///   structure is succinct if k is chosen as a sublinear function of n
     ///   (e.g. k = (log n)² / 32).
     pub fn new(bits: BitVec<u8>, k: usize) -> RankSelect {
         let n = bits.len() as usize;
@@ -84,8 +85,8 @@ impl RankSelect {
         self.bits.get_bit(i)
     }
 
-    /// Get the 1-rank of a given bit, i.e. the number of 1-bits in the bitvector up to i (inclusive).
-    /// Complexity: O(k).
+    /// Get the 1-rank of a given bit, i.e. the number of 1-bits in the
+    /// bitvector up to i (inclusive). Complexity: O(k).
     ///
     /// # Arguments
     ///
@@ -113,8 +114,8 @@ impl RankSelect {
         }
     }
 
-    /// Get the 0-rank of a given bit, i.e. the number of 0-bits in the bitvector up to i (inclusive).
-    /// Complexity: O(k).
+    /// Get the 0-rank of a given bit, i.e. the number of 0-bits in the
+    /// bitvector up to i (inclusive). Complexity: O(k).
     ///
     /// # Arguments
     ///

--- a/src/data_structures/smallints.rs
+++ b/src/data_structures/smallints.rs
@@ -4,9 +4,10 @@
 // except according to those terms.
 
 //! A data structure for a sequence of small integers with a few big integers.
-//! Small ints are stored in type S (e.g. a byte), big ints are stored separately (in type B) in a BTree.
-//! The implementation provides vector-like operations on the data structure (e.g. retrieve a position,
-//! add an integer, etc.).
+//! Small ints are stored in type S (e.g. a byte), big ints are stored
+//! separately (in type B) in a BTree. The implementation provides vector-like
+//! operations on the data structure (e.g. retrieve a position, add an integer,
+//! etc.).
 //!
 //! # Example
 //!
@@ -31,8 +32,8 @@ use std::slice;
 use num_integer::Integer;
 use num_traits::{cast, Bounded, Num, NumCast};
 
-/// Data structure for storing a sequence of small integers with few big ones space efficiently
-/// while supporting classical vector operations.
+/// Data structure for storing a sequence of small integers with few big ones
+/// space efficiently while supporting classical vector operations.
 #[derive(Serialize, Deserialize)]
 pub struct SmallInts<F: Integer + Bounded + NumCast + Copy, B: Integer + NumCast + Copy> {
     smallints: Vec<F>,
@@ -72,7 +73,8 @@ impl<S: Integer + Bounded + NumCast + Copy, B: Integer + NumCast + Copy> SmallIn
         }
     }
 
-    /// Create a new instance containing `n` times the integer `v` (and `v` is expected to be small).
+    /// Create a new instance containing `n` times the integer `v` (and `v` is
+    /// expected to be small).
     pub fn from_elem(v: S, n: usize) -> Self {
         assert!(
             size_of::<S>() < size_of::<B>(),
@@ -97,7 +99,8 @@ impl<S: Integer + Bounded + NumCast + Copy, B: Integer + NumCast + Copy> SmallIn
         }
     }
 
-    /// Append `v` to the sequence. This will determine whether `v` is big or small and store it accordingly.
+    /// Append `v` to the sequence. This will determine whether `v` is big or
+    /// small and store it accordingly.
     pub fn push(&mut self, v: B) {
         let maxv: S = S::max_value();
         match cast(v) {
@@ -110,7 +113,8 @@ impl<S: Integer + Bounded + NumCast + Copy, B: Integer + NumCast + Copy> SmallIn
         }
     }
 
-    /// Set value of position `i` to `v`. This will determine whether `v` is big or small and store it accordingly.
+    /// Set value of position `i` to `v`. This will determine whether `v` is big
+    /// or small and store it accordingly.
     pub fn set(&mut self, i: usize, v: B) {
         let maxv: S = S::max_value();
         match cast(v) {
@@ -122,7 +126,8 @@ impl<S: Integer + Bounded + NumCast + Copy, B: Integer + NumCast + Copy> SmallIn
         }
     }
 
-    /// Iterate over sequence. Values will be returned in the big integer type (`B`).
+    /// Iterate over sequence. Values will be returned in the big integer type
+    /// (`B`).
     pub fn iter(&self) -> Iter<'_, S, B> {
         Iter {
             smallints: self,

--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -5,8 +5,8 @@
 
 //! Suffix arrays and related algorithms.
 //! The implementation is based on the lecture notes
-//! "Algorithmen auf Sequenzen", Kopczynski, Marschall, Martin and Rahmann, 2008 - 2015.
-//! The original algorithm desciption can be found in:
+//! "Algorithmen auf Sequenzen", Kopczynski, Marschall, Martin and Rahmann, 2008
+//! - 2015. The original algorithm desciption can be found in:
 //! [Ge Nong, Sen Zhang, Wai Hong Chan: Two Efficient Algorithms for Linear Time Suffix Array Construction. IEEE Trans. Computers 60(10): 1471–1484 (2011)](https://doi.org/10.1109/TC.2010.188)
 //!
 //! # Examples
@@ -77,8 +77,8 @@ pub trait SuffixArray {
     //     (&self, bwt: DBWT, less: DLess, occ: DOcc, sampling_rate: usize) ->
     //     SampledSuffixArray<DBWT, DLess, DOcc> {
     //
-    //     let mut sample = Vec::with_capacity((self.len() as f32 / sampling_rate as f32).ceil() as usize);
-    //     for i in 0..self.len() {
+    //     let mut sample = Vec::with_capacity((self.len() as f32 / sampling_rate as
+    // f32).ceil() as usize);     for i in 0..self.len() {
     //         if (i % sampling_rate) == 0 {
     //             sample.push(self.get(i).unwrap());
     //         }
@@ -95,8 +95,8 @@ pub trait SuffixArray {
 }
 
 // /// A sampled suffix array.
-// pub struct SampledSuffixArray<DBWT: DerefBWT, DLess: DerefLess, DOcc: DerefOcc> {
-//     bwt: DBWT,
+// pub struct SampledSuffixArray<DBWT: DerefBWT, DLess: DerefLess, DOcc:
+// DerefOcc> {     bwt: DBWT,
 //     less: DLess,
 //     occ: DOcc,
 //     sample: Vec<usize>,
@@ -138,9 +138,9 @@ impl SuffixArray for RawSuffixArray {
     // }
 }
 
-// impl<DBWT: DerefBWT, DLess: DerefLess, DOcc: DerefOcc> SuffixArray for SampledSuffixArray<DBWT, DLess, DOcc> {
-//     fn get(&self, index: usize) -> Option<usize> {
-//         if index < self.len() {
+// impl<DBWT: DerefBWT, DLess: DerefLess, DOcc: DerefOcc> SuffixArray for
+// SampledSuffixArray<DBWT, DLess, DOcc> {     fn get(&self, index: usize) ->
+// Option<usize> {         if index < self.len() {
 //             let mut pos = index;
 //             let mut offset = 0;
 //             loop {
@@ -149,8 +149,8 @@ impl SuffixArray for RawSuffixArray {
 //                 }
 //
 //                 let c = self.bwt[pos];
-//                 pos = self.less[c as usize] + self.occ.get(&self.bwt, pos - 1, c);
-//                 offset += 1;
+//                 pos = self.less[c as usize] + self.occ.get(&self.bwt, pos -
+// 1, c);                 offset += 1;
 //             }
 //         } else {
 //             None
@@ -167,9 +167,9 @@ impl SuffixArray for RawSuffixArray {
 // }
 //
 //
-// impl<DBWT: DerefBWT, DLess: DerefLess, DOcc: DerefOcc> SampledSuffixArray<DBWT, DLess, DOcc> {
-//     pub fn sampling_rate(&self) -> usize {
-//         self.s
+// impl<DBWT: DerefBWT, DLess: DerefLess, DOcc: DerefOcc>
+// SampledSuffixArray<DBWT, DLess, DOcc> {     pub fn sampling_rate(&self) ->
+// usize {         self.s
 //     }
 // }
 
@@ -181,25 +181,26 @@ impl SuffixArray for RawSuffixArray {
 /// http://ls11-www.cs.tu-dortmund.de/people/rahmann/algoseq.pdf
 ///
 /// The idea is to first mark positions as L or S, with L being a position
-/// the suffix of which is lexicographically larger than that of the next position.
-/// Then, LMS-positions (leftmost S) are S-positions right to an L-position.
-/// An LMS substring is the substring from one LMS position to the next (inclusive).
-/// The algorithm works as follows:
+/// the suffix of which is lexicographically larger than that of the next
+/// position. Then, LMS-positions (leftmost S) are S-positions right to an
+/// L-position. An LMS substring is the substring from one LMS position to the
+/// next (inclusive). The algorithm works as follows:
 ///
 /// 1. Sort LMS positions: first step 2 is applied to the unsorted sequence
-///    of positions. Surprisingly, this sorts the LMS substrings. If all substrings
-///    are different, LMS positions (and their suffixes) are sorted. Else, a reduced
-///    text is build (at most half the size of the original text) and we recurse into
-///    suffix array construction on the reduced text, yielding the sorted LMS positions.
-/// 2. Derive the order of the other positions/suffixes from the (sorted) LMS positions.
-///    For this, the (still empty) suffix array is partitioned into buckets.
-///    Each bucket denotes an interval of suffixes with the same first symbol.
-///    We know that the L-suffixes have to occur first in the buckets, because they
-///    have to be lexicographically smaller than the S-suffixes with the same first letter.
-///    The LMS-positions can now be used to insert the L-positions in the correct order
-///    into the buckets.
-///    Then, the S-positions can be inserted, again using the already existing entries
-///    in the array.
+///    of positions. Surprisingly, this sorts the LMS substrings. If all
+/// substrings    are different, LMS positions (and their suffixes) are sorted.
+/// Else, a reduced    text is build (at most half the size of the original
+/// text) and we recurse into    suffix array construction on the reduced text,
+/// yielding the sorted LMS positions. 2. Derive the order of the other
+/// positions/suffixes from the (sorted) LMS positions.    For this, the (still
+/// empty) suffix array is partitioned into buckets.    Each bucket denotes an
+/// interval of suffixes with the same first symbol.    We know that the
+/// L-suffixes have to occur first in the buckets, because they    have to be
+/// lexicographically smaller than the S-suffixes with the same first letter.
+///    The LMS-positions can now be used to insert the L-positions in the
+/// correct order    into the buckets.
+///    Then, the S-positions can be inserted, again using the already existing
+/// entries    in the array.
 ///
 /// # Arguments
 ///
@@ -294,9 +295,9 @@ pub fn lcp<SA: Deref<Target = RawSuffixArray>>(text: &[u8], pos: SA) -> LCPArray
     lcp
 }
 
-/// Calculate all locally shortest unique substrings from a given suffix and lcp array
-/// (Ohlebusch (2013). "Bioinformatics Algorithms". ISBN 978-3-00-041316-2).
-/// Complexity: O(n)
+/// Calculate all locally shortest unique substrings from a given suffix and lcp
+/// array (Ohlebusch (2013). "Bioinformatics Algorithms". ISBN
+/// 978-3-00-041316-2). Complexity: O(n)
 ///
 /// # Arguments
 ///
@@ -305,8 +306,9 @@ pub fn lcp<SA: Deref<Target = RawSuffixArray>>(text: &[u8], pos: SA) -> LCPArray
 ///
 /// # Returns
 ///
-/// An vector of the length of the shortest unique substring for each position of the text.
-/// Suffixes are excluded. If no unique substring starts at a given position, the entry is `None`.
+/// An vector of the length of the shortest unique substring for each position
+/// of the text. Suffixes are excluded. If no unique substring starts at a given
+/// position, the entry is `None`.
 ///
 /// # Example
 ///
@@ -336,15 +338,17 @@ pub fn lcp<SA: Deref<Target = RawSuffixArray>>(text: &[u8], pos: SA) -> LCPArray
 /// ```
 pub fn shortest_unique_substrings<SA: SuffixArray>(pos: &SA, lcp: &LCPArray) -> Vec<Option<usize>> {
     let n = pos.len();
-    // Initialize array representing the length of the shortest unique substring starting at position i
+    // Initialize array representing the length of the shortest unique substring
+    // starting at position i
     let mut sus = vec![None; n];
     for i in 0..n {
-        // The longest common prefixes (LCP) of suffix pos[i] with its predecessor and successor are not unique.
-        // In turn the their maximum + 1 is the length of the shortest unique substring starting at pos[i].
+        // The longest common prefixes (LCP) of suffix pos[i] with its predecessor and
+        // successor are not unique. In turn the their maximum + 1 is the length
+        // of the shortest unique substring starting at pos[i].
         let len = 1 + cmp::max(lcp.get(i).unwrap(), lcp.get(i + 1).unwrap_or(0)) as usize;
         let p = pos.get(i).unwrap();
-        // Check if the suffix pos[i] is a prefix of pos[i+1]. In that case, there is no unique substring
-        // at this position.
+        // Check if the suffix pos[i] is a prefix of pos[i+1]. In that case, there is no
+        // unique substring at this position.
         if n - p >= len {
             sus[p] = Some(len);
         }
@@ -357,7 +361,8 @@ fn sentinel(text: &[u8]) -> u8 {
     text[text.len() - 1]
 }
 
-/// Count the sentinels occurring in the text given that the last character is the sentinel.
+/// Count the sentinels occurring in the text given that the last character is
+/// the sentinel.
 fn sentinel_count(text: &[u8]) -> usize {
     let sentinel = sentinel(text);
     assert!(
@@ -587,7 +592,8 @@ impl SAIS {
         for &p in self.lms_pos.iter().rev() {
             let c: usize = cast(text[p]).unwrap();
             self.pos[self.bucket_end[c]] = p;
-            // subtract without overflow: last -1 will cause overflow, but it does not matter
+            // subtract without overflow: last -1 will cause overflow, but it does not
+            // matter
             self.bucket_end[c] = self.bucket_end[c].wrapping_sub(1);
         }
 
@@ -634,8 +640,8 @@ struct PosTypes {
 
 impl PosTypes {
     /// Calculate the text position type.
-    /// L-type marks suffixes being lexicographically larger than their successor,
-    /// S-type marks the others.
+    /// L-type marks suffixes being lexicographically larger than their
+    /// successor, S-type marks the others.
     /// This function fills a BitVec, with 1-bits denoting S-type
     /// and 0-bits denoting L-type.
     ///
@@ -696,7 +702,8 @@ mod tests {
         let n = text.len();
 
         let pos_types = PosTypes::new(&text);
-        //let mut test = BitSlice::from_slice(&[0b01100110, 0b10010011, 0b01100100]).to_owned();
+        //let mut test = BitSlice::from_slice(&[0b01100110, 0b10010011,
+        // 0b01100100]).to_owned();
         let mut test = BitVec::new();
         test.push_block(0b001001101100100101100110);
         test.truncate(n as u64);
@@ -828,13 +835,17 @@ mod tests {
     //             CAGCC$"[..],
     //             "substring"),
     //          (&b"GTAGGCCTAATTATAATCAGCGGACATTTCGTATTGCTCGGGCTGCCAGGATTTTAGCATCAGTAGCCGGGTAATGGAACCTCAAGAGGTCAGCGTCGAA$\
-    //             AATCAGCGGACATTTCGTATTGCTCGGGCTGCCAGGATTTTAGCATCAGTAGCCGGGTAATGGAACCTCAAGAGGTCAGCGTCGAATGGCTATTCCAATA$"[..],
-    //             "complex"),
+    //
+    // AATCAGCGGACATTTCGTATTGCTCGGGCTGCCAGGATTTTAGCATCAGTAGCCGGGTAATGGAACCTCAAGAGGTCAGCGTCGAATGGCTATTCCAATA$"
+    // [..],             "complex"),
     //          (&b"GTAGGCCTAATTATAATCAGCGGACATTTCGTATTGCTCGGGCTGCCAGGATTTTAGCATCAGTAGCCGGGTAATGGAACCTCAAGAGGTCAGCGTCGAA$\
-    //             TTCGACGCTGACCTCTTGAGGTTCCATTACCCGGCTACTGATGCTAAAATCCTGGCAGCCCGAGCAATACGAAATGTCCGCTGATTATAATTAGGCCTAC$\
-    //             AATCAGCGGACATTTCGTATTGCTCGGGCTGCCAGGATTTTAGCATCAGTAGCCGGGTAATGGAACCTCAAGAGGTCAGCGTCGAATGGCTATTCCAATA$\
-    //             TATTGGAATAGCCATTCGACGCTGACCTCTTGAGGTTCCATTACCCGGCTACTGATGCTAAAATCCTGGCAGCCCGAGCAATACGAAATGTCCGCTGATT$"[..],
-    //             "complex with revcomps"),
+    //
+    // TTCGACGCTGACCTCTTGAGGTTCCATTACCCGGCTACTGATGCTAAAATCCTGGCAGCCCGAGCAATACGAAATGTCCGCTGATTATAATTAGGCCTAC$\
+    //
+    // AATCAGCGGACATTTCGTATTGCTCGGGCTGCCAGGATTTTAGCATCAGTAGCCGGGTAATGGAACCTCAAGAGGTCAGCGTCGAATGGCTATTCCAATA$\
+    //
+    // TATTGGAATAGCCATTCGACGCTGACCTCTTGAGGTTCCATTACCCGGCTACTGATGCTAAAATCCTGGCAGCCCGAGCAATACGAAATGTCCGCTGATT$"
+    // [..],             "complex with revcomps"),
     //          ];
     //
     //     for &(text, _) in test_cases.into_iter() {

--- a/src/io/bed.rs
+++ b/src/io/bed.rs
@@ -216,7 +216,8 @@ impl Record {
         }
     }
 
-    /// Add auxilliary field. This has to happen after name and score have been set.
+    /// Add auxilliary field. This has to happen after name and score have been
+    /// set.
     pub fn push_aux(&mut self, field: &str) {
         self.aux.push(field.to_owned());
     }
@@ -439,7 +440,8 @@ mod tests {
 
     #[test]
     fn spliced_to_bed() {
-        //chrV    166236  166885  YER007C-A       0       -       166236  166885  0       2       535,11, 0,638,
+        //chrV    166236  166885  YER007C-A       0       -       166236  166885  0
+        // 2       535,11, 0,638,
         let tma20 = Spliced::with_lengths_starts(
             "chrV".to_owned(),
             166236,
@@ -460,7 +462,8 @@ mod tests {
             String::from_utf8(buf).unwrap().as_str()
         );
 
-        //chrXVI  173151  174702  YPL198W 0       +       173151  174702  0       3       11,94,630,      0,420,921,
+        //chrXVI  173151  174702  YPL198W 0       +       173151  174702  0       3
+        // 11,94,630,      0,420,921,
         let rpl7b = Spliced::with_lengths_starts(
             "chrXVI".to_owned(),
             173151,
@@ -481,7 +484,8 @@ mod tests {
             String::from_utf8(buf).unwrap().as_str()
         );
 
-        //chrXII  765265  766358  YLR316C 0       -       765265  766358  0       3       808,52,109,     0,864,984,
+        //chrXII  765265  766358  YLR316C 0       -       765265  766358  0       3
+        // 808,52,109,     0,864,984,
         let tad3 = Spliced::with_lengths_starts(
             "chrXII".to_owned(),
             765265,

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -9,7 +9,8 @@
 //!
 //! ## Read
 //!
-//! In this example, we parse a fasta file from stdin and compute some statistics
+//! In this example, we parse a fasta file from stdin and compute some
+//! statistics
 //!
 //! ```
 //! use bio::io::fasta;
@@ -53,7 +54,8 @@
 //!
 //! ## Write
 //!
-//! In this example we generate 10 random sequences with length 100 and write them to stdout.
+//! In this example we generate 10 random sequences with length 100 and write
+//! them to stdout.
 //!
 //! ```
 //! use std::io;
@@ -77,7 +79,8 @@
 //!
 //! ## Read and Write
 //!
-//! In this example we filter reads from stdin on sequence length and write them to stdout
+//! In this example we filter reads from stdin on sequence length and write them
+//! to stdout
 //!
 //! ```
 //! use bio::io::fasta;
@@ -365,8 +368,8 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
         Ok(())
     }
 
-    /// Fetch an interval from the sequence with the given record index for reading.
-    /// (stop position is exclusive).
+    /// Fetch an interval from the sequence with the given record index for
+    /// reading. (stop position is exclusive).
     pub fn fetch_by_rid(&mut self, rid: usize, start: u64, stop: u64) -> io::Result<()> {
         let idx = self.idx_by_rid(rid)?;
         self.start = Some(start);
@@ -806,9 +809,9 @@ impl Record {
 }
 
 impl fmt::Display for Record {
-    /// Allows for using `Record` in a given formatter `f`. In general this is for
-    /// creating a `String` representation of a `Record` and, optionally, writing it to
-    /// a file.
+    /// Allows for using `Record` in a given formatter `f`. In general this is
+    /// for creating a `String` representation of a `Record` and,
+    /// optionally, writing it to a file.
     ///
     /// # Errors
     /// Returns [`std::fmt::Error`](https://doc.rust-lang.org/std/fmt/struct.Error.html)
@@ -1159,16 +1162,18 @@ ATTGTTGTTTTA
         assert_eq!(read(&mut reader, "id", 0, 12).unwrap(), b"ACCGTAGGCTGA");
         assert!(read(&mut reader, "id", 0, 13).is_err()); // read past EOF
         assert!(read(&mut reader, "id", 36, 52).is_err()); // seek and read past EOF
-        assert!(read(&mut reader, "id2", 12, 40).is_err()); // seek and read past EOF
+        assert!(read(&mut reader, "id2", 12, 40).is_err()); // seek and read
+                                                            // past EOF
     }
 
     fn _test_indexed_reader_extreme_whitespace<'a, F>(read: F)
     where
         F: Fn(&mut IndexedReader<io::Cursor<Vec<u8>>>, &str, u64, u64) -> io::Result<Vec<u8>>,
     {
-        // Test to exercise the case where we cannot consume all whitespace at once. More than
-        // DEFAULT_BUF_SIZE (a non-public constant set to 8 * 1024) whitespace is used to ensure
-        // that it can't all fit in the BufReader at once.
+        // Test to exercise the case where we cannot consume all whitespace at once.
+        // More than DEFAULT_BUF_SIZE (a non-public constant set to 8 * 1024)
+        // whitespace is used to ensure that it can't all fit in the BufReader
+        // at once.
         let mut seq = Vec::new();
         seq.push(b'A');
         seq.resize(10000, b' ');

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -9,7 +9,8 @@
 //!
 //! ## Read
 //!
-//! In this example, we parse a fastq file from stdin and compute some statistics
+//! In this example, we parse a fastq file from stdin and compute some
+//! statistics
 //!
 //! ```
 //! use bio::io::fastq;
@@ -50,7 +51,8 @@
 //!
 //! ## Write
 //!
-//! In this example we generate 10 random sequences with length 100 and write them to stdout.
+//! In this example we generate 10 random sequences with length 100 and write
+//! them to stdout.
 //!
 //! ```
 //! use std::io;
@@ -76,7 +78,8 @@
 //!
 //! ## Read and Write
 //!
-//! In this example we filter reads from stdin on mean quality (Phred + 33) and write them to stdout
+//! In this example we filter reads from stdin on mean quality (Phred + 33) and
+//! write them to stdout
 //!
 //! ```
 //! use bio::io::fastq;
@@ -184,8 +187,9 @@ where
     ///
     /// This function will return an error if the record is incomplete,
     /// syntax is violated or any form of I/O error is encountered.
-    /// Additionally, if the FastQ file has line-wrapped records, and the wrapping is not
-    /// consistent between the sequence and quality string for a record, parsing will fail.
+    /// Additionally, if the FastQ file has line-wrapped records, and the
+    /// wrapping is not consistent between the sequence and quality string
+    /// for a record, parsing will fail.
     ///
     /// # Example
     ///
@@ -321,10 +325,11 @@ impl Record {
     /// Check the validity of a FastQ record.
     ///
     /// # Errors
-    /// This function will return an `Err` if one of the following conditions is met:
-    /// -   The record identifier is empty.
-    /// -   There is a non-ASCII character found in either the sequence or quality strings.
-    /// -   The sequence and quality strings do not have the same length.
+    /// This function will return an `Err` if one of the following conditions is
+    /// met:
+    /// - The record identifier is empty.
+    /// - There is a non-ASCII character found in either the sequence or quality strings.
+    /// - The sequence and quality strings do not have the same length.
     ///
     /// # Example
     ///
@@ -389,9 +394,9 @@ impl Record {
 }
 
 impl fmt::Display for Record {
-    /// Allows for using `Record` in a given formatter `f`. In general this is for
-    /// creating a `String` representation of a `Record` and, optionally, writing it to
-    /// a file.
+    /// Allows for using `Record` in a given formatter `f`. In general this is
+    /// for creating a `String` representation of a `Record` and,
+    /// optionally, writing it to a file.
     ///
     /// # Errors
     /// Returns [`std::fmt::Error`](https://doc.rust-lang.org/std/fmt/struct.Error.html)
@@ -496,7 +501,8 @@ impl<W: io::Write> Writer<W> {
         self.write(record.id(), record.desc(), record.seq(), record.qual())
     }
 
-    /// Write a FastQ record with given id, optional description, sequence and qualities.
+    /// Write a FastQ record with given id, optional description, sequence and
+    /// qualities.
     pub fn write(
         &mut self,
         id: &str,

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -83,7 +83,8 @@ impl Reader<fs::File> {
 }
 
 impl<R: io::Read> Reader<R> {
-    /// Create a new GFF reader given an instance of `io::Read`, in given format.
+    /// Create a new GFF reader given an instance of `io::Read`, in given
+    /// format.
     pub fn new(reader: R, fileformat: GffType) -> Self {
         Reader {
             inner: csv::ReaderBuilder::new()
@@ -390,7 +391,8 @@ gene_id \"ENSG00000223972.5\"; gene_type \"transcribed_unprocessed_pseudogene\";
 chr1\tHAVANA\ttranscript\t11869\t14409\t.\t+\t.\tgene_id \"ENSG00000223972.5\";\
 transcript_id \"ENST00000456328.2\"; gene_type \"transcribed_unprocessed_pseudogene\"";
 
-    // GTF file with duplicate attribute keys, taken from a published GENCODE GTF file.
+    // GTF file with duplicate attribute keys, taken from a published GENCODE GTF
+    // file.
     const GTF_FILE_DUP_ATTR_KEYS: &'static [u8] = b"chr1\tENSEMBL\ttranscript\t182393\t\
 184158\t.\t+\t.\tgene_id \"ENSG00000279928.1\"; transcript_id \"ENST00000624431.1\";\
 gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"FO538757.2\";\

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@
 //! All provided implementations are rigorously tested via continuous
 //! integration.
 //!
-//! For **getting started** with using `rust-bio`, see [the `Getting started` section below](#getting-started).
-//! For navigating the documentation of the available modules, see [the `Modules` section below](#modules).
-//! If you want to contribute to `rust-bio`, see [the `Contribute` section in the repo](https://github.com/rust-bio/rust-bio#contribute).
+//! For **getting started** with using `rust-bio`, see [the `Getting started`
+//! section below](#getting-started). For navigating the documentation of the
+//! available modules, see [the `Modules` section below](#modules). If you want to contribute to `rust-bio`, see [the `Contribute` section in the repo](https://github.com/rust-bio/rust-bio#contribute).
 //!
 //! Currently, rust-bio provides
 //!
@@ -31,7 +31,8 @@
 //! * utilities to work with [PSSMs](https://en.wikipedia.org/wiki/Position_weight_matrix),
 //! * an open reading frame (ORF) search algorithm,
 //! * a rank/select data structure,
-//! * [serde](https://github.com/serde-rs/serde) support for all data structures when built with `nightly` feature,
+//! * [serde](https://github.com/serde-rs/serde) support for all data structures when built with
+//!   `nightly` feature,
 //! * readers and writers for FASTQ, FASTA and BED,
 //! * helper functions for combinatorics and dealing with log probabilities,
 //! * an implementation of the Hidden Markov Model and related algorithms.
@@ -51,16 +52,16 @@
 //!
 //! ## Step 2: Setting up a new Rust project
 //!
-//! Since Rust-Bio is a library, you need to setup your own new Rust project to use Rust-Bio.
-//! With Rust, projects and their dependencies are managed with the builtin package manager [Cargo](https://doc.rust-lang.org/cargo/index.html).
+//! Since Rust-Bio is a library, you need to setup your own new Rust project to
+//! use Rust-Bio. With Rust, projects and their dependencies are managed with the builtin package manager [Cargo](https://doc.rust-lang.org/cargo/index.html).
 //! To create a new Rust project, issue
 //!
 //! ```bash
 //! cargo new hello_world --bin
 //! cd hello_world
 //! ```
-//! in your terminal. The flag `--bin` tells Cargo to create an executable project instead of a library.
-//! In [this section](https://doc.rust-lang.org/nightly/book/hello-cargo.html#a-new-project) of the Rust docs, you find details about what Cargo just created for you.
+//! in your terminal. The flag `--bin` tells Cargo to create an executable
+//! project instead of a library. In [this section](https://doc.rust-lang.org/nightly/book/hello-cargo.html#a-new-project) of the Rust docs, you find details about what Cargo just created for you.
 //!
 //! Your new project can be compiled with
 //! ```bash
@@ -149,7 +150,8 @@
 //! }
 //! ```
 //!
-//! Documentation and further examples for each module can be found in the module descriptions below.
+//! Documentation and further examples for each module can be found in the
+//! module descriptions below.
 //!
 //!
 //! ## Example: Multithreaded
@@ -188,11 +190,14 @@
 //! }
 //! ```
 //!
-//! Documentation and further examples for each module can be found in the module descriptions below.
+//! Documentation and further examples for each module can be found in the
+//! module descriptions below.
 //!
 //! # Benchmarks
 //!
-//! Since Rust-Bio is based on a compiled language, similar performance to C/C++ based libraries can be expected. Indeed, we find the pattern matching algorithms of Rust-Bio to perform in the range of the C++ library Seqan:
+//! Since Rust-Bio is based on a compiled language, similar performance to C/C++
+//! based libraries can be expected. Indeed, we find the pattern matching
+//! algorithms of Rust-Bio to perform in the range of the C++ library Seqan:
 //!
 //! | Algorithm | Rust-Bio | Seqan   |
 //! | --------- | -------: | ------: |
@@ -201,10 +206,13 @@
 //! | BOM       | 103ms    | 107ms   |
 //! | Shift-And | 241ms    | 545ms   |
 //!
-//! We measured 10000 iterations of searching pattern `GCGCGTACACACCGCCCG` in the sequence of the hg38 MT chromosome.
-//! Initialization time of each algorithm for the given pattern was included in each iteration. Benchmarks were conducted with *Cargo bench* for Rust-Bio and *Python timeit* for Seqan on an Intel Core i5-3427U CPU.
-//! Benchmarking Seqan from *Python timeit* entails an overhead of 1.46ms for calling a C++ binary. This overhead was subtracted from above Seqan run times.
-//! Note that this benchmark only compares the two libraries to exemplify that Rust-Bio has comparable speed to C++ libraries: all used algorithms have their advantages for specific text and pattern structures and lengths (see [the pattern matching section in the documentation](https://docs.rs/bio/0.28.2/bio/pattern_matching/index.html))./!
+//! We measured 10000 iterations of searching pattern `GCGCGTACACACCGCCCG` in
+//! the sequence of the hg38 MT chromosome. Initialization time of each
+//! algorithm for the given pattern was included in each iteration. Benchmarks
+//! were conducted with *Cargo bench* for Rust-Bio and *Python timeit* for Seqan
+//! on an Intel Core i5-3427U CPU. Benchmarking Seqan from *Python timeit*
+//! entails an overhead of 1.46ms for calling a C++ binary. This overhead was
+//! subtracted from above Seqan run times. Note that this benchmark only compares the two libraries to exemplify that Rust-Bio has comparable speed to C++ libraries: all used algorithms have their advantages for specific text and pattern structures and lengths (see [the pattern matching section in the documentation](https://docs.rs/bio/0.28.2/bio/pattern_matching/index.html))./!
 
 #[macro_use]
 extern crate approx;

--- a/src/pattern_matching/bndm.rs
+++ b/src/pattern_matching/bndm.rs
@@ -4,8 +4,8 @@
 // except according to those terms.
 
 //! Backward nondeterministic DAWG matching (BNDM).
-//! Best-case complexity: O(n / m) with pattern of length m <= 64 and text of length n.
-//! Worst case complexity: O(n * m).
+//! Best-case complexity: O(n / m) with pattern of length m <= 64 and text of
+//! length n. Worst case complexity: O(n * m).
 //!
 //! # Example
 //!
@@ -47,7 +47,8 @@ impl BNDM {
         BNDM { m, masks, accept }
     }
 
-    /// Find all matches of pattern with a given text. Matches are returned as iterator over start positions.
+    /// Find all matches of pattern with a given text. Matches are returned as
+    /// iterator over start positions.
     pub fn find_all<'a>(&'a self, text: TextSlice<'a>) -> Matches<'_> {
         Matches {
             bndm: self,

--- a/src/pattern_matching/bom.rs
+++ b/src/pattern_matching/bom.rs
@@ -4,8 +4,8 @@
 // except according to those terms.
 
 //! Backward oracle matching algorithm.
-//! Best-case complexity: O(n / m) with pattern of length m and text of length n.
-//! Worst case complexity: O(n * m).
+//! Best-case complexity: O(n / m) with pattern of length m and text of length
+//! n. Worst case complexity: O(n * m).
 //!
 //! # Example
 //!
@@ -95,7 +95,8 @@ impl BOM {
         }
     }
 
-    /// Find all matches of the pattern in the given text. Matches are returned as an iterator over start positions.
+    /// Find all matches of the pattern in the given text. Matches are returned
+    /// as an iterator over start positions.
     pub fn find_all<'a>(&'a self, text: TextSlice<'a>) -> Matches<'_> {
         Matches {
             bom: self,

--- a/src/pattern_matching/horspool.rs
+++ b/src/pattern_matching/horspool.rs
@@ -61,8 +61,8 @@ impl<'a> Horspool<'a> {
         Horspool { m, shift, pattern }
     }
 
-    /// Find all matches with a given text. Matches are returned as an iterator over start
-    /// positions.
+    /// Find all matches with a given text. Matches are returned as an iterator
+    /// over start positions.
     pub fn find_all<'b>(&'b self, text: TextSlice<'b>) -> Matches<'_> {
         Matches {
             horspool: self,

--- a/src/pattern_matching/kmp.rs
+++ b/src/pattern_matching/kmp.rs
@@ -6,10 +6,10 @@
 //! Algorithm of Knuth Morris and Pratt.
 //! Constructs an automaton recognizing the pattern, and scans linearly over
 //! a text of length n. Complexity: O(n).
-//! The transition function delta is simulated via the lps-function, that assigns to each position
-//! q in the pattern the longest prefix of the pattern that is suffix of pattern[..q+1].
-//! Then, in the NFA for the pattern, active states after reading position q are
-//! {q, lps(q), lps(lps(q)), ... 0}.
+//! The transition function delta is simulated via the lps-function, that
+//! assigns to each position q in the pattern the longest prefix of the pattern
+//! that is suffix of pattern[..q+1]. Then, in the NFA for the pattern, active
+//! states after reading position q are {q, lps(q), lps(lps(q)), ... 0}.
 //!
 //! # Example
 //!
@@ -56,8 +56,8 @@ impl<'a> KMP<'a> {
         q
     }
 
-    /// Find all matches of pattern in a given text. Matches are returned as iterator over start
-    /// positions.
+    /// Find all matches of pattern in a given text. Matches are returned as
+    /// iterator over start positions.
     pub fn find_all<C, T>(&self, text: T) -> Matches<C, T::IntoIter>
     where
         C: Borrow<u8>,

--- a/src/pattern_matching/mod.rs
+++ b/src/pattern_matching/mod.rs
@@ -5,7 +5,8 @@
 
 //! This module contains various useful pattern matching algorithms.
 //! The implementations are based on the lecture notes
-//! "Algorithmen auf Sequenzen", Kopczynski, Marschall, Martin and Rahmann, 2008 - 2015.
+//! "Algorithmen auf Sequenzen", Kopczynski, Marschall, Martin and Rahmann, 2008
+//! - 2015.
 //!
 //! * Algorithm of Horspool: fastest for a sufficiently large alphabet
 //! * Shift And algorithm: fast for patterns with less than 64 symbols and very small alphabets.
@@ -13,7 +14,8 @@
 //! * BOM algorithm: fast for long patterns and small alphabet.
 //! * KMP algorithm: the classical ancestor.
 //! * Ukkonens algorithm: approximate pattern matching with dynamic programming.
-//! * Myers algorithm: linear-time approximate pattern matching with edit distance for small patterns
+//! * Myers algorithm: linear-time approximate pattern matching with edit distance for small
+//!   patterns
 //!
 //! Another fast pattern matching algorithm is available in the twoway crate: https://crates.io/crates/twoway
 

--- a/src/pattern_matching/myers/builder.rs
+++ b/src/pattern_matching/myers/builder.rs
@@ -8,7 +8,8 @@ use super::{BitVec, Myers};
 ///
 /// # Example:
 ///
-/// This example shows how recognition of IUPAC ambiguities in patterns can be implemented:
+/// This example shows how recognition of IUPAC ambiguities in patterns can be
+/// implemented:
 ///
 /// ```
 /// # extern crate bio;
@@ -44,9 +45,10 @@ use super::{BitVec, Myers};
 /// # }
 /// ```
 ///
-/// Note that only ambiguities in the pattern are recognized. The reverse is not true; ambiguities
-/// in the search text are not matched by multiple symbols in the pattern. This would require
-/// specifying additional ambiguities (`builder.ambig(b'A', b"MRWVHDN")`, etc...).
+/// Note that only ambiguities in the pattern are recognized. The reverse is not
+/// true; ambiguities in the search text are not matched by multiple symbols in
+/// the pattern. This would require specifying additional ambiguities
+/// (`builder.ambig(b'A', b"MRWVHDN")`, etc...).
 #[derive(Default, Clone, Eq, PartialEq)]
 pub struct MyersBuilder {
     ambigs: HashMap<u8, Vec<u8>>,
@@ -58,9 +60,9 @@ impl MyersBuilder {
         Self::default()
     }
 
-    /// Allows to specify ambiguous symbols and their equivalents. Note that the ambiguous symbol
-    /// will always be matched by itself. Explicitly including it in the equivalents is not
-    /// necessary.
+    /// Allows to specify ambiguous symbols and their equivalents. Note that the
+    /// ambiguous symbol will always be matched by itself. Explicitly
+    /// including it in the equivalents is not necessary.
     ///
     /// # Example:
     ///
@@ -92,10 +94,11 @@ impl MyersBuilder {
         self
     }
 
-    /// Allows to specify a wildcard symbol, that upon appearance in the search text
-    /// shall be matched by any symbol of the pattern. Multiple wildcards are possible.
-    /// For the inverse, that is, wildcards in the pattern matching any symbol in search
-    /// text, use `ambig(byte, 0..255)`.
+    /// Allows to specify a wildcard symbol, that upon appearance in the search
+    /// text shall be matched by any symbol of the pattern. Multiple
+    /// wildcards are possible. For the inverse, that is, wildcards in the
+    /// pattern matching any symbol in search text, use `ambig(byte,
+    /// 0..255)`.
     ///
     /// # Example:
     ///
@@ -118,8 +121,8 @@ impl MyersBuilder {
         self
     }
 
-    /// Creates a Myers instance given a pattern, using `u64` as bit vector type.
-    /// Pattern length is restricted to at most 64 symbols.
+    /// Creates a Myers instance given a pattern, using `u64` as bit vector
+    /// type. Pattern length is restricted to at most 64 symbols.
     pub fn build_64<C, P>(&self, pattern: P) -> Myers<u64>
     where
         C: Borrow<u8>,
@@ -129,8 +132,8 @@ impl MyersBuilder {
         self.build(pattern)
     }
 
-    /// Creates a Myers instance given a pattern, using `u128` as bit vector type.
-    /// Pattern length is restricted to at most 128 symbols.
+    /// Creates a Myers instance given a pattern, using `u128` as bit vector
+    /// type. Pattern length is restricted to at most 128 symbols.
     #[cfg(has_u128)]
     pub fn build_128<C, P>(&self, pattern: P) -> Myers<u128>
     where
@@ -141,8 +144,9 @@ impl MyersBuilder {
         self.build(pattern)
     }
 
-    /// Creates a Myers instance given a pattern, using any desired type for bit vectors.
-    /// Pattern length is restricted to the size of the bit vector `T`.
+    /// Creates a Myers instance given a pattern, using any desired type for bit
+    /// vectors. Pattern length is restricted to the size of the bit vector
+    /// `T`.
     ///
     /// # Example:
     ///
@@ -166,8 +170,9 @@ impl MyersBuilder {
         Myers::new_ambig(pattern, Some(&self.ambigs), Some(&self.wildcards))
     }
 
-    /// Creates a `long::Myers` instance given a pattern, using `u64` as bit vector type.
-    /// Pattern length is not restricted regardless of the type of the bit vector.
+    /// Creates a `long::Myers` instance given a pattern, using `u64` as bit
+    /// vector type. Pattern length is not restricted regardless of the type
+    /// of the bit vector.
     pub fn build_long_64<C, P>(&self, pattern: P) -> MyersLong<u64>
     where
         C: Borrow<u8>,
@@ -177,8 +182,9 @@ impl MyersBuilder {
         self.build_long(pattern)
     }
 
-    /// Creates a `long::Myers` instance given a pattern, using `u128` as bit vector type.
-    /// Pattern length is not restricted regardless of the type of the bit vector.
+    /// Creates a `long::Myers` instance given a pattern, using `u128` as bit
+    /// vector type. Pattern length is not restricted regardless of the type
+    /// of the bit vector.
     #[cfg(has_u128)]
     pub fn build_long_128<C, P>(&self, pattern: P) -> MyersLong<u128>
     where
@@ -189,8 +195,9 @@ impl MyersBuilder {
         self.build_long(pattern)
     }
 
-    /// Creates a `long::Myers` instance given a pattern, using any desired type for bit vectors.
-    /// Pattern length is not restricted regardless of the type of the bit vector.
+    /// Creates a `long::Myers` instance given a pattern, using any desired type
+    /// for bit vectors. Pattern length is not restricted regardless of the
+    /// type of the bit vector.
     pub fn build_long<T, C, P>(&self, pattern: P) -> MyersLong<T>
     where
         T: BitVec,

--- a/src/pattern_matching/myers/common_tests.rs
+++ b/src/pattern_matching/myers/common_tests.rs
@@ -211,7 +211,8 @@ macro_rules! impl_tests {
             let text = b"TGABCNTR";
             let patt = b"TGRRCGTR";
             //                x  x
-            // Matching is asymmetric here (A matches R and G matches N, but the reverse is not true)
+            // Matching is asymmetric here (A matches R and G matches N, but the reverse is
+            // not true)
 
             let myers = MyersBuilder::new().ambig(b'R', b"AG").build_64(patt);
             assert_eq!(myers.distance(text), 2);

--- a/src/pattern_matching/myers/helpers.rs
+++ b/src/pattern_matching/myers/helpers.rs
@@ -3,16 +3,17 @@ use std::ops::*;
 
 use num_traits::{AsPrimitive, FromPrimitive, PrimInt, ToPrimitive, WrappingAdd};
 
-/// Trait for types that should be used to store the distance score when using the simple
-/// Myers algorithm (not the block-based one, which always uses `usize`).
+/// Trait for types that should be used to store the distance score when using
+/// the simple Myers algorithm (not the block-based one, which always uses
+/// `usize`).
 ///
 /// For all currently implemented BitVec types, the maximum possible distance
 /// can be stored in `u8`. Custom implementations using bigger integers can
 /// adjust `DistType` to hold bigger numbers. Note that due to how the traceback
-/// algorithm currently works, `DistType` should be able to represent numbers larger
-/// than the bit-width of the `BitVec` type. For instance, a hypothetical `BitVec` type
-/// of `u256` should use `u16` as distance, since `u8` cannot store numbers larger
-/// than 255.
+/// algorithm currently works, `DistType` should be able to represent numbers
+/// larger than the bit-width of the `BitVec` type. For instance, a hypothetical
+/// `BitVec` type of `u256` should use `u16` as distance, since `u8` cannot
+/// store numbers larger than 255.
 pub trait DistType: Copy
         + Debug
         + Default
@@ -78,7 +79,8 @@ impl_bitvec!(u128, u8);
 use crate::alignment::{Alignment, AlignmentMode};
 
 /// Updates an `Alignment` instance with new data (except of path).
-/// Assumes *0-based* range end coordinates, they will be converted to 1-based ones
+/// Assumes *0-based* range end coordinates, they will be converted to 1-based
+/// ones
 #[inline(always)]
 pub(crate) fn update_aln(
     end_pos: usize,

--- a/src/pattern_matching/myers/long.rs
+++ b/src/pattern_matching/myers/long.rs
@@ -1,11 +1,12 @@
-//! Block-based version of the algorithm, which does not restrict pattern length.
+//! Block-based version of the algorithm, which does not restrict pattern
+//! length.
 //!
-//! This module implements the block-based version of the Myers pattern matching algorithm.
-//! It can be used for searching patterns of any length and obtaining semiglobal alignments
-//! of the hits. Apart from that, the `Myers` object in this module provides exactly the same
-//! API as the 'simple' version `bio::pattern_matching::myers::Myers`.
-//! For short patterns, the 'simple' version is still to be preferred, as the block-based
-//! algorithm is slower.
+//! This module implements the block-based version of the Myers pattern matching
+//! algorithm. It can be used for searching patterns of any length and obtaining
+//! semiglobal alignments of the hits. Apart from that, the `Myers` object in
+//! this module provides exactly the same API as the 'simple' version
+//! `bio::pattern_matching::myers::Myers`. For short patterns, the 'simple'
+//! version is still to be preferred, as the block-based algorithm is slower.
 
 use std::borrow::Borrow;
 use std::cmp::{max, min};
@@ -351,8 +352,8 @@ impl<'a, T: BitVec> LongTracebackHandler<'a, T> {
         let col = states_iter.next().unwrap();
         let left_col = states_iter.next().unwrap();
 
-        // This bit mask is supplied to State::adjust_by_mask() in order to adjust the distance
-        // of the left block. It is adjusted with every `move_up_left`
+        // This bit mask is supplied to State::adjust_by_mask() in order to adjust the
+        // distance of the left block. It is adjusted with every `move_up_left`
         let left_mask = if last_m != 1 {
             T::zero()
         } else {
@@ -422,10 +423,10 @@ impl<'a, T: BitVec + 'a> TracebackHandler<'a, T, usize> for LongTracebackHandler
 
     #[inline]
     fn move_up_left(&mut self, adjust_dist: bool) {
-        // If the block boundary has not been reached yet, we can extend the range mask by
-        // activating a new bit.
-        // However, we switch to a new block (if there is one!) before the mask would cover
-        // the whole block.
+        // If the block boundary has not been reached yet, we can extend the range mask
+        // by activating a new bit.
+        // However, we switch to a new block (if there is one!) before the mask would
+        // cover the whole block.
         if self.left_mask & T::from_usize(0b10).unwrap() == T::zero() || self.left_block_pos == 0 {
             self.left_mask = (self.left_mask >> 1) | self.left_max_mask;
             if adjust_dist {

--- a/src/pattern_matching/myers/mod.rs
+++ b/src/pattern_matching/myers/mod.rs
@@ -4,27 +4,29 @@
 // except according to those terms.
 
 //! Myers bit-parallel approximate pattern matching algorithm.
-//! Finds all matches up to a given edit distance. The pattern has to fit into a bitvector,
-//! and is thus limited to 64 or (since stable Rust version 1.26) to 128 symbols.
-//! Complexity: O(n)
+//! Finds all matches up to a given edit distance. The pattern has to fit into a
+//! bitvector, and is thus limited to 64 or (since stable Rust version 1.26) to
+//! 128 symbols. Complexity: O(n)
 //!
-//! Traceback allows obtaining the starting position and the alignment path of the hit.
-//! Its implementation is somehow similar to the one by Edlib (Šošić and Šikić 2017),
-//! although there can be small differences when there is more than one possible alignment
-//! path with then same edit distance at a position: Edlib prefers to make insertions
-//! and deletions to the pattern (query) over substitutions
-//! (Insertion > Deletion > Substitution) while our implementation prefers substitutions
-//! (Substitution > Insertion > Deletion).
+//! Traceback allows obtaining the starting position and the alignment path of
+//! the hit. Its implementation is somehow similar to the one by Edlib (Šošić
+//! and Šikić 2017), although there can be small differences when there is more
+//! than one possible alignment path with then same edit distance at a position:
+//! Edlib prefers to make insertions and deletions to the pattern (query) over
+//! substitutions (Insertion > Deletion > Substitution) while our implementation
+//! prefers substitutions (Substitution > Insertion > Deletion).
 //!
-//! *Myers, G. (1999). A fast bit-vector algorithm for approximate string matching based on dynamic
-//!  programming. Journal of the ACM (JACM) 46, 395–415.*
+//! *Myers, G. (1999). A fast bit-vector algorithm for approximate string
+//! matching based on dynamic  programming. Journal of the ACM (JACM) 46,
+//! 395–415.*
 //!
-//! *Šošić, M., and Šikić, M. (2017). Edlib: a C/C ++ library for fast, exact sequence alignment
-//! using edit distance. Bioinformatics 33, 1394–1395.*
+//! *Šošić, M., and Šikić, M. (2017). Edlib: a C/C ++ library for fast, exact
+//! sequence alignment using edit distance. Bioinformatics 33, 1394–1395.*
 //!
 //! # Example
 //!
-//! Iterating over matches in pairs of `(end, distance)` using `u64` as bitvector type:
+//! Iterating over matches in pairs of `(end, distance)` using `u64` as
+//! bitvector type:
 //!
 //! ```
 //! # extern crate bio;
@@ -41,15 +43,17 @@
 //! # }
 //! ```
 //!
-//! Starting with stable Rust 1.26, it is also possible to use `u128` as bitvector
-//! (`Myers::<u128>`), which enables longer patterns, but is somewhat slower.
+//! Starting with stable Rust 1.26, it is also possible to use `u128` as
+//! bitvector (`Myers::<u128>`), which enables longer patterns, but is somewhat
+//! slower.
 //!
 //! # Long patterns
 //!
-//! With the default implementation, query (pattern) length is limited by the size of the
-//! bit-vector; 64 symbols for `Myers::<u64>`. Patterns longer than 128 symbols (when using
-//! `u128` as bit-vector) can only be handled by using the block-based Myers implementation,
-//! which lives in the [`long`](long/index.html) submodule. An example:
+//! With the default implementation, query (pattern) length is limited by the
+//! size of the bit-vector; 64 symbols for `Myers::<u64>`. Patterns longer than
+//! 128 symbols (when using `u128` as bit-vector) can only be handled by using
+//! the block-based Myers implementation, which lives in the
+//! [`long`](long/index.html) submodule. An example:
 //!
 //! ```
 //! # extern crate bio;
@@ -76,15 +80,17 @@
 //! assert_eq!(occ_64, occ_long_8);
 //! # }
 //! ```
-//! Note that `u8` just used for demonstration, using `u64` is still the best in most cases.
+//! Note that `u8` just used for demonstration, using `u64` is still the best in
+//! most cases.
 //!
 //! # Obtaining the starting position of a match
 //!
-//! The `Myers::find_all` method provides an iterator over tuples of `(start, end, distance)`.
-//! Calculating the starting position requires finding the alignment path, therefore this is
-//! slower than `Myers::find_all_end`. Note that the end positions differ from above by one.
-//! This is intentional, as the iterator returns a range rather an index, and ranges in Rust
-//! do not include the end position by default.
+//! The `Myers::find_all` method provides an iterator over tuples of `(start,
+//! end, distance)`. Calculating the starting position requires finding the
+//! alignment path, therefore this is slower than `Myers::find_all_end`. Note
+//! that the end positions differ from above by one. This is intentional, as the
+//! iterator returns a range rather an index, and ranges in Rust do not include
+//! the end position by default.
 //!
 //! ```
 //! # extern crate bio;
@@ -103,8 +109,8 @@
 //!
 //! # Obtaining alignments
 //!
-//! [`FullMatches`](struct.FullMatches.html) returned by `Myers::find_all()` also provide a method
-//! for obtaining an alignment path:
+//! [`FullMatches`](struct.FullMatches.html) returned by `Myers::find_all()`
+//! also provide a method for obtaining an alignment path:
 //!
 //! ```
 //! # extern crate bio;
@@ -153,21 +159,22 @@
 //!
 //! </pre>
 //!
-//! **Note** that the [`Alignment`](../../alignment/struct.Alignment.html) instance is only created
-//! once and then reused. Because the Myers algorithm is very fast, the allocation necessary for
-//! `Alignment::operations` can have a non-negligible impact on performance; and thus, recycling
-//! makes sense.
+//! **Note** that the [`Alignment`](../../alignment/struct.Alignment.html)
+//! instance is only created once and then reused. Because the Myers algorithm
+//! is very fast, the allocation necessary for `Alignment::operations` can have
+//! a non-negligible impact on performance; and thus, recycling makes sense.
 //!
 //! # Finding the best hit
 //!
-//! In many cases, only the match with the smallest edit distance is actually of interest.
-//! Calculating an alignment for every hit is therefore not necessary.
-//! [`LazyMatches`](struct.LazyMatches.html) returned by `Myers::find_all_lazy()`
-//! provide an iterator over tuples of `(end, distance)` like `Myers::find_all_end()`, but
-//! additionally keep the data necessary for calculating the alignment path later at any desired
-//! position. Storing the data itself has a slight performance impact and requires more memory
-//! compared to `Myers::find_all_end()` [O(n) as opposed to O(m + k)]. Still the following code
-//! is faster than using `FullMatches`:
+//! In many cases, only the match with the smallest edit distance is actually of
+//! interest. Calculating an alignment for every hit is therefore not necessary.
+//! [`LazyMatches`](struct.LazyMatches.html) returned by
+//! `Myers::find_all_lazy()` provide an iterator over tuples of `(end,
+//! distance)` like `Myers::find_all_end()`, but additionally keep the data
+//! necessary for calculating the alignment path later at any desired
+//! position. Storing the data itself has a slight performance impact and
+//! requires more memory compared to `Myers::find_all_end()` [O(n) as opposed to
+//! O(m + k)]. Still the following code is faster than using `FullMatches`:
 //!
 //! ```
 //! # extern crate bio;
@@ -205,13 +212,14 @@
 //! TCCTCCTGAGGG-ATTAGCAC
 //! </pre>
 //!
-//! Actually as seen in the previous chapters, there are two hits with the same distance of 2.
-//! It may make sense to consider both of them.
+//! Actually as seen in the previous chapters, there are two hits with the same
+//! distance of 2. It may make sense to consider both of them.
 //!
 //! # Dealing with ambiguities
 //!
-//! Matching multiple or all symbols at once can be achieved using `MyersBuilder`. This example
-//! allows `N` in the search pattern to match all four DNA bases in the text:
+//! Matching multiple or all symbols at once can be achieved using
+//! `MyersBuilder`. This example allows `N` in the search pattern to match all
+//! four DNA bases in the text:
 //!
 //! ```
 //! # extern crate bio;
@@ -226,7 +234,8 @@
 //! # }
 //! ```
 //!
-//! For more examples see the documentation of [`MyersBuilder`](struct.MyersBuilder.html).
+//! For more examples see the documentation of
+//! [`MyersBuilder`](struct.MyersBuilder.html).
 
 #[macro_use]
 mod myers_impl;

--- a/src/pattern_matching/myers/myers_impl.rs
+++ b/src/pattern_matching/myers/myers_impl.rs
@@ -47,8 +47,9 @@ where
         self.pv >= (T::max_value() >> 1) && self.mv == T::zero()
     }
 
-    // Adjust the distance of the block ('moving the cursor up in the traceback matrix')
-    // given a range bit mask that specifies which positions should be crossed.
+    // Adjust the distance of the block ('moving the cursor up in the traceback
+    // matrix') given a range bit mask that specifies which positions should be
+    // crossed.
     #[inline]
     pub fn adjust_by_mask(&mut self, mask: T) {
         let p = (self.pv & mask).count_ones();
@@ -69,11 +70,14 @@ where
         }
 
         // not faster:
-        // let diff = ((self.mv & pos_mask) != T::zero()) as isize - ((self.pv & pos_mask) != T::zero()) as isize;
-        // self.dist = D::from_usize(self.dist.to_usize().unwrap().wrapping_add(diff as usize)).unwrap();
+        // let diff = ((self.mv & pos_mask) != T::zero()) as isize - ((self.pv &
+        // pos_mask) != T::zero()) as isize; self.dist =
+        // D::from_usize(self.dist.to_usize().unwrap().wrapping_add(diff as
+        // usize)).unwrap();
     }
 
-    /// This method may be used for performance comparison instead of adjust_by_mask()
+    /// This method may be used for performance comparison instead of
+    /// adjust_by_mask()
     #[inline]
     #[allow(dead_code)]
     pub fn adjust_many(&mut self, pos_mask: T, n: usize) {

--- a/src/pattern_matching/pssm/dnamotif.rs
+++ b/src/pattern_matching/pssm/dnamotif.rs
@@ -23,8 +23,8 @@ impl DNAMotif {
     /// Returns a Motif representing the sequences provided.
     /// # Arguments
     /// * `seqs` - sequences incorporated into motif
-    /// * `pseudos` - array slice with a pseudocount for each monomer;
-    ///    defaults to pssm::DEF_PSEUDO for all if None is supplied
+    /// * `pseudos` - array slice with a pseudocount for each monomer; defaults to pssm::DEF_PSEUDO
+    ///   for all if None is supplied
     ///
     /// FIXME: pseudos should be an array of size MONO_CT, but that
     /// is currently impossible - see

--- a/src/pattern_matching/pssm/mod.rs
+++ b/src/pattern_matching/pssm/mod.rs
@@ -8,8 +8,8 @@
 //! occurrences of this motif.
 //! Complexity: O(n*m) for motif length n and query length m
 //!
-//! The position-specific scoring matrix (PSSM), aka position weight matrix (PWM),
-//! algorithm is implemented for both DNA and amino-acid sequences.
+//! The position-specific scoring matrix (PSSM), aka position weight matrix
+//! (PWM), algorithm is implemented for both DNA and amino-acid sequences.
 //!
 //! # Examples
 //!
@@ -85,8 +85,8 @@ pub trait Motif {
     /// This code is shared by implementations of `from_seqs`
     /// # Arguments
     /// * `seqs` - sequences incorporated into motif
-    /// * `pseudos` - array slice with a pseudocount for each monomer;
-    ///    defaults to DEF_PSEUDO for all if None is supplied
+    /// * `pseudos` - array slice with a pseudocount for each monomer; defaults to DEF_PSEUDO for
+    ///   all if None is supplied
     ///
     /// FIXME: pseudos should be an array of size MONO_CT, but that
     /// is currently unsupported
@@ -131,8 +131,8 @@ pub trait Motif {
         Ok(counts)
     }
 
-    /// Returns the index of given monomer in the scores matrix using the lookup table `LK`
-    /// # Arguments
+    /// Returns the index of given monomer in the scores matrix using the lookup
+    /// table `LK` # Arguments
     /// * `mono` - monomer, eg, b'A' for DNA or b'R' for protein
     /// # Errors
     /// * `Error::InvalidMonomer(mono)` - `mono` wasn't found in the lookup table
@@ -149,9 +149,9 @@ pub trait Motif {
         }
     }
 
-    /// Returns the monomer associated with the given index; the reverse of `lookup`.
-    /// Returns INVALID_MONO if the index isn't associated with a monomer.
-    /// # Arguments
+    /// Returns the monomer associated with the given index; the reverse of
+    /// `lookup`. Returns INVALID_MONO if the index isn't associated with a
+    /// monomer. # Arguments
     /// * `idx` - the index in question
     fn rev_lk(idx: usize) -> u8;
 
@@ -182,8 +182,8 @@ pub trait Motif {
     /// FIXME: this should be replaced with a CTFE ... or maybe just a constant
     fn get_bits() -> f32;
 
-    /// Returns the un-normalized sum of matching bases, useful for comparing matches from
-    /// motifs of different lengths
+    /// Returns the un-normalized sum of matching bases, useful for comparing
+    /// matches from motifs of different lengths
     ///
     /// # Arguments
     /// * `seq_it` - iterator representing the query sequence
@@ -224,10 +224,10 @@ pub trait Motif {
         Ok((best_start, best_score, best_m))
     }
 
-    /// Returns a `ScoredPos` struct representing the best match within the query sequence
-    /// see:
-    ///   MATCHTM: a tool for searching transcription factor binding sites in DNA sequences
-    ///   Nucleic Acids Res. 2003 Jul 1; 31(13): 3576–3579
+    /// Returns a `ScoredPos` struct representing the best match within the
+    /// query sequence see:
+    ///   MATCHTM: a tool for searching transcription factor binding sites in
+    /// DNA sequences   Nucleic Acids Res. 2003 Jul 1; 31(13): 3576–3579
     ///   https://www.ncbi.nlm.nih.gov/pmc/articles/PMC169193/
     ///
     /// # Arguments
@@ -274,8 +274,8 @@ pub trait Motif {
         })
     }
 
-    /// Returns a float representing the information content of a motif; roughly the
-    /// inverse of Shannon Entropy.
+    /// Returns a float representing the information content of a motif; roughly
+    /// the inverse of Shannon Entropy.
     /// Adapted from the information content described here:
     ///    https://en.wikipedia.org/wiki/Sequence_logo#Logo_creation
     fn info_content(&self) -> f32 {

--- a/src/pattern_matching/pssm/protmotif.rs
+++ b/src/pattern_matching/pssm/protmotif.rs
@@ -23,8 +23,8 @@ impl ProtMotif {
     /// Returns a Motif representing the sequences provided.
     /// # Arguments
     /// * `seqs` - sequences incorporated into motif
-    /// * `pseudos` - array slice with a pseudocount for each monomer;
-    ///    defaults to pssm::DEF_PSEUDO for all if None is supplied
+    /// * `pseudos` - array slice with a pseudocount for each monomer; defaults to pssm::DEF_PSEUDO
+    ///   for all if None is supplied
     ///
     /// FIXME: pseudos should be an array of size MONO_CT, but that
     /// is currently impossible - see

--- a/src/pattern_matching/shift_and.rs
+++ b/src/pattern_matching/shift_and.rs
@@ -44,8 +44,8 @@ impl ShiftAnd {
         ShiftAnd { m, masks, accept }
     }
 
-    /// Find all matches of pattern in the given text. Matches are returned as an iterator
-    /// over start positions.
+    /// Find all matches of pattern in the given text. Matches are returned as
+    /// an iterator over start positions.
     pub fn find_all<C, T>(&self, text: T) -> Matches<'_, C, T::IntoIter>
     where
         C: Borrow<u8>,
@@ -59,8 +59,8 @@ impl ShiftAnd {
     }
 }
 
-/// Calculate ShiftAnd masks. This function is called automatically when instantiating
-/// a new ShiftAnd for a given pattern.
+/// Calculate ShiftAnd masks. This function is called automatically when
+/// instantiating a new ShiftAnd for a given pattern.
 pub fn masks<C, P>(pattern: P) -> ([u64; 256], u64)
 where
     C: Borrow<u8>,

--- a/src/pattern_matching/ukkonen.rs
+++ b/src/pattern_matching/ukkonen.rs
@@ -7,10 +7,11 @@
 //! Complexity: O(n * k) on random texts.
 //!
 //! The algorithm finds all matches of a pattern in a text with up to k errors.
-//! Idea is to use dynamic programming to column-wise explore the edit matrix, but to omit
-//! parts of the matrix for which the error exceeds k. To achieve this, a value `lastk` is
-//! maintained that provides the lower feasible boundary of the matrix.
-//! Initially, lastk = min(k, m). In each iteration (over a column), lastk can increase by at most 1.
+//! Idea is to use dynamic programming to column-wise explore the edit matrix,
+//! but to omit parts of the matrix for which the error exceeds k. To achieve
+//! this, a value `lastk` is maintained that provides the lower feasible
+//! boundary of the matrix. Initially, lastk = min(k, m). In each iteration
+//! (over a column), lastk can increase by at most 1.
 //!
 //! # Example
 //!
@@ -60,7 +61,8 @@ where
     }
 
     /// Find all matches between pattern and text with up to k errors.
-    /// Matches are returned as an iterator over pairs of end position and distance.
+    /// Matches are returned as an iterator over pairs of end position and
+    /// distance.
     pub fn find_all_end<'a, C, T>(
         &'a mut self,
         pattern: TextSlice<'a>,
@@ -128,8 +130,8 @@ where
                 );
             }
 
-            // reduce lastk as long as k is exceeded: while lastk can increase by at most 1, it can
-            // decrease more in one iteration.
+            // reduce lastk as long as k is exceeded: while lastk can increase by at most 1,
+            // it can decrease more in one iteration.
             while self.ukkonen.D[col][self.lastk] > self.k {
                 self.lastk -= 1;
             }

--- a/src/seq_analysis/orf.rs
+++ b/src/seq_analysis/orf.rs
@@ -26,8 +26,8 @@
 //!
 //! Right now the only way to check the reverse strand for ORF is to use
 //! the `alphabet::dna::RevComp` struct and to check for both sequences.
-//! But that's not so performance friendly, as the reverse complementation and the ORF research
-//! could go on at the same time.
+//! But that's not so performance friendly, as the reverse complementation and
+//! the ORF research could go on at the same time.
 
 use std::borrow::Borrow;
 use std::collections::VecDeque;
@@ -47,8 +47,8 @@ pub struct Finder {
 }
 
 impl Finder {
-    /// Create a new instance of a finder for the given start and stop codons and the minimum
-    /// length of an ORF.
+    /// Create a new instance of a finder for the given start and stop codons
+    /// and the minimum length of an ORF.
     pub fn new<'a>(
         start_codons: Vec<&'a [u8; 3]>,
         stop_codons: Vec<&'a [u8; 3]>,
@@ -107,7 +107,8 @@ impl State {
     }
 }
 
-/// Iterator over offset, start position, end position and sequence of matched ORFs.
+/// Iterator over offset, start position, end position and sequence of matched
+/// ORFs.
 pub struct Matches<'a, C, T>
 where
     C: Borrow<u8>,

--- a/src/stats/bayesian/mod.rs
+++ b/src/stats/bayesian/mod.rs
@@ -16,11 +16,12 @@ use ordered_float::OrderedFloat;
 use crate::stats::LogProb;
 
 /// For each of the hypothesis tests given as posterior error probabilities
-/// (PEPs, i.e. the posterior probability of the null hypothesis), estimate the FDR
-/// for the case that all null hypotheses with at most this PEP are rejected.
-/// FDR is calculated as presented by Müller, Parmigiani, and Rice,
+/// (PEPs, i.e. the posterior probability of the null hypothesis), estimate the
+/// FDR for the case that all null hypotheses with at most this PEP are
+/// rejected. FDR is calculated as presented by Müller, Parmigiani, and Rice,
 /// "FDR and Bayesian Multiple Comparisons Rules" (July 2006).
-/// Johns Hopkin's University, Dept. of Biostatistics Working Papers. Working Paper 115.
+/// Johns Hopkin's University, Dept. of Biostatistics Working Papers. Working
+/// Paper 115.
 ///
 /// # Returns
 ///

--- a/src/stats/bayesian/model.rs
+++ b/src/stats/bayesian/model.rs
@@ -21,8 +21,9 @@ pub trait Likelihood<Payload = ()> {
     type Event;
     type Data;
 
-    /// Compute likelihood of event given the data. Optionally, the passed payload can be used
-    /// to e.g., cache intermediate results. One payload corresponds to one model instance.
+    /// Compute likelihood of event given the data. Optionally, the passed
+    /// payload can be used to e.g., cache intermediate results. One payload
+    /// corresponds to one model instance.
     fn compute(&self, event: &Self::Event, data: &Self::Data, payload: &mut Payload) -> LogProb;
 }
 

--- a/src/stats/combinatorics.rs
+++ b/src/stats/combinatorics.rs
@@ -8,8 +8,8 @@
 use std::cmp;
 
 /// Calculate the number of combinations when choosing
-/// k elements from n elements without replacement, multiplied by a scaling factor.
-/// Time complexity: O(min(k, n - k))
+/// k elements from n elements without replacement, multiplied by a scaling
+/// factor. Time complexity: O(min(k, n - k))
 ///
 /// # Examples
 /// ```

--- a/src/stats/hmm/mod.rs
+++ b/src/stats/hmm/mod.rs
@@ -63,13 +63,13 @@
 //!
 //! ## Limitations
 //!
-//! Currently, only discrete and single-variate Gaussian continuous HMMs are implemented.
-//! Also, only dense transition matrices are supported.
+//! Currently, only discrete and single-variate Gaussian continuous HMMs are
+//! implemented. Also, only dense transition matrices are supported.
 //!
 //! ## References
 //!
-//! - Rabiner, Lawrence R. "A tutorial on hidden Markov models and selected applications
-//!   in speech recognition." Proceedings of the IEEE 77, no. 2 (1989): 257-286.
+//! - Rabiner, Lawrence R. "A tutorial on hidden Markov models and selected applications in speech
+//!   recognition." Proceedings of the IEEE 77, no. 2 (1989): 257-286.
 
 pub mod errors;
 
@@ -183,17 +183,19 @@ impl Iterator for StateTransitionIter {
 
 /// A trait for Hidden Markov Models (HMM) with generic `Observation` type.
 ///
-/// Rabiner (1989) defines a Hidden Markov Model λ as the tiple (*A*, *B*, π) of transition matrix
-/// *A*, emission probabilities *B*, and initial state distribution π.  This has been generalized
-/// in `Model` such that you implement `transition_prob()`, `observation_prob()`, and
-/// `initial_prob()` (and the other methods; implementation of `transition_prob_idx()` can
-/// optionally be implemented and your implementation of `transition_prob()` can then panic).
+/// Rabiner (1989) defines a Hidden Markov Model λ as the tiple (*A*, *B*, π) of
+/// transition matrix *A*, emission probabilities *B*, and initial state
+/// distribution π.  This has been generalized in `Model` such that you
+/// implement `transition_prob()`, `observation_prob()`, and `initial_prob()`
+/// (and the other methods; implementation of `transition_prob_idx()` can
+/// optionally be implemented and your implementation of `transition_prob()` can
+/// then panic).
 ///
-/// The inference algorithm implementations `viterbi()`, `forward()`, and `backward()` will work
-/// with any implementation.
+/// The inference algorithm implementations `viterbi()`, `forward()`, and
+/// `backward()` will work with any implementation.
 ///
-/// Consequently, this allows for the implementation of HMMs with both discrete and continuous
-/// emission distributions.
+/// Consequently, this allows for the implementation of HMMs with both discrete
+/// and continuous emission distributions.
 pub trait Model<Observation> {
     /// The number of states in the model.
     fn num_states(&self) -> usize;
@@ -207,12 +209,13 @@ pub trait Model<Observation> {
     /// Transition probability between two states `from` and `to`.
     fn transition_prob(&self, from: State, to: State) -> LogProb;
 
-    /// Transition probability between two states `from` and `to` for observation with index
-    /// `_to_idx` (index of `to`).
+    /// Transition probability between two states `from` and `to` for
+    /// observation with index `_to_idx` (index of `to`).
     ///
-    /// This feature comes in handy in several applications of HMMs to biological sequences.
-    /// One prominent one is how XHMM by Fromer et al. (2014) uses the distance between target
-    /// regions for adjusting the transition probabilities.
+    /// This feature comes in handy in several applications of HMMs to
+    /// biological sequences. One prominent one is how XHMM by Fromer et al.
+    /// (2014) uses the distance between target regions for adjusting the
+    /// transition probabilities.
     ///
     /// The default implementation return the result of the position-independent
     /// `transition_prob()`.
@@ -234,7 +237,8 @@ fn viterbi_matrices<O, M: Model<O>>(
 ) -> (Array2<LogProb>, Array2<usize>) {
     // The matrix with probabilities.
     let mut vals = Array2::<LogProb>::zeros((observations.len(), hmm.num_states()));
-    // For each cell in `vals`, a pointer to the row in the previous column (for the traceback).
+    // For each cell in `vals`, a pointer to the row in the previous column (for the
+    // traceback).
     let mut from = Array2::<usize>::zeros((observations.len(), hmm.num_states()));
 
     // Compute matrix.
@@ -303,8 +307,8 @@ fn viterbi_traceback(vals: Array2<LogProb>, from: Array2<usize>) -> (Vec<State>,
     (result, res_prob)
 }
 
-/// Execute Viterbi algorithm on the given slice of `Observation` values to get the maximum a
-/// posteriori (MAP) probability.
+/// Execute Viterbi algorithm on the given slice of `Observation` values to get
+/// the maximum a posteriori (MAP) probability.
 ///
 /// ## Arguments
 ///
@@ -313,8 +317,9 @@ fn viterbi_traceback(vals: Array2<LogProb>, from: Array2<usize>) -> (Vec<State>,
 ///
 /// ## Result
 ///
-/// The resulting pair *(s, p)* is the `Vec<State>` of most probable states given `hmm`
-/// and `observations` as well as the probability (as `LogProb`) of path `s`.
+/// The resulting pair *(s, p)* is the `Vec<State>` of most probable states
+/// given `hmm` and `observations` as well as the probability (as `LogProb`) of
+/// path `s`.
 ///
 /// ## Type Parameters
 ///
@@ -325,8 +330,8 @@ pub fn viterbi<O, M: Model<O>>(hmm: &M, observations: &[O]) -> (Vec<State>, LogP
     viterbi_traceback(vals, from)
 }
 
-/// Execute the forward algorithm and return the forward probabilites as `LogProb` values
-/// and the resulting forward probability.
+/// Execute the forward algorithm and return the forward probabilites as
+/// `LogProb` values and the resulting forward probability.
 ///
 /// ## Arguments
 ///
@@ -335,9 +340,9 @@ pub fn viterbi<O, M: Model<O>>(hmm: &M, observations: &[O]) -> (Vec<State>, LogP
 ///
 /// ## Result
 ///
-/// The resulting pair (*P*, *p*) is the forward probability table (`P[[s, o]]` is the entry
-/// for state `s` and observation `o`) and the overall probability for `observations` (as
-/// `LogProb`).
+/// The resulting pair (*P*, *p*) is the forward probability table (`P[[s, o]]`
+/// is the entry for state `s` and observation `o`) and the overall probability
+/// for `observations` (as `LogProb`).
 ///
 /// ## Type Parameters
 ///
@@ -376,8 +381,8 @@ pub fn forward<O, M: Model<O>>(hmm: &M, observations: &[O]) -> (Array2<LogProb>,
     (vals, prob)
 }
 
-/// Execute the backward algorithm and return the backward probabilities as `LogProb` values
-/// and the resulting backward probability.
+/// Execute the backward algorithm and return the backward probabilities as
+/// `LogProb` values and the resulting backward probability.
 ///
 /// ## Arguments
 ///
@@ -386,9 +391,9 @@ pub fn forward<O, M: Model<O>>(hmm: &M, observations: &[O]) -> (Array2<LogProb>,
 ///
 /// ## Result
 ///
-/// The resulting pair (*P*, *p*) is the backward probability table (`P[[s, o]]` is the entry
-/// for state `s` and observation `o`) and the overall probability for `observations` (as
-/// `LogProb`).
+/// The resulting pair (*P*, *p*) is the backward probability table (`P[[s, o]]`
+/// is the entry for state `s` and observation `o`) and the overall probability
+/// for `observations` (as `LogProb`).
 ///
 /// ## Type Parameters
 ///
@@ -438,34 +443,40 @@ pub fn backward<O, M: Model<O>>(hmm: &M, observations: &[O]) -> (Array2<LogProb>
     (vals, prob)
 }
 
-/// Implementation of Hidden Markov Model with emission values from discrete distributions.
+/// Implementation of Hidden Markov Model with emission values from discrete
+/// distributions.
 pub mod discrete_emission {
     use super::super::{LogProb, Prob};
     use super::*;
 
-    /// Implementation of a `hmm::Model` with emission values from discrete distributions.
+    /// Implementation of a `hmm::Model` with emission values from discrete
+    /// distributions.
     ///
     /// Log-scale probabilities are used for numeric stability.
     ///
-    /// In Rabiner's tutorial, a discrete emission value HMM has `N` states and `M` output symbols.
-    /// The state transition matrix with dimensions `NxN` is `A`, the observation probability
-    /// distribution is the matrix `B` with dimensions `NxM` and the initial state distribution `pi`
+    /// In Rabiner's tutorial, a discrete emission value HMM has `N` states and
+    /// `M` output symbols. The state transition matrix with dimensions
+    /// `NxN` is `A`, the observation probability distribution is the matrix
+    /// `B` with dimensions `NxM` and the initial state distribution `pi`
     /// has length `N`.
     #[derive(Debug, PartialEq)]
     pub struct Model {
         /// The state transition matrix (size `NxN`), `A` in Rabiner's tutorial.
         transition: Array2<LogProb>,
 
-        /// The observation symbol probability distribution (size `NxM`), `B` in Rabiner's tutorial.
+        /// The observation symbol probability distribution (size `NxM`), `B` in
+        /// Rabiner's tutorial.
         observation: Array2<LogProb>,
 
-        /// The initial state distribution (size `N`), `pi` in Rabiner's tutorial.
+        /// The initial state distribution (size `N`), `pi` in Rabiner's
+        /// tutorial.
         initial: Array1<LogProb>,
     }
 
     impl Model {
-        /// Construct new Hidden MarkovModel with the given transition, observation, and initial
-        /// state matrices and vectors already in log-probability space.
+        /// Construct new Hidden MarkovModel with the given transition,
+        /// observation, and initial state matrices and vectors already
+        /// in log-probability space.
         pub fn new(
             transition: Array2<LogProb>,
             observation: Array2<LogProb>,
@@ -492,8 +503,9 @@ pub mod discrete_emission {
             }
         }
 
-        /// Construct new Hidden MarkovModel with the given transition, observation, and initial
-        /// state matrices and vectors already as `Prob` values.
+        /// Construct new Hidden MarkovModel with the given transition,
+        /// observation, and initial state matrices and vectors already
+        /// as `Prob` values.
         pub fn with_prob(
             transition: &Array2<Prob>,
             observation: &Array2<Prob>,
@@ -506,8 +518,9 @@ pub mod discrete_emission {
             )
         }
 
-        /// Construct new Hidden MarkovModel with the given transition, observation, and initial
-        /// state matrices and vectors with probabilities as `f64` values.
+        /// Construct new Hidden MarkovModel with the given transition,
+        /// observation, and initial state matrices and vectors with
+        /// probabilities as `f64` values.
         pub fn with_float(
             transition: &Array2<f64>,
             observation: &Array2<f64>,
@@ -555,13 +568,14 @@ pub mod discrete_emission {
     }
 }
 
-/// Implementation of Hidden Markov Models with emission values from univariate continuous
-/// distributions.
+/// Implementation of Hidden Markov Models with emission values from univariate
+/// continuous distributions.
 pub mod univariate_continuous_emission {
     use super::super::{LogProb, Prob};
     use super::*;
 
-    /// Implementation of a `hmm::Model` with emission values from univariate continuous distributions.
+    /// Implementation of a `hmm::Model` with emission values from univariate
+    /// continuous distributions.
     ///
     /// Log-scale probabilities are used for numeric stability.
     pub struct Model<Dist: Continuous<f64, f64>> {
@@ -571,13 +585,15 @@ pub mod univariate_continuous_emission {
         /// The emission probability distributions.
         observation: Vec<Dist>,
 
-        /// The initial state distribution (size `N`), `pi` in Rabiner's tutorial.
+        /// The initial state distribution (size `N`), `pi` in Rabiner's
+        /// tutorial.
         initial: Array1<LogProb>,
     }
 
     impl<Dist: Continuous<f64, f64>> Model<Dist> {
-        /// Construct new Hidden MarkovModel with the given transition, observation, and initial
-        /// state matrices and vectors already in log-probability space.
+        /// Construct new Hidden MarkovModel with the given transition,
+        /// observation, and initial state matrices and vectors already
+        /// in log-probability space.
         pub fn new(
             transition: Array2<LogProb>,
             observation: Vec<Dist>,
@@ -604,8 +620,9 @@ pub mod univariate_continuous_emission {
             }
         }
 
-        /// Construct new Hidden MarkovModel with the given transition, observation, and initial
-        /// state matrices and vectors already as `Prob` values.
+        /// Construct new Hidden MarkovModel with the given transition,
+        /// observation, and initial state matrices and vectors already
+        /// as `Prob` values.
         pub fn with_prob(
             transition: &Array2<Prob>,
             observation: Vec<Dist>,
@@ -618,8 +635,9 @@ pub mod univariate_continuous_emission {
             )
         }
 
-        /// Construct new Hidden MarkovModel with the given transition, observation, and initial
-        /// state matrices and vectors with probabilities as `f64` values.
+        /// Construct new Hidden MarkovModel with the given transition,
+        /// observation, and initial state matrices and vectors with
+        /// probabilities as `f64` values.
         pub fn with_float(
             transition: &Array2<f64>,
             observation: Vec<Dist>,

--- a/src/stats/pairhmm/mod.rs
+++ b/src/stats/pairhmm/mod.rs
@@ -1,9 +1,9 @@
-//! This module contains the implementation of a classic `PairHMM` as described in
-//! Durbin, R., Eddy, S., Krogh, A., & Mitchison, G. (1998). Biological Sequence Analysis.
-//! Current Topics in Genome Analysis 2008. http://doi.org/10.1017/CBO9780511790492.
-//! It also contains a modified variant `HomopolyPairHMM` with additional homopolymer states suited
-//! for dealing with homopolymer runs in sequencing as often encountered in Oxford Nanopore
-//! sequencing data.
+//! This module contains the implementation of a classic `PairHMM` as described
+//! in Durbin, R., Eddy, S., Krogh, A., & Mitchison, G. (1998). Biological
+//! Sequence Analysis. Current Topics in Genome Analysis 2008. http://doi.org/10.1017/CBO9780511790492.
+//! It also contains a modified variant `HomopolyPairHMM` with additional
+//! homopolymer states suited for dealing with homopolymer runs in sequencing as
+//! often encountered in Oxford Nanopore sequencing data.
 //!
 //! Traits defined in this module apply to both `PairHMM` and `HomopolyPairHMM`.
 //!
@@ -110,8 +110,8 @@ mod pairhmm;
 /// Trait for parametrization of `PairHMM` emission behavior.
 pub trait EmissionParameters {
     /// Emission probability for (x[i], y[j]).
-    /// Returns a tuple with probability and a boolean indicating whether emissions match
-    /// (e.g., are the same DNA alphabet letter).
+    /// Returns a tuple with probability and a boolean indicating whether
+    /// emissions match (e.g., are the same DNA alphabet letter).
     fn prob_emit_xy(&self, i: usize, j: usize) -> XYEmission;
 
     /// Emission probability for (x[i], -).
@@ -156,8 +156,8 @@ pub trait GapParameters {
 /// * global: methods return `false` and `LogProb::ln_zero()`.
 /// * semiglobal: methods return `true` and `LogProb::ln_one()`.
 pub trait StartEndGapParameters {
-    /// Probability to start at x[i]. This can be left unchanged if you use `free_start_gap_x` and
-    /// `free_end_gap_x`.
+    /// Probability to start at x[i]. This can be left unchanged if you use
+    /// `free_start_gap_x` and `free_end_gap_x`.
     #[inline]
     #[allow(unused_variables)]
     fn prob_start_gap_x(&self, i: usize) -> LogProb {

--- a/src/stats/pairhmm/pairhmm.rs
+++ b/src/stats/pairhmm/pairhmm.rs
@@ -3,14 +3,16 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! A pair Hidden Markov Model for calculating the probability that two sequences are related to
-//! each other. Depending on the used parameters, this can, e.g., be used to calculate the
-//! probability that a certain sequencing read comes from a given position in a reference genome.
+//! A pair Hidden Markov Model for calculating the probability that two
+//! sequences are related to each other. Depending on the used parameters, this
+//! can, e.g., be used to calculate the probability that a certain sequencing
+//! read comes from a given position in a reference genome.
 //!
-//! Time complexity: O(n * m) where `n = seq1.len()`, `m = seq2.len()` (or `m = min(seq2.len(), max_edit_dist)` with banding enabled).
-//! Memory complexity: O(m) where `m = seq2.len()`.
-//! Note that if the number of states weren't fixed in this implementation, we would have to include
-//! these in both time and memory complexity above as an additional factor.
+//! Time complexity: O(n * m) where `n = seq1.len()`, `m = seq2.len()` (or `m =
+//! min(seq2.len(), max_edit_dist)` with banding enabled). Memory complexity:
+//! O(m) where `m = seq2.len()`. Note that if the number of states weren't fixed
+//! in this implementation, we would have to include these in both time and
+//! memory complexity above as an additional factor.
 
 use std::cmp;
 use std::mem;
@@ -21,9 +23,9 @@ pub use crate::stats::pairhmm::{
 };
 use crate::stats::LogProb;
 
-/// Fast approximation of sum over the three given proabilities. If the largest is sufficiently
-/// large compared to the others, we just return that instead of computing the full (expensive)
-/// sum.
+/// Fast approximation of sum over the three given proabilities. If the largest
+/// is sufficiently large compared to the others, we just return that instead of
+/// computing the full (expensive) sum.
 #[inline]
 fn ln_sum3_exp_approx(mut p0: LogProb, mut p1: LogProb, mut p2: LogProb) -> LogProb {
     if p1 < p2 {
@@ -42,8 +44,8 @@ fn ln_sum3_exp_approx(mut p0: LogProb, mut p1: LogProb, mut p2: LogProb) -> LogP
 }
 
 /// A pair Hidden Markov Model for comparing sequences x and y as described by
-/// Durbin, R., Eddy, S., Krogh, A., & Mitchison, G. (1998). Biological Sequence Analysis.
-/// Current Topics in Genome Analysis 2008. http://doi.org/10.1017/CBO9780511790492.
+/// Durbin, R., Eddy, S., Krogh, A., & Mitchison, G. (1998). Biological Sequence
+/// Analysis. Current Topics in Genome Analysis 2008. http://doi.org/10.1017/CBO9780511790492.
 #[derive(Debug, Clone)]
 pub struct PairHMM {
     fm: [Vec<LogProb>; 2],
@@ -96,13 +98,15 @@ impl PairHMM {
         }
     }
 
-    /// Calculate the probability of sequence x being related to y via any alignment.
+    /// Calculate the probability of sequence x being related to y via any
+    /// alignment.
     ///
     /// # Arguments
     ///
     /// * `gap_params` - parameters for opening or extending gaps
     /// * `emission_params` - parameters for emission
-    /// * `max_edit_dist` - maximum edit distance to consider; if not `None`, perform banded alignment
+    /// * `max_edit_dist` - maximum edit distance to consider; if not `None`, perform banded
+    ///   alignment
     pub fn prob_related<E, A>(
         &mut self,
         emission_params: &E,
@@ -137,7 +141,8 @@ impl PairHMM {
 
         // iterate over x
         for i in 0..emission_params.len_x() {
-            // allow alignment to start from offset in x (if prob_start_gap_x is set accordingly)
+            // allow alignment to start from offset in x (if prob_start_gap_x is set
+            // accordingly)
             self.fm[prev][0] = self.fm[prev][0].ln_add_exp(alignment_mode.prob_start_gap_x(i));
             if alignment_mode.free_start_gap_x() {
                 self.min_edit_dist[prev][0] = 0;
@@ -145,7 +150,8 @@ impl PairHMM {
 
             let prob_emit_x = emission_params.prob_emit_x(i);
 
-            // TODO: in the case of no gap extensions, we can reduce the number of columns of y that need to be looked at (by cone).
+            // TODO: in the case of no gap extensions, we can reduce the number of columns
+            // of y that need to be looked at (by cone).
             let (j_min, j_max) = (0, emission_params.len_y());
 
             // iterate over y

--- a/src/stats/probs/cdf.rs
+++ b/src/stats/probs/cdf.rs
@@ -3,8 +3,8 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Support for discrete probability distributions in terms of cumulative distribution
-//! functions (CDF).
+//! Support for discrete probability distributions in terms of cumulative
+//! distribution functions (CDF).
 //!
 //! # Examples
 //!
@@ -104,8 +104,9 @@ use ordered_float::OrderedFloat;
 
 use crate::stats::LogProb;
 
-/// An `Entry` associates a `LogProb` with a value on an ordered axis. It can for example be
-/// used to set up probability mass functions or cumulative distribution functions ([CDF](struct.CDF)).
+/// An `Entry` associates a `LogProb` with a value on an ordered axis. It can
+/// for example be used to set up probability mass functions or cumulative
+/// distribution functions ([CDF](struct.CDF)).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Entry<T: Ord> {
     /// A `value` on the ordered axis, which has to have the Trait [`std::cmp::Ord`](https://doc.rust-lang.org/std/cmp/trait.Ord.html) implemented.
@@ -135,7 +136,8 @@ impl<T: Ord> Entry<T> {
     }
 }
 
-/// Implementation of a cumulative distribution function as a vector of `Entry`s.
+/// Implementation of a cumulative distribution function as a vector of
+/// `Entry`s.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CDF<T: Ord> {
     inner: Vec<Entry<T>>,
@@ -143,8 +145,8 @@ pub struct CDF<T: Ord> {
 
 impl<T: Ord> CDF<T> {
     /// Create CDF from a vector representing a probability mass function (PMF).
-    /// The PMF may contain duplicate values the probabilities of which are summed
-    /// during generation of the CDF.
+    /// The PMF may contain duplicate values the probabilities of which are
+    /// summed during generation of the CDF.
     ///
     /// Runtime complexity: O(n log n), where n is the number of `entries`.
     ///
@@ -168,7 +170,8 @@ impl<T: Ord> CDF<T> {
         }
         let mut cdf = CDF { inner };
 
-        // cap at prob=1.0 if there are slightly exceeding values due to numerical issues.
+        // cap at prob=1.0 if there are slightly exceeding values due to numerical
+        // issues.
         for e in &mut cdf.inner {
             e.prob = e.prob.cap_numerical_overshoot(0.00001);
         }
@@ -176,7 +179,8 @@ impl<T: Ord> CDF<T> {
         cdf
     }
 
-    /// Create CDF from iterator. This can be used to replace the values of a CDF.
+    /// Create CDF from iterator. This can be used to replace the values of a
+    /// CDF.
     ///
     /// Runtime complexity: O(n), where n is the number of `entries`.
     ///
@@ -191,7 +195,8 @@ impl<T: Ord> CDF<T> {
 
     /// Reduce CDF by omitting values with zero probability.
     ///
-    /// Runtime complexity: O(n), where n is the number of `value`s with `prob` of zero.
+    /// Runtime complexity: O(n), where n is the number of `value`s with `prob`
+    /// of zero.
     pub fn reduce(self) -> Self {
         let mut inner = Vec::new();
         let mut last = LogProb::ln_zero();
@@ -204,10 +209,11 @@ impl<T: Ord> CDF<T> {
         CDF { inner }
     }
 
-    /// Downsample CDF to n entries. Panics if n <= 1 and returns identity if n is greater
-    /// than the number of entries.
+    /// Downsample CDF to n entries. Panics if n <= 1 and returns identity if n
+    /// is greater than the number of entries.
     ///
-    /// Runtime complexity: O(m), where m is the original number of `Entry`s in `CDF`.
+    /// Runtime complexity: O(m), where m is the original number of `Entry`s in
+    /// `CDF`.
     ///
     /// # Arguments
     ///
@@ -253,8 +259,9 @@ impl<T: Ord> CDF<T> {
 
     /// Get cumulative probability for a given value.
     ///
-    /// If the value is not present, return the probability of the previous value.
-    /// Time complexity: O(log n), where n is the number of `Entry`s in `CDF`.
+    /// If the value is not present, return the probability of the previous
+    /// value. Time complexity: O(log n), where n is the number of `Entry`s
+    /// in `CDF`.
     ///
     /// # Arguments
     ///
@@ -325,10 +332,12 @@ impl<T: Ord> CDF<T> {
         }
     }
 
-    /// Return w%-credible interval. The width w is a float between 0 and 1. Panics otherwise.
-    /// E.g. provide `width=0.95` for the 95% credible interval.
+    /// Return w%-credible interval. The width w is a float between 0 and 1.
+    /// Panics otherwise. E.g. provide `width=0.95` for the 95% credible
+    /// interval.
     ///
-    /// Runtime complexity: O(log n), where n is the number of `Entry`s in `CDF`.
+    /// Runtime complexity: O(log n), where n is the number of `Entry`s in
+    /// `CDF`.
     ///
     /// # Arguments
     ///

--- a/src/stats/probs/mod.rs
+++ b/src/stats/probs/mod.rs
@@ -3,8 +3,9 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Handling log-probabilities. Log probabilities are an important tool to deal with probabilities
-//! in a numerically stable way, in particular when having probabilities close to zero.
+//! Handling log-probabilities. Log probabilities are an important tool to deal
+//! with probabilities in a numerically stable way, in particular when having
+//! probabilities close to zero.
 
 pub mod cdf;
 pub mod errors;
@@ -23,14 +24,16 @@ use crate::utils::FastExp;
 
 pub use self::errors::{Error, Result};
 
-/// A factor to convert log-probabilities to PHRED-scale (phred = p * `LOG_TO_PHRED_FACTOR`).
+/// A factor to convert log-probabilities to PHRED-scale (phred = p *
+/// `LOG_TO_PHRED_FACTOR`).
 const LOG_TO_PHRED_FACTOR: f64 = -4.342_944_819_032_517_5; // -10 * 1 / ln(10)
 
-/// A factor to convert PHRED-scale to log-probabilities (p = phred * `PHRED_TO_LOG_FACTOR`).
+/// A factor to convert PHRED-scale to log-probabilities (p = phred *
+/// `PHRED_TO_LOG_FACTOR`).
 const PHRED_TO_LOG_FACTOR: f64 = -0.230_258_509_299_404_56; // 1 / (-10 * log10(e))
 
-/// Calculate log(1 - p) with p given in log space without loss of precision as described in
-/// http://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf.
+/// Calculate log(1 - p) with p given in log space without loss of precision as
+/// described in http://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf.
 fn ln_1m_exp(p: f64) -> f64 {
     assert!(p <= 0.0);
     if p < -0.693 {
@@ -292,14 +295,16 @@ impl LogProb {
         }
     }
 
-    /// Calculate the cumulative sum of the given probabilities in a numerically stable way (Durbin 1998).
+    /// Calculate the cumulative sum of the given probabilities in a numerically
+    /// stable way (Durbin 1998).
     pub fn ln_cumsum_exp<I: IntoIterator<Item = LogProb>>(probs: I) -> ScanIter<I> {
         probs
             .into_iter()
             .scan(Self::ln_zero(), Self::scan_ln_add_exp)
     }
 
-    /// Integrate numerically stable over given log-space density in the interval [a, b]. Uses the trapezoidal rule with n grid points.
+    /// Integrate numerically stable over given log-space density in the
+    /// interval [a, b]. Uses the trapezoidal rule with n grid points.
     pub fn ln_trapezoidal_integrate_exp<T, D>(mut density: D, a: T, b: T, n: usize) -> LogProb
     where
         T: Copy + Add<Output = T> + Sub<Output = T> + Div<Output = T> + Mul<Output = T> + Float,
@@ -319,7 +324,8 @@ impl LogProb {
         LogProb(*Self::ln_sum_exp(&probs) + width.ln() - (2.0 * (n - 1) as f64).ln())
     }
 
-    /// Integrate numerically stable over given log-space density in the interval [a, b]. Uses Simpson's rule with n (odd) grid points.
+    /// Integrate numerically stable over given log-space density in the
+    /// interval [a, b]. Uses Simpson's rule with n (odd) grid points.
     pub fn ln_simpsons_integrate_exp<T, D>(mut density: D, a: T, b: T, n: usize) -> LogProb
     where
         T: Copy + Add<Output = T> + Sub<Output = T> + Div<Output = T> + Mul<Output = T> + Float,
@@ -333,7 +339,8 @@ impl LogProb {
             .dropping_back(1)
             .map(|(i, v)| {
                 let weight = (2 + (i % 2) * 2) as f64;
-                LogProb(*density(i, v) + weight.ln()) // factors alter between 2 and 4
+                LogProb(*density(i, v) + weight.ln()) // factors alter between 2
+                                                      // and 4
             })
             .collect_vec();
         probs.push(density(0, a));

--- a/src/utils/fastexp.rs
+++ b/src/utils/fastexp.rs
@@ -3,9 +3,9 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! This module provides a trait adding a fast approximation of the exponential function to f64.
-//! This can be very useful if the exact value is not too important, for example when working with
-//! `bio::stats::LogProb`.
+//! This module provides a trait adding a fast approximation of the exponential
+//! function to f64. This can be very useful if the exact value is not too
+//! important, for example when working with `bio::stats::LogProb`.
 
 use num_traits::Float;
 use std::f64;

--- a/src/utils/interval/mod.rs
+++ b/src/utils/interval/mod.rs
@@ -1,4 +1,5 @@
-//! This module defines a newtype `Interval` for `std::ops::Range`, which will panic if `end` < `start`.
+//! This module defines a newtype `Interval` for `std::ops::Range`, which will
+//! panic if `end` < `start`.
 //!
 //! # Examples
 //! Create a new `Interval` given a `Range`.
@@ -28,8 +29,8 @@ use std::ops::{Deref, Range};
 
 pub use self::errors::{Error, Result};
 
-/// An `Interval` wraps the `std::ops::Range` from the stdlib and is defined by a start and end field
-/// where end should be >= start.
+/// An `Interval` wraps the `std::ops::Range` from the stdlib and is defined by
+/// a start and end field where end should be >= start.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Interval<N: Ord + Clone>(Range<N>);
 
@@ -45,7 +46,8 @@ impl<N: Ord + Clone> Interval<N> {
     }
 }
 
-/// Convert a `Range` into an `Interval`. This conversion will panic if the `Range` has end < start
+/// Convert a `Range` into an `Interval`. This conversion will panic if the
+/// `Range` has end < start
 impl<N: Ord + Clone> From<Range<N>> for Interval<N> {
     fn from(r: Range<N>) -> Self {
         match Interval::new(r) {
@@ -55,8 +57,8 @@ impl<N: Ord + Clone> From<Range<N>> for Interval<N> {
     }
 }
 
-/// Convert a reference to a `Range` to an interval by cloning. This conversion will panic if the
-/// `Range` has end < start
+/// Convert a reference to a `Range` to an interval by cloning. This conversion
+/// will panic if the `Range` has end < start
 impl<'a, N: Ord + Clone> From<&'a Range<N>> for Interval<N> {
     fn from(r: &Range<N>) -> Self {
         match Interval::new(r.clone()) {
@@ -66,7 +68,8 @@ impl<'a, N: Ord + Clone> From<&'a Range<N>> for Interval<N> {
     }
 }
 
-/// Use the `Deref` operator to get a reference to `Range` wrapped by the `Interval` newtype.
+/// Use the `Deref` operator to get a reference to `Range` wrapped by the
+/// `Interval` newtype.
 impl<N: Ord + Clone> Deref for Interval<N> {
     type Target = Range<N>;
 

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -14,8 +14,8 @@ pub fn trim_newline(s: &mut String) {
 mod tests {
     use std::ops::Deref;
 
-    /// This function demonstrates the use of the IntoSequenceIterator alias, which takes both
-    /// slices and iterators.
+    /// This function demonstrates the use of the IntoSequenceIterator alias,
+    /// which takes both slices and iterators.
     fn print_sequence<'a, Item: Deref<Target = u8>, T: IntoIterator<Item = Item>>(sequence: T) {
         for c in sequence {
             println!("{}", *c);


### PR DESCRIPTION
The `wrap_comments` option is now available in rustfmt. How about applying it? I added `comment_width = 100` because the default width of lines of code is 100 but the current default for comment lines is 80. ([some advocate setting default `comment_width = 100` before stabilization](https://github.com/rust-lang/rustfmt/issues/3349#issuecomment-622522913))