### PR TITLE
Adds niceties for taking union/intersect/difference on alphabets.

### DIFF
--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -165,13 +165,9 @@ impl Alphabet {
     ///
     /// assert_eq!(intersect_alpha, alphabets::Alphabet::new(b"atcg"));
     /// ```
-    pub fn intersection(self, other: Alphabet) -> Self {
-        let mut new_symbols = BitSet::new();
-        for symbol_to_add in self.symbols.intersection(&other.symbols) {
-            new_symbols.insert(symbol_to_add);
-        }
+    pub fn intersection(&self, other: &Alphabet) -> Self {
         return Alphabet {
-            symbols: new_symbols,
+            symbols: self.symbols.intersection(&other.symbols).collect(),
         };
     }
 
@@ -187,13 +183,9 @@ impl Alphabet {
     ///
     /// assert_eq!(dna_lower, alphabets::Alphabet::new(b"atcg"));
     /// ```
-    pub fn difference(self, other: Alphabet) -> Self {
-        let mut new_symbols = BitSet::new();
-        for symbol_to_add in self.symbols.difference(&other.symbols) {
-            new_symbols.insert(symbol_to_add);
-        }
+    pub fn difference(&self, other: &Alphabet) -> Self {
         return Alphabet {
-            symbols: new_symbols,
+            symbols: self.symbols.difference(&other.symbols).collect(),
         };
     }
 
@@ -209,13 +201,9 @@ impl Alphabet {
     ///
     /// assert_eq!(alpha, alphabets::Alphabet::new(b"ATCG?|"));
     /// ```
-    pub fn union(self, other: Alphabet) -> Self {
-        let mut new_symbols = BitSet::new();
-        for symbol_to_add in self.symbols.union(&other.symbols) {
-            new_symbols.insert(symbol_to_add);
-        }
+    pub fn union(&self, other: &Alphabet) -> Self {
         return Alphabet {
-            symbols: new_symbols,
+            symbols: self.symbols.union(&other.symbols).collect(),
         };
     }
 }

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -152,6 +152,72 @@ impl Alphabet {
     pub fn is_empty(&self) -> bool {
         self.symbols.is_empty()
     }
+
+    /// Return a new alphabet taking the intersect between this and other.
+    ///
+    /// # Example
+    /// ```
+    /// use bio::alphabets;
+    ///
+    /// let alpha_a = alphabets::Alphabet::new(b"acgtACGT");
+    /// let alpha_b = alphabets::Alphabet::new(b"atcgMVP");
+    /// let intersect_alpha = alpha_a.intersection(alpha_b);
+    ///
+    /// assert_eq!(intersect_alpha, alphabets::Alphabet::new(b"atcg"));
+    /// ```
+    pub fn intersection(self, other: Alphabet) -> Self {
+        let mut new_symbols = BitSet::new();
+        for symbol_to_add in self.symbols.intersection(&other.symbols) {
+            new_symbols.insert(symbol_to_add);
+        }
+        return Alphabet {
+            symbols: new_symbols,
+        };
+    }
+
+    /// Return a new alphabet taking the difference between this and other.
+    ///
+    /// # Example
+    /// ```
+    /// use bio::alphabets;
+    ///
+    /// let dna_alphabet = alphabets::Alphabet::new(b"acgtACGT");
+    /// let dna_alphabet_upper = alphabets::Alphabet::new(b"ACGT");
+    /// let dna_lower = dna_alphabet.difference(dna_alphabet_upper);
+    ///
+    /// assert_eq!(dna_lower, alphabets::Alphabet::new(b"atcg"));
+    /// ```
+    pub fn difference(self, other: Alphabet) -> Self {
+        let mut new_symbols = BitSet::new();
+        for symbol_to_add in self.symbols.difference(&other.symbols) {
+            new_symbols.insert(symbol_to_add);
+        }
+        return Alphabet {
+            symbols: new_symbols,
+        };
+    }
+
+    /// Return a new alphabet taking the union between this and other.
+    ///
+    /// # Example
+    /// ```
+    /// use bio::alphabets;
+    ///
+    /// let dna_alphabet = alphabets::Alphabet::new(b"ATCG");
+    /// let tokenize_alpha = alphabets::Alphabet::new(b"?|");
+    /// let alpha = dna_alphabet.union(tokenize_alpha);
+    ///
+    /// assert_eq!(alpha, alphabets::Alphabet::new(b"ATCG?|"));
+    /// ```
+    pub fn union(self, other: Alphabet) -> Self {
+        let mut new_symbols = BitSet::new();
+        for symbol_to_add in self.symbols.union(&other.symbols) {
+            new_symbols.insert(symbol_to_add);
+        }
+        return Alphabet {
+            symbols: new_symbols,
+        };
+    }
 }
 
 /// Tools based on transforming the alphabet symbols to their lexicographical ranks.
@@ -372,6 +438,16 @@ where
             None => None,
         }
     }
+}
+
+/// Returns the english ascii lower case alphabet.
+pub fn english_ascii_lower_alphabet() -> Alphabet {
+    Alphabet::new(&b"abcdefghijklmnopqrstuvwxyz"[..])
+}
+
+/// Returns the english ascii upper case alphabet.
+pub fn english_ascii_upper_alphabet() -> Alphabet {
+    Alphabet::new(&b"ABCDEFGHIJKLMNOPQRSTUVWXYZ"[..])
 }
 
 #[cfg(test)]

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -161,7 +161,7 @@ impl Alphabet {
     ///
     /// let alpha_a = alphabets::Alphabet::new(b"acgtACGT");
     /// let alpha_b = alphabets::Alphabet::new(b"atcgMVP");
-    /// let intersect_alpha = alpha_a.intersection(alpha_b);
+    /// let intersect_alpha = alpha_a.intersection(&alpha_b);
     ///
     /// assert_eq!(intersect_alpha, alphabets::Alphabet::new(b"atcg"));
     /// ```
@@ -179,7 +179,7 @@ impl Alphabet {
     ///
     /// let dna_alphabet = alphabets::Alphabet::new(b"acgtACGT");
     /// let dna_alphabet_upper = alphabets::Alphabet::new(b"ACGT");
-    /// let dna_lower = dna_alphabet.difference(dna_alphabet_upper);
+    /// let dna_lower = dna_alphabet.difference(&dna_alphabet_upper);
     ///
     /// assert_eq!(dna_lower, alphabets::Alphabet::new(b"atcg"));
     /// ```
@@ -197,7 +197,7 @@ impl Alphabet {
     ///
     /// let dna_alphabet = alphabets::Alphabet::new(b"ATCG");
     /// let tokenize_alpha = alphabets::Alphabet::new(b"?|");
-    /// let alpha = dna_alphabet.union(tokenize_alpha);
+    /// let alpha = dna_alphabet.union(&tokenize_alpha);
     ///
     /// assert_eq!(alpha, alphabets::Alphabet::new(b"ATCG?|"));
     /// ```


### PR DESCRIPTION
Adds basic set operations to the alphabet. Also adds upper and lower english alphabets. These together are useful for things like taking the built in protein alphabet, and filtering it to be only upper to reduce the alpha size overall.

Also somewhat newer to rust, so if there's some better idioms to follow, happy to do so.