### PR TITLE
Add from_str impl for gff.

### DIFF
--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -55,7 +55,7 @@ pub enum GffType {
 }
 
 impl FromStr for GffType {
-    type Err = ();
+    type Err = String;
 
     /// Create a GffType from a string.
     ///
@@ -67,7 +67,10 @@ impl FromStr for GffType {
             "gff3" => Ok(GffType::GFF3),
             "gff2" => Ok(GffType::GFF2),
             "gtf2" => Ok(GffType::GTF2),
-            _ => Err(()),
+            _ => Err(format!(
+                "String {} is not a valid GFFType (GFF/GTF format version).",
+                src_str
+            )),
         }
     }
 }
@@ -483,8 +486,11 @@ P0A7B8\tUniProtKB\tChain\t2\t176\t50\t+\t.\tID PRO_0000148105
         let gtf2 = GffType::from_str("gtf2").expect("Error parsing");
         assert_eq!(gtf2, GffType::GTF2);
 
-        let unk = GffType::from_str("unknown");
-        assert!(unk.is_err());
+        let unk = GffType::from_str("unknown").unwrap_err();
+        assert_eq!(
+            unk,
+            "String unknown is not a valid GFFType (GFF/GTF format version)."
+        )
     }
 
     #[test]

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -68,7 +68,7 @@ impl FromStr for GffType {
             "gff2" => Ok(GffType::GFF2),
             "gtf2" => Ok(GffType::GTF2),
             _ => Err(format!(
-                "String {} is not a valid GFFType (GFF/GTF format version).",
+                "String '{}' is not a valid GFFType (GFF/GTF format version).",
                 src_str
             )),
         }
@@ -489,7 +489,7 @@ P0A7B8\tUniProtKB\tChain\t2\t176\t50\t+\t.\tID PRO_0000148105
         let unk = GffType::from_str("unknown").unwrap_err();
         assert_eq!(
             unk,
-            "String unknown is not a valid GFFType (GFF/GTF format version)."
+            "String 'unknown' is not a valid GFFType (GFF/GTF format version)."
         )
     }
 

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -31,6 +31,7 @@ use std::convert::AsRef;
 use std::fs;
 use std::io;
 use std::path::Path;
+use std::str::FromStr;
 
 use bio_types::strand::Strand;
 
@@ -39,7 +40,7 @@ use bio_types::strand::Strand;
 /// We have three format in the GFF family.
 /// The change is in the last field of GFF.
 /// For each type we have key value separator and field separator
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum GffType {
     /// Attribute format is: key1=value; key2=value1,value2
     GFF3,
@@ -51,6 +52,24 @@ pub enum GffType {
     /// second field separates multiple key value pairs, and
     /// third field separates multiple values for the same key
     Any(u8, u8, u8),
+}
+
+impl FromStr for GffType {
+    type Err = ();
+
+    /// Create a GffType from a string.
+    ///
+    /// # Arguments
+    ///
+    /// * `src_str` - The source string to convert to the GffType.
+    fn from_str(src_str: &str) -> Result<Self, Self::Err> {
+        match src_str {
+            "gff3" => Ok(GffType::GFF3),
+            "gff2" => Ok(GffType::GFF2),
+            "gtf2" => Ok(GffType::GTF2),
+            _ => Err(()),
+        }
+    }
 }
 
 impl GffType {
@@ -451,6 +470,21 @@ P0A7B8\tUniProtKB\tChain\t2\t176\t50\t+\t.\tID PRO_0000148105
             assert_eq!(record.frame(), frame[i]);
             assert_eq!(record.attributes(), &attributes[i]);
         }
+    }
+
+    #[test]
+    fn test_gff_type_from_str() {
+        let gff3 = GffType::from_str("gff3").expect("Error parsing");
+        assert_eq!(gff3, GffType::GFF3);
+
+        let gff2 = GffType::from_str("gff2").expect("Error parsing");
+        assert_eq!(gff2, GffType::GFF2);
+
+        let gtf2 = GffType::from_str("gtf2").expect("Error parsing");
+        assert_eq!(gtf2, GffType::GTF2);
+
+        let unk = GffType::from_str("unknown");
+        assert!(unk.is_err());
     }
 
     #[test]


### PR DESCRIPTION
Implements [from_str](https://doc.rust-lang.org/std/str/trait.FromStr.html) for `GffType`, useful to accept an input from a CLI or something and get the appropriate type.