### PR TITLE
Last record of fastq file being incomplete has the possibility to deadlock.

### DIFF
--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -212,6 +212,7 @@ where
                      of 4 lines: header, sequence, separator and \
                      qualities.";
         
+        record.clear();
         self.line_buffer.clear();
         if self.reader.read_line(&mut self.line_buffer)? > 0 { // reader successfully read bytes
             if !self.line_buffer.starts_with('@') {
@@ -259,9 +260,6 @@ where
                     incomplete_msg,
                 ));
             }
-        } else {
-            // mark record as empty in case user reuses prefilled record
-            record.clear();
         }
 
         Ok(())


### PR DESCRIPTION
Consider the following fastq file:
```
@SEQ1
ATGCATGCATGC
+
123456789ABC
@SEQ2
ATGGATGCATGC
+
ABCDEFGHIJKL
@SEQ3
AAAAAAAAAAAA
111111111111
```
This read misses a "+" at the final fastq record and will lead to a deadlock (since the loop expects to find a "+" char when reading from the reader, but nevers since the reader has no characters to read from anymore).

This pull request attempts to fix this problem.
Other potential issues that can arise from this is if the "+" is omitted in the middle of the file. I'm not sure what to do for that case since checking for valid sequences (i.e. a check that all nucleotides are ATGC + the additional other ones that I forgot about) may be too computationally expensive (a compromise could be to assert the character of each line isn't an "@").

Sorry if this has any problems; this is my first pull request.