### PR TITLE
Remove some uses of unsafe from Myers pattern matching and fastexp

### DIFF
--- a/src/pattern_matching/myers/long.rs
+++ b/src/pattern_matching/myers/long.rs
@@ -473,7 +473,7 @@ impl<'a, T: BitVec + 'a> TracebackHandler<'a, T, usize> for LongTracebackHandler
     }
 
     #[inline]
-    fn column_slice(&self) -> &'a [State<T, usize>] {
+    fn column_slice(&self) -> &[State<T, usize>] {
         self.col
     }
 

--- a/src/pattern_matching/myers/simple.rs
+++ b/src/pattern_matching/myers/simple.rs
@@ -272,8 +272,8 @@ where
     }
 
     #[inline]
-    fn column_slice(&self) -> &'a [State<T, T::DistType>] {
-        unsafe { std::slice::from_raw_parts(&self.state, 1) }
+    fn column_slice(&self) -> &[State<T, T::DistType>] {
+        std::slice::from_ref(&self.state)
     }
 
     #[inline]

--- a/src/pattern_matching/myers/traceback.rs
+++ b/src/pattern_matching/myers/traceback.rs
@@ -136,7 +136,7 @@ where
 
     /// Returns a slice containing all blocks of the current traceback column
     /// from top to bottom. Used for debugging only.
-    fn column_slice(&self) -> &'a [State<T, D>];
+    fn column_slice(&self) -> &[State<T, D>];
 
     /// Returns true if topmost position in the traceback matrix has been reached,
     /// meaning that the traceback is complete.

--- a/src/utils/fastexp.rs
+++ b/src/utils/fastexp.rs
@@ -34,21 +34,15 @@ impl FastExp<f64> for f64 {
         if *self > MIN_VAL {
             let mut x = ONEBYLOG2 * self;
 
-            #[repr(C)]
-            union F1 {
-                i: i64,
-                f: f64,
-            }
-            let mut f1 = F1 { i: x as i64 };
 
-            x -= unsafe { f1.i } as f64;
+            let mut bits = x as i64;
+
+            x -= bits as f64;
             let mut f2 = x;
             let mut x_tmp = x;
 
-            unsafe {
-                f1.i += OFFSET_F64;
-                f1.i <<= FRACTION_F64;
-            }
+            bits += OFFSET_F64;
+            bits <<= FRACTION_F64;
 
             f2 *= COEFF_4;
             x_tmp += COEFF_1;
@@ -59,7 +53,7 @@ impl FastExp<f64> for f64 {
             f2 *= x_tmp;
             f2 += COEFF_0;
 
-            unsafe { f1.f * f2 }
+            f64::from_bits(bits as u64) * f2
         } else {
             0.0
         }

--- a/src/utils/fastexp.rs
+++ b/src/utils/fastexp.rs
@@ -34,7 +34,6 @@ impl FastExp<f64> for f64 {
         if *self > MIN_VAL {
             let mut x = ONEBYLOG2 * self;
 
-
             let mut bits = x as i64;
 
             x -= bits as f64;


### PR DESCRIPTION
There's two uses of `unsafe` that aren't necessary for performance
or functionality:

- using a union to convert between raw bits in a f64 floating point
  format and f64 itself, because there's the [safe `f64::from_bits`
  function in std](https://doc.rust-lang.org/std/primitive.f64.html#method.from_bits)
- using from_raw_parts to build a slice `&[T]` from a single &T, because
  there's [the safe `std::slice::from_ref` function](https://doc.rust-lang.org/std/slice/fn.from_ref.html)

The latter flags a minor safety issue: the
ShortTracebackHandler::column_slice method had an incorrect lifetime
in its return value. It was incorrectly suggesting that the returned
slice lived for longer than the `self` value. In particular, code
could write something like (in pseudo-Rust, with named lifetimes of
locals):

```rust
let states: &'outer [State<T, T::DistType>] = ...;
let column: &'outer [State<T, T::DistType>];
{
    let handler = ShortTracebackHandler::new(.., states);
    column = handler.column_slice(); // refers to handler.state
} // handler becomes invalid, as does handler.state

println!("{}", column); // invalid use of reference to handler.state
```

This method is private and explicitly designed for debugging use only,
and so (a) this minor safety issue probably doesn't cause issues in
practice, and (b) the fix doesn't break any existing code.

After this PR, the only two remaining uses of `unsafe` are the following, which are likely important for performance (#229 introduced them and states "Benchmarks are around 1.5 x faster when using unsafe").

https://github.com/rust-bio/rust-bio/blob/480872e819f8f85ab67056cfc2a42e9bf171fdfa/src/pattern_matching/myers/simple.rs#L143-L158