### PR TITLE
Impl SequenceRead for Record adding  'is_empty' implementation

### DIFF
--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -465,7 +465,9 @@ impl SequenceRead for Record {
         self.seq().len()
     }
 
-    fn is_empty(&self) -> bool { self.is_empty() }
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
 }
 
 /// An iterator over the records of a FastQ file.

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -464,6 +464,8 @@ impl SequenceRead for Record {
     fn len(&self) -> usize {
         self.seq().len()
     }
+
+    fn is_empty(&self) -> bool { self.is_empty() }
 }
 
 /// An iterator over the records of a FastQ file.


### PR DESCRIPTION
Hi all,

When trying to compile rust-bio v0.32 I get the following error:

```
error[E0046]: not all trait items implemented, missing: `is_empty`
   --> /home/n10853499/.cargo/registry/src/github.com-1ecc6299db9ec823/bio-0.32.0/src/io/fastq.rs:435:1
    |
435 | impl SequenceRead for Record {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `is_empty` in implementation
    |
    = help: implement the missing item: `fn is_empty(&self) -> bool { todo!() }`
```

When I check out the io::fastq module it is indeed missing is_empty:

```
impl SequenceRead for Record {
    fn name(&self) -> &[u8] {
        self.id.as_bytes()
    }

    fn base(&self, i: usize) -> u8 {
        self.seq()[i]
    }

    fn base_qual(&self, i: usize) -> u8 {
        self.qual()[i]
    }

    fn len(&self) -> usize {
        self.seq().len()
    }
}
```
Compare this to the SequenceRead trait in bio_types 0.9.0 which definitely does have an is_empty function:

```
pub trait SequenceRead {
    fn name(&self) -> &[u8];
    fn base(&self, i: usize) -> u8;
    fn base_qual(&self, i: usize) -> u8;
    fn len(&self) -> usize;
    fn is_empty(&self) -> bool;
}
```

This can be easily fixed by adding the implementation as such:

```
impl SequenceRead for Record {
    fn name(&self) -> &[u8] {
        self.id.as_bytes()
    }

    fn base(&self, i: usize) -> u8 {
        self.seq()[i]
    }

    fn base_qual(&self, i: usize) -> u8 {
        self.qual()[i]
    }

    fn len(&self) -> usize {
        self.seq().len()
    }

    fn is_empty(&self) -> bool {
        self.is_empty()
    }
}
```


Cheers,
Rhys