### PR TITLE
Add substitution matrix scoring documentation

### DIFF
--- a/src/scores/blosum62.rs
+++ b/src/scores/blosum62.rs
@@ -78,6 +78,14 @@ fn lookup(a: u8) -> usize {
     }
 }
 
+/// Return the BLOSUM62 substitution matrix score of [a, b]
+///
+/// # Example
+///
+/// ```
+/// use bio::scores::blosum62;
+/// assert_eq!(blosum62(b'H', b'A'), -2);
+/// ```
 pub fn blosum62(a: u8, b: u8) -> i32 {
     let a = lookup(a);
     let b = lookup(b);

--- a/src/scores/pam120.rs
+++ b/src/scores/pam120.rs
@@ -80,6 +80,14 @@ fn lookup(a: u8) -> usize {
     }
 }
 
+/// Return the PAM120 substitution matrix score of [a, b]
+///
+/// # Example
+///
+/// ```
+/// use bio::scores::pam120;
+/// assert_eq!(pam120(b'H', b'A'), -3);
+/// ```
 pub fn pam120(a: u8, b: u8) -> i32 {
     let a = lookup(a);
     let b = lookup(b);

--- a/src/scores/pam200.rs
+++ b/src/scores/pam200.rs
@@ -80,6 +80,14 @@ fn lookup(a: u8) -> usize {
     }
 }
 
+/// Return the PAM200 substitution matrix score of [a, b]
+///
+/// # Example
+///
+/// ```
+/// use bio::scores::pam200;
+/// assert_eq!(pam200(b'H', b'A'), -2);
+/// ```
 pub fn pam200(a: u8, b: u8) -> i32 {
     let a = lookup(a);
     let b = lookup(b);

--- a/src/scores/pam250.rs
+++ b/src/scores/pam250.rs
@@ -80,6 +80,14 @@ fn lookup(a: u8) -> usize {
     }
 }
 
+/// Return the PAM250 substitution matrix score of [a, b]
+///
+/// # Example
+///
+/// ```
+/// use bio::scores::pam250;
+/// assert_eq!(pam250(b'H', b'A'), -1);
+/// ```
 pub fn pam250(a: u8, b: u8) -> i32 {
     let a = lookup(a);
     let b = lookup(b);

--- a/src/scores/pam40.rs
+++ b/src/scores/pam40.rs
@@ -78,6 +78,14 @@ fn lookup(a: u8) -> usize {
     }
 }
 
+/// Return the PAM40 substitution matrix score of [a, b]
+///
+/// # Example
+///
+/// ```
+/// use bio::scores::pam40;
+/// assert_eq!(pam40(b'H', b'A'), -6);
+/// ```
 pub fn pam40(a: u8, b: u8) -> i32 {
     let a = lookup(a);
     let b = lookup(b);


### PR DESCRIPTION
This PR adds documentation for BLOSUM62, PAM40, PAM120, PAM200, and PAM250 scoring functions.