### PR TITLE
Fix pattern matching subtract with overflow panic

### DIFF
--- a/src/pattern_matching/shift_and.rs
+++ b/src/pattern_matching/shift_and.rs
@@ -99,7 +99,7 @@ where
         for (i, c) in self.text.by_ref() {
             self.active = ((self.active << 1) | 1) & self.shiftand.masks[*c.borrow() as usize];
             if self.active & self.shiftand.accept > 0 {
-                return Some(i - self.shiftand.m + 1);
+                return Some(i + 1 - self.shiftand.m);
             }
         }
 
@@ -118,5 +118,13 @@ mod tests {
         let pattern = b"qnnnannan";
         let shiftand = ShiftAnd::new(pattern);
         assert_eq!(shiftand.find_all(text).collect_vec(), [8]);
+    }
+
+    #[test]
+    fn test_issue_416() {
+        let text_pos_0 = b"CCTTTTTTTTTTTTTTT";
+        let pattern = b"CC";
+        let shiftand = ShiftAnd::new(pattern);
+        assert_eq!(shiftand.find_all(text_pos_0).collect_vec(), [0]);
     }
 }


### PR DESCRIPTION
This changes the order of addition and subtraction to avoid a subtract
with overflow panic that occurred when the pattern was at the beginning
of the text.

Fixes #416.

Edit: this also adds a test case for the issue.