### PR TITLE
Improve fasta::Index useability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# unreleased
+- Improved documentation for FASTA index (@mbhall88)
+
 # [0.33.0] - 2021-03-09
 - Fixed a floating point error in gcn_content (@tedil).
 - Improved error messages in io module (@fxwiegand).

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -107,22 +107,25 @@
 //! Random access to FASTA files is facilitated by [`Index`] and [`IndexedReader`]. The FASTA files
 //! must already be indexed with [`samtools faidx`](https://www.htslib.org/doc/faidx.html).
 //!
-//! In this example, we read in the first 20 bases of the sequence named "chr1".
+//! In this example, we read in the first 10 bases of the sequence named "chr1".
 //!
 //! ```rust
 //! use bio::io::fasta::IndexedReader;
+//! // create dummy files
+//! const FASTA_FILE: &[u8] = b">chr1\nGTAGGCTGAAAA\nCCCC";
+//! const FAI_FILE: &[u8] = b"chr1\t16\t6\t12\t13";
 //!
 //! let seq_name = "chr1";
 //! let start: u64 = 0;  // start is 0-based, inclusive
-//! let stop: u64 = 20;  // stop is 0-based, exclusive
-//! let path = std::path::PathBuf::from("in.fa");  // in.fa.fai must exist
+//! let stop: u64 = 10;  // stop is 0-based, exclusive
 //! // load the index
-//! let mut faidx = IndexedReader::from_file(&path).expect("Couldn't open FASTA index");
+//! let mut faidx = IndexedReader::new(std::io::Cursor::new(FASTA_FILE), FAI_FILE).unwrap();
 //! // move the pointer in the index to the desired sequence and interval
 //! faidx.fetch(seq_name, start, stop).expect("Couldn't fetch interval");
 //! // read the subsequence defined by the interval into a vector
-//! let mut seq: Vec<u8> = vec![];
-//! faidx.read(&mut seq);
+//! let mut seq = Vec::new();
+//! faidx.read(&mut seq).expect("Couldn't read the interval");
+//! assert_eq!(seq, b"GTAGGCTGAA");
 //! ```
 //!
 
@@ -392,13 +395,21 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
     ///
     /// ```rust
     /// use bio::io::fasta::IndexedReader;
+    /// // create dummy files
+    /// const FASTA_FILE: &[u8] = b">chr1\nGTAGGCTGAAAA\nCCCC";
+    /// const FAI_FILE: &[u8] = b"chr1\t16\t6\t12\t13";
     ///
-    /// // indexed FASTA file
-    /// let path = std::path::PathBuf::from("in.fa");
-    /// let mut faidx = IndexedReader::from_file(&path).expect("Couldn't open FASTA index");
-    /// faidx.fetch("chrom1", 5, 10).expect("Couldn't fetch interval");
-    /// let mut seq: Vec<u8> = vec![];
-    /// faidx.read(&mut seq);
+    /// let seq_name = "chr1";
+    /// let start: u64 = 0;  // start is 0-based, inclusive
+    /// let stop: u64 = 10;  // stop is 0-based, exclusive
+    /// // load the index
+    /// let mut faidx = IndexedReader::new(std::io::Cursor::new(FASTA_FILE), FAI_FILE).unwrap();
+    /// // move the pointer in the index to the desired sequence and interval
+    /// faidx.fetch(seq_name, start, stop).expect("Couldn't fetch interval");
+    /// // read the subsequence defined by the interval into a vector
+    /// let mut seq = Vec::new();
+    /// faidx.read(&mut seq).expect("Couldn't read the interval");
+    /// assert_eq!(seq, b"GTAGGCTGAA");
     /// ```
     ///
     /// # Errors
@@ -420,13 +431,21 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
     ///
     /// ```rust
     /// use bio::io::fasta::IndexedReader;
+    /// // create dummy files
+    /// const FASTA_FILE: &[u8] = b">chr1\nGTAGGCTGAAAA\nCCCC";
+    /// const FAI_FILE: &[u8] = b"chr1\t16\t6\t12\t13";
     ///
-    /// // indexed FASTA file
-    /// let path = std::path::PathBuf::from("in.fa");
-    /// let mut faidx = IndexedReader::from_file(&path).expect("Couldn't open FASTA index");
-    /// faidx.fetch_by_rid(0, 5, 10).expect("Couldn't fetch interval");
-    /// let mut seq: Vec<u8> = vec![];
-    /// faidx.read(&mut seq);
+    /// let rid: usize = 0;
+    /// let start: u64 = 0;  // start is 0-based, inclusive
+    /// let stop: u64 = 10;  // stop is 0-based, exclusive
+    /// // load the index
+    /// let mut faidx = IndexedReader::new(std::io::Cursor::new(FASTA_FILE), FAI_FILE).unwrap();
+    /// // move the pointer in the index to the desired sequence and interval
+    /// faidx.fetch_by_rid(rid, start, stop).expect("Couldn't fetch interval");
+    /// // read the subsequence defined by the interval into a vector
+    /// let mut seq = Vec::new();
+    /// faidx.read(&mut seq).expect("Couldn't read the interval");
+    /// assert_eq!(seq, b"GTAGGCTGAA");
     /// ```
     ///
     /// # Errors

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -389,7 +389,25 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
     }
 
     /// Fetch an interval from the sequence with the given record index for reading.
-    /// (stop position is exclusive).
+    ///
+    /// `start` and `stop` are 0-based and `stop` is exclusive - i.e. `[start, stop)`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bio::io::fasta::IndexedReader;
+    ///
+    /// // indexed FASTA file
+    /// let path = std::path::PathBuf::from("in.fa");
+    /// let mut faidx = IndexedReader::from_file(&path).expect("Couldn't open FASTA index");
+    /// faidx.fetch_by_rid(0, 5, 10).expect("Couldn't fetch interval");
+    /// let mut seq: Vec<u8> = vec![];
+    /// faidx.read(&mut seq);
+    /// ```
+    ///
+    /// # Errors
+    /// If `rid` does not exist within the index.
+    ///
     pub fn fetch_by_rid(&mut self, rid: usize, start: u64, stop: u64) -> io::Result<()> {
         let idx = self.idx_by_rid(rid)?;
         self.start = Some(start);

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -101,6 +101,30 @@
 //!     }
 //! }
 //! ```
+//!
+//! ## Index
+//!
+//! Random access to FASTA files is facilitated by [`Index`] and [`IndexedReader`]. The FASTA files
+//! must already be indexed with [`samtools faidx`](https://www.htslib.org/doc/faidx.html).
+//!
+//! In this example, we read in the first 20 bases of the sequence named "chr1".
+//!
+//! ```rust
+//! use bio::io::fasta::IndexedReader;
+//!
+//! let seq_name = "chr1";
+//! let start: u64 = 0;  // start is 0-based, inclusive
+//! let stop: u64 = 20;  // stop is 0-based, exclusive
+//! let path = std::path::PathBuf::from("in.fa");  // in.fa.fai must exist
+//! // load the index
+//! let mut faidx = IndexedReader::from_file(&path).expect("Couldn't open FASTA index");
+//! // move the pointer in the index to the desired sequence and interval
+//! faidx.fetch(seq_name, start, stop).expect("Couldn't fetch interval");
+//! // read the subsequence defined by the interval into a vector
+//! let mut seq: Vec<u8> = vec![];
+//! faidx.read(&mut seq);
+//! ```
+//!
 
 use std::cmp::min;
 use std::collections;

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -361,7 +361,25 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
     }
 
     /// Fetch an interval from the sequence with the given name for reading.
-    /// (stop position is exclusive).
+    ///
+    /// `start` and `stop` are 0-based and `stop` is exclusive - i.e. `[start, stop)`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bio::io::fasta::IndexedReader;
+    ///
+    /// // indexed FASTA file
+    /// let path = std::path::PathBuf::from("in.fa");
+    /// let mut faidx = IndexedReader::from_file(&path).expect("Couldn't open FASTA index");
+    /// faidx.fetch("chrom1", 5, 10).expect("Couldn't fetch interval");
+    /// let mut seq: Vec<u8> = vec![];
+    /// faidx.read(&mut seq);
+    /// ```
+    ///
+    /// # Errors
+    /// If the `seq_name` does not exist within the index.
+    ///
     pub fn fetch(&mut self, seq_name: &str, start: u64, stop: u64) -> io::Result<()> {
         let idx = self.idx(seq_name)?;
         self.start = Some(start);

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -3,11 +3,10 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! GFF3 format reading and writing.
+//! [GFF3] format reading and writing. [GFF2] is currently not supported.
 //!
-//! GFF2 definition : http://gmod.org/wiki/GFF2#The_GFF2_File_Format (not yet support)
-//! GTF2 definition : http://mblab.wustl.edu/GTF2.html (not yet support)
-//! GFF3 definition : http://gmod.org/wiki/GFF3#GFF3_Format
+//! [GFF2]: http://gmod.org/wiki/GFF2
+//! [GFF3]: http://gmod.org/wiki/GFF3#GFF3_Format
 //!
 //! # Example
 //!

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -5,7 +5,8 @@
 
 //! [GFF3] format reading and writing. [GFF2] is currently not supported.
 //!
-//! [GFF2]: http://gmod.org/wiki/GFF2
+//! [GFF2]: http://gmod.org/wiki/GFF2 (not supported)
+//! [GTF2]: http://mblab.wustl.edu/GTF2.html (not supported)
 //! [GFF3]: http://gmod.org/wiki/GFF3#GFF3_Format
 //!
 //! # Example


### PR DESCRIPTION
This PR improves (some) documentation for the FASTA index module [closes #422 ].

It (may) also makes some private methods and struct public [#421]. (I will wait to see what the discussion on #421 concludes as to whether to add this to the PR)