### PR TITLE
Allow user to control size of reading and writting buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,4 @@ features = ["stable_graph"]
 [dev-dependencies]
 proptest = "0.10"
 tempfile = "3.1.0"
+rand = "0.8.3"

--- a/benches/fasta_buffer_size.rs
+++ b/benches/fasta_buffer_size.rs
@@ -1,0 +1,140 @@
+#![feature(test)]
+
+extern crate test;
+
+use test::Bencher;
+
+use bio::io;
+
+use std::io::Seek;
+use std::io::Write;
+
+use rand::SeedableRng;
+
+const NUCS: [u8; 4] = [b'A', b'C', b'T', b'G'];
+
+fn random_seq<RNG>(length: usize, rng: &mut RNG) -> Vec<u8>
+where
+    RNG: rand::Rng,
+{
+    (0..length).map(|_| NUCS[rng.gen_range(0..=3)]).collect()
+}
+
+fn write_sequence(file: &mut std::fs::File, seed: u64) {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    for i in 0..1000 {
+        writeln!(
+            file,
+            ">{}\n{}",
+            i,
+            String::from_utf8(random_seq(300, &mut rng)).unwrap()
+        )
+        .unwrap();
+    }
+}
+
+mod fasta_buffer {
+    use super::*;
+
+    #[bench]
+    fn default(b: &mut Bencher) {
+        let mut tempfile = tempfile::tempfile().unwrap();
+
+        write_sequence(&mut tempfile, 42);
+
+        b.iter(|| {
+            tempfile.seek(std::io::SeekFrom::Start(0)).unwrap();
+            io::fasta::Reader::new(&mut tempfile)
+                .records()
+                .for_each(|_| ())
+        });
+    }
+
+    #[bench]
+    fn wrapped_default(b: &mut Bencher) {
+        let mut tempfile = tempfile::tempfile().unwrap();
+
+        write_sequence(&mut tempfile, 42);
+
+        b.iter(|| {
+            tempfile.seek(std::io::SeekFrom::Start(0)).unwrap();
+            io::fasta::Reader::new(std::io::BufReader::new(&mut tempfile))
+                .records()
+                .for_each(|_| ())
+        });
+    }
+
+    #[bench]
+    fn capacity_default(b: &mut Bencher) {
+        let mut tempfile = tempfile::tempfile().unwrap();
+
+        write_sequence(&mut tempfile, 42);
+
+        b.iter(|| {
+            tempfile.seek(std::io::SeekFrom::Start(0)).unwrap();
+            io::fasta::Reader::with_capacity(8192, &mut tempfile)
+                .records()
+                .for_each(|_| ())
+        });
+    }
+
+    #[bench]
+    fn bufreader_default(b: &mut Bencher) {
+        let mut tempfile = tempfile::tempfile().unwrap();
+
+        write_sequence(&mut tempfile, 42);
+
+        b.iter(|| {
+            tempfile.seek(std::io::SeekFrom::Start(0)).unwrap();
+            io::fasta::Reader::from_bufreader(std::io::BufReader::new(&mut tempfile))
+                .records()
+                .for_each(|_| ())
+        });
+    }
+
+    #[bench]
+    fn wrapped_32768(b: &mut Bencher) {
+        let mut tempfile = tempfile::tempfile().unwrap();
+
+        write_sequence(&mut tempfile, 42);
+
+        b.iter(|| {
+            tempfile.seek(std::io::SeekFrom::Start(0)).unwrap();
+            io::fasta::Reader::new(std::io::BufReader::with_capacity(32768, &mut tempfile))
+                .records()
+                .for_each(|_| ())
+        });
+    }
+
+    #[bench]
+    fn capacity_32768(b: &mut Bencher) {
+        let mut tempfile = tempfile::tempfile().unwrap();
+
+        write_sequence(&mut tempfile, 42);
+
+        b.iter(|| {
+            tempfile.seek(std::io::SeekFrom::Start(0)).unwrap();
+            io::fasta::Reader::with_capacity(32768, &mut tempfile)
+                .records()
+                .for_each(|_| ())
+        });
+    }
+
+    #[bench]
+    fn bufreader_32768(b: &mut Bencher) {
+        let mut tempfile = tempfile::tempfile().unwrap();
+
+        write_sequence(&mut tempfile, 42);
+
+        b.iter(|| {
+            tempfile.seek(std::io::SeekFrom::Start(0)).unwrap();
+            io::fasta::Reader::from_bufreader(std::io::BufReader::with_capacity(
+                32768,
+                &mut tempfile,
+            ))
+            .records()
+            .for_each(|_| ())
+        });
+    }
+}

--- a/benches/fasta_buffer_size.rs
+++ b/benches/fasta_buffer_size.rs
@@ -4,7 +4,7 @@ extern crate test;
 
 use test::Bencher;
 
-use bio::io;
+use bio::io::fasta;
 
 use std::io::Seek;
 use std::io::Write;
@@ -35,6 +35,8 @@ fn write_sequence(file: &mut std::fs::File, seed: u64) {
 }
 
 mod fasta_buffer {
+    use std::io;
+
     use super::*;
 
     #[bench]
@@ -44,10 +46,8 @@ mod fasta_buffer {
         write_sequence(&mut tempfile, 42);
 
         b.iter(|| {
-            tempfile.seek(std::io::SeekFrom::Start(0)).unwrap();
-            io::fasta::Reader::new(&mut tempfile)
-                .records()
-                .for_each(|_| ())
+            tempfile.seek(io::SeekFrom::Start(0)).unwrap();
+            fasta::Reader::new(&mut tempfile).records().for_each(|_| ())
         });
     }
 
@@ -58,8 +58,8 @@ mod fasta_buffer {
         write_sequence(&mut tempfile, 42);
 
         b.iter(|| {
-            tempfile.seek(std::io::SeekFrom::Start(0)).unwrap();
-            io::fasta::Reader::new(std::io::BufReader::new(&mut tempfile))
+            tempfile.seek(io::SeekFrom::Start(0)).unwrap();
+            fasta::Reader::new(io::BufReader::new(&mut tempfile))
                 .records()
                 .for_each(|_| ())
         });
@@ -72,22 +72,23 @@ mod fasta_buffer {
         write_sequence(&mut tempfile, 42);
 
         b.iter(|| {
-            tempfile.seek(std::io::SeekFrom::Start(0)).unwrap();
-            io::fasta::Reader::with_capacity(8192, &mut tempfile)
+            tempfile.seek(io::SeekFrom::Start(0)).unwrap();
+            fasta::Reader::with_capacity(8192, &mut tempfile)
                 .records()
                 .for_each(|_| ())
         });
     }
 
     #[bench]
-    fn bufreader_default(b: &mut Bencher) {
+    fn bufread_default(b: &mut Bencher) {
         let mut tempfile = tempfile::tempfile().unwrap();
 
         write_sequence(&mut tempfile, 42);
 
         b.iter(|| {
-            tempfile.seek(std::io::SeekFrom::Start(0)).unwrap();
-            io::fasta::Reader::from_bufreader(std::io::BufReader::new(&mut tempfile))
+            tempfile.seek(io::SeekFrom::Start(0)).unwrap();
+            let buffer = io::BufReader::new(&mut tempfile);
+            fasta::Reader::from_bufread(buffer)
                 .records()
                 .for_each(|_| ())
         });
@@ -100,8 +101,8 @@ mod fasta_buffer {
         write_sequence(&mut tempfile, 42);
 
         b.iter(|| {
-            tempfile.seek(std::io::SeekFrom::Start(0)).unwrap();
-            io::fasta::Reader::new(std::io::BufReader::with_capacity(32768, &mut tempfile))
+            tempfile.seek(io::SeekFrom::Start(0)).unwrap();
+            fasta::Reader::new(io::BufReader::with_capacity(32768, &mut tempfile))
                 .records()
                 .for_each(|_| ())
         });
@@ -114,27 +115,25 @@ mod fasta_buffer {
         write_sequence(&mut tempfile, 42);
 
         b.iter(|| {
-            tempfile.seek(std::io::SeekFrom::Start(0)).unwrap();
-            io::fasta::Reader::with_capacity(32768, &mut tempfile)
+            tempfile.seek(io::SeekFrom::Start(0)).unwrap();
+            fasta::Reader::with_capacity(32768, &mut tempfile)
                 .records()
                 .for_each(|_| ())
         });
     }
 
     #[bench]
-    fn bufreader_32768(b: &mut Bencher) {
+    fn bufread_32768(b: &mut Bencher) {
         let mut tempfile = tempfile::tempfile().unwrap();
 
         write_sequence(&mut tempfile, 42);
 
         b.iter(|| {
-            tempfile.seek(std::io::SeekFrom::Start(0)).unwrap();
-            io::fasta::Reader::from_bufreader(std::io::BufReader::with_capacity(
-                32768,
-                &mut tempfile,
-            ))
-            .records()
-            .for_each(|_| ())
+            tempfile.seek(io::SeekFrom::Start(0)).unwrap();
+            let buffer = io::BufReader::with_capacity(32768, &mut tempfile);
+            fasta::Reader::from_bufread(buffer)
+                .records()
+                .for_each(|_| ())
         });
     }
 }

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -223,7 +223,7 @@ impl<B> Reader<B>
 where
     B: io::BufRead,
 {
-    /// Create a new Fasta reader given an object that implement `io::BufRead`.
+    /// Create a new Fasta reader with an object that implements `io::BufRead`.
     ///
     /// # Example
     /// ```rust
@@ -233,7 +233,7 @@ where
     /// # const fasta_file: &'static [u8] = b">id desc
     /// # AAAA
     /// # ";
-    /// let buffer = io::Bufreader::with_capacity(16384, fasta_file)
+    /// let buffer = io::BufReader::with_capacity(16384, fasta_file);
     /// let reader = Reader::from_bufread(buffer);
     /// # }
     /// ```

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -177,7 +177,7 @@ impl<B> Reader<B>
 where
     B: io::BufRead,
 {
-    /// Create a new Fasta reader given a `io::BufReader`.
+    ///  Create a new Fastq reader with an object that implements `io::BufReader`.
     pub fn from_bufread(bufreader: B) -> Self {
         Reader {
             reader: bufreader,


### PR DESCRIPTION
This pull request try to solve issue #258.

I add constructor `from_file_with_capacity`, `with_capacity`, `from_bufreader` to `Reader` and `with_capacity`, `to_file_with_capacity` to `Writer`.

I also add a benchmark to demonstrate, this constructor is more efficient than build a `BufReader` and give it to `new` constructor. Benchmark run on my XPS13 with SSD.

```
test fasta_buffer::default           ... bench:     151,396 ns/iter (+/- 1,561)
test fasta_buffer::wrapped_default   ... bench:     145,718 ns/iter (+/- 2,595)
test fasta_buffer::capacity_default  ... bench:     139,736 ns/iter (+/- 27,226)
test fasta_buffer::bufreader_default ... bench:     138,331 ns/iter (+/- 2,336)

test fasta_buffer::wrapped_32768     ... bench:     147,414 ns/iter (+/- 1,752)
test fasta_buffer::capacity_32768    ... bench:     139,956 ns/iter (+/- 30,602)
test fasta_buffer::bufreader_32768   ... bench:     138,981 ns/iter (+/- 19,455)
```

Should I replace`from_bufreader` by `from_bufread` to be more generic ? But this change require a modification of structure `Reader` and `Writer` and maybe break compatibility, I'm not sure it's a good idea.

Todo list:
----------------------------------
- [X] fasta
- [x] fastq

