### PR TITLE
Support dealing with fasta and fastq files interchangably

### DIFF
--- a/src/io/fastx.rs
+++ b/src/io/fastx.rs
@@ -154,7 +154,7 @@ pub fn get_type<R: io::Read + io::Seek>(reader: &mut R) -> Result<FastxType, io:
         _ => {
             let msg = format!("first character was '{}' which is not a valid first character for a fastq or fasta file", first[0]);
             Err(io::Error::new(io::ErrorKind::InvalidData, msg))
-        },
+        }
     }
 }
 

--- a/src/io/fastx.rs
+++ b/src/io/fastx.rs
@@ -1,0 +1,225 @@
+// Copyright 2021 Todd Morse.
+// Licensed under the MIT license (http://opensource.org/licenses/MIT)
+// This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Traits and utilities to read and write files in the FASTA and FASTQ format interchangably
+//!
+//! Files in the FASTA and FASTQ format have several common fields: ID, Sequence, and Description.
+//! These utilities can be used to implement algorithms that only require these fields for files
+//! that are in either format.
+//!
+//! # Example
+//!
+//! ## Common Statistics
+//!
+//! In this example, we implement a count_bases function that for supports both the FASTA and FASTQ
+//! format.
+//!
+//! ```
+//! use bio::io::{fasta, fastq, fastx};
+//! use std::io;
+//!
+//! fn count_bases<T, E, I>(mut records: I) -> Result<usize, E>
+//! where T: fastx::Record,
+//!     E: std::error::Error,
+//!     I: Iterator<Item = Result<T, E>> {
+//!     let mut nb_bases = 0;
+//!     for result in records {
+//!         let record = result?;
+//!         nb_bases += record.seq().len();
+//!     }
+//!     Ok(nb_bases)
+//! }
+//!
+//! let mut raw_reader = io::Cursor::new(b">id desc
+//! ACTG
+//! ");
+//!
+//! match fastx::get_type(&mut raw_reader) {
+//!     Ok(fastx::FastxType::Fasta) => {
+//!         let mut reader = fasta::Reader::new(raw_reader);
+//!         let nb_bases = count_bases(reader.records()).unwrap();
+//!         println!("Number of bases: {}", nb_bases);
+//!     },
+//!     Ok(fastx::FastxType::Fastq) => {
+//!         let mut reader = fastq::Reader::new(raw_reader);
+//!         let nb_bases = count_bases(reader.records()).unwrap();
+//!         println!("Number of bases: {}", nb_bases);
+//!     },
+//!     _ => println!("Encountered an error"),
+//! }
+//! ```
+//!
+//! ## Filtration
+//!
+//! In this example, we define an at_least_n_bases function that can filter fasta or fastq
+//! records based on their sequence lengths. It works seemlessly with fasta records as if
+//! it was implemented just on fasta records. In a realistic scenario this function might be
+//! defined in a library so callers could use it with both fasta and fastq files as needed.
+//!
+//! ```
+//! use bio::io::{fasta, fastq, fastx};
+//! use std::io;
+//!
+//! fn at_least_n_bases<T, E, I>(mut records: I, n: usize) -> impl Iterator<Item = Result<T, E>>
+//! where T: fastx::Record,
+//!     E: std::error::Error,
+//!     I: Iterator<Item = Result<T, E>> {
+//!     records.filter(move |rr| match rr {
+//!         Ok(r) => r.seq().len() > n,
+//!         _ => true,
+//!     })
+//! }
+//!
+//! let mut reader = fasta::Reader::new(io::stdin());
+//! let mut writer = fasta::Writer::new(io::stdout());
+//!
+//! for record in at_least_n_bases(reader.records(), 10) {
+//!     writer.write_record(&record.unwrap());
+//! }
+//! ```
+//!
+use std::io;
+use std::io::SeekFrom;
+
+use crate::utils::TextSlice;
+
+pub trait Record {
+    fn is_empty(&self) -> bool;
+    fn check(&self) -> Result<(), &str>;
+    fn id(&self) -> &str;
+    fn desc(&self) -> Option<&str>;
+    fn seq(&self) -> TextSlice<'_>;
+}
+
+impl Record for super::fasta::Record {
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
+
+    fn check(&self) -> Result<(), &str> {
+        self.check()
+    }
+
+    fn id(&self) -> &str {
+        self.id()
+    }
+
+    fn desc(&self) -> Option<&str> {
+        self.desc()
+    }
+
+    fn seq(&self) -> TextSlice<'_> {
+        self.seq()
+    }
+}
+
+impl Record for super::fastq::Record {
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
+
+    fn check(&self) -> Result<(), &str> {
+        self.check()
+    }
+
+    fn id(&self) -> &str {
+        self.id()
+    }
+
+    fn desc(&self) -> Option<&str> {
+        self.desc()
+    }
+
+    fn seq(&self) -> TextSlice<'_> {
+        self.seq()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum FastxType {
+    Fastq,
+    Fasta,
+}
+
+pub fn get_type<R: io::Read + io::Seek>(reader: &mut R) -> Result<FastxType, io::Error> {
+    let mut first = [0];
+    reader.read_exact(&mut first)?;
+    reader.seek(SeekFrom::Current(-1))?;
+
+    match first[0] as char {
+        '>' => Ok(FastxType::Fasta),
+        '@' => Ok(FastxType::Fastq),
+        _ => {
+            let msg = format!("first character was '{}' which is not a valid first character for a fastq or fasta file", first[0]);
+            Err(io::Error::new(io::ErrorKind::InvalidData, msg))
+        },
+    }
+}
+
+impl std::fmt::Display for FastxType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            FastxType::Fasta => "fasta",
+            FastxType::Fastq => "fastq",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Cursor;
+
+    const FASTA_FILE: &[u8] = b">id desc
+ACCGTAGGCTGA
+CCGTAGGCTGAA
+CGTAGGCTGAAA
+GTAGGCTGAAAA
+CCCC
+>id2
+ATTGTTGTTTTA
+ATTGTTGTTTTA
+ATTGTTGTTTTA
+GGGG
+";
+
+    const FASTQ_FILE: &[u8] = b"@id desc
+ACCGTAGGCTGA
++
+IIIIIIJJJJJJ
+";
+
+    #[test]
+    fn test_get_type_fasta() {
+        let mut read_seeker = Cursor::new(FASTA_FILE);
+        let fastx_type = get_type(&mut read_seeker).unwrap();
+        assert_eq!(FastxType::Fasta, fastx_type);
+        assert_eq!(read_seeker.position(), 0);
+    }
+
+    #[test]
+    fn test_get_type_fastq() {
+        let mut read_seeker = Cursor::new(FASTQ_FILE);
+        let fastq_type = get_type(&mut read_seeker).unwrap();
+        assert_eq!(FastxType::Fastq, fastq_type);
+        assert_eq!(read_seeker.position(), 0);
+    }
+
+    #[test]
+    fn test_get_type_empty() {
+        let mut read_seeker = Cursor::new(b"");
+        let e = get_type(&mut read_seeker).unwrap_err();
+        assert_eq!(io::ErrorKind::UnexpectedEof, e.kind());
+    }
+
+    #[test]
+    fn test_get_type_invalid() {
+        let mut read_seeker = Cursor::new(b"*");
+        let e = get_type(&mut read_seeker).unwrap_err();
+        assert_eq!(io::ErrorKind::InvalidData, e.kind());
+    }
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -3,6 +3,7 @@
 pub mod bed;
 pub mod fasta;
 pub mod fastq;
+pub mod fastx;
 pub mod gff;
 #[cfg(feature = "phylogeny")]
 pub mod newick;


### PR DESCRIPTION
For my very small project I implemented a FASTA/FASTQ deduplicator based on sequences. This was de-duplicating FASTA/FASTQ files based entirely on sequence information so I wanted to support both formats. I thought the ability to treat these interchangeably might be helpful upstream. Right now this is just the basics but I'd be happy to add more like readers and writers if it would be appreciated. They take some wrangling with the type system so it'd be a bit more effort.

This adds the functionality in a backwards compatible way, users won't need this trait in scope to use the normal FASTA/FASTX implementations. To achieve this I needed to do a weird function pass-through thing. On balance I think this is the best way and I assume the compiler will remove any abstraction costs here.

I have some usage examples that use this trait and the type system so you can still use this with static dispatch so this abstraction can be 0 cost.

Statistics:

```Rust
use bio::io::{fasta, fastq, fastx};
use std::io;

fn count_bases<T, E, I>(mut records: I) -> Result<usize, E>
where T: fastx::Record,
    E: std::error::Error,
    I: Iterator<Item = Result<T, E>> {
    let mut nb_bases = 0;
    for result in records {
        let record = result?;
        nb_bases += record.seq().len();
    }
    Ok(nb_bases)
}

let mut raw_reader = io::Cursor::new(b">id desc
ACTG
");

match fastx::get_type(&mut raw_reader) {
    Ok(fastx::FastxType::Fasta) => {
        let mut reader = fasta::Reader::new(raw_reader);
        let nb_bases = count_bases(reader.records()).unwrap();
        println!("Number of bases: {}", nb_bases);
    },
    Ok(fastx::FastxType::Fastq) => {
        let mut reader = fastq::Reader::new(raw_reader);
        let nb_bases = count_bases(reader.records()).unwrap();
        println!("Number of bases: {}", nb_bases);
    },
    _ => println!("Encountered an error"),
}
```

Simple Filtration:

```Rust
use bio::io::{fasta, fastq, fastx};
use std::io;

fn at_least_n_bases<T, E, I>(mut records: I, n: usize) -> impl Iterator<Item = Result<T, E>>
where T: fastx::Record,
    E: std::error::Error,
    I: Iterator<Item = Result<T, E>> {
    records.filter(move |rr| match rr {
        Ok(r) => r.seq().len() > n,
        _ => true,
    })
}

let mut reader = fasta::Reader::new(io::stdin());
let mut writer = fasta::Writer::new(io::stdout());

for record in at_least_n_bases(reader.records(), 10) {
    writer.write_record(&record.unwrap());
}

```