### PR TITLE
update crates so that users can use rand version 0.8.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ ordered-float = "1.0"
 regex = "1.3"
 multimap = ">=0.6, <=0.8"
 fxhash = "0.2"
-statrs = ">= 0.11, <= 0.13"
+statrs = ">= 0.11, <= 0.14"
 bio-types = ">=0.11.0"
 pest = { version = "2", optional = true }
 pest_derive = { version = "2", optional = true }
@@ -64,5 +64,5 @@ features = ["stable_graph"]
 
 
 [dev-dependencies]
-proptest = "0.10"
+proptest = "1"
 tempfile = "3.1.0"


### PR DESCRIPTION
Currently users of the bio 0.34 will have rand 0.7.3 as a dependency.  This change
allows the rand dependency to advance to 0.8.3.  It would be great if a release could 
be made with this change.
