### PR TITLE
widen ndarray dependency and fix warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ itertools = ">= 0.8, <= 0.9"
 itertools-num = "0.1"
 bv = { version = "0.11", features = ["serde"] }
 bit-set = "0.5"
-ndarray= ">=0.13, <=0.14"
+ndarray= ">=0.13, <=0.15"
 lazy_static = "1.4"
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/pattern_matching/pssm/mod.rs
+++ b/src/pattern_matching/pssm/mod.rs
@@ -296,7 +296,7 @@ pub trait Motif {
         let bits = Self::get_bits();
         let scores = self.get_scores();
         let mut tot = 0.0;
-        for row in scores.genrows() {
+        for row in scores.rows() {
             tot += bits - ent(row.iter());
         }
         tot


### PR DESCRIPTION
Widen the ndarray dependency to accept up to 0.15.  This caused a warning, which
said to replace an instance of genrows() by rows(), and that was done.
