### PR TITLE
Fix compiler warning when running tests

### DIFF
--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -805,15 +805,13 @@ mod tests {
 
                 assert!(
                     cur <= next,
-                    format!(
-                        "Failed:\n{}\n{}\nat positions {} and {} are out of order in \
+                    "Failed:\n{}\n{}\nat positions {} and {} are out of order in \
                          test: {}",
-                        cur,
-                        next,
-                        pos[i],
-                        pos[i + 1],
-                        test_name
-                    )
+                    cur,
+                    next,
+                    pos[i],
+                    pos[i + 1],
+                    test_name
                 );
             }
         }


### PR DESCRIPTION
Just a quick fix of for `#[warn(non_fmt_panic)]`. Looks like the `format!` macro should be avoided inside the `assert!` as shown [here](https://doc.rust-lang.org/std/macro.assert.html#custom-messages) in the example for custom error messages with `assert!`.  