### PR TITLE
fix edge case where FastX parser can loop infinitely

### DIFF
--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -249,7 +249,7 @@ where
             self.reader.read_line(&mut self.line_buffer)?;
 
             let mut lines_read = 0;
-            while !self.line_buffer.starts_with('+') {
+            while !self.line_buffer.is_empty() && !self.line_buffer.starts_with('+') {
                 record.seq.push_str(&self.line_buffer.trim_end());
                 self.line_buffer.clear();
                 self.reader.read_line(&mut self.line_buffer)?;
@@ -852,6 +852,16 @@ IIIIIIJJJJJJ
         let expected = 4;
 
         assert_eq!(actual, expected)
+    }
+
+    #[test]
+    fn test_read_with_missing_plus() {
+        let fq: &'static [u8] = b"@id description\nACGT\n*\n!!!!\n";
+        let mut reader = Reader::new(fq);
+        let mut record = Record::new();
+        let err = reader.read(&mut record).unwrap_err();
+
+        assert!(matches!(err, Error::IncompleteRecord))
     }
 
     #[test]


### PR DESCRIPTION
I found this bug while writing tests for this: https://github.com/rust-bio/rust-bio/pull/433. I felt that this was somewhat urgent and the fix shouldn't be tied to my PR.

In the current code at `src/io/fastq.rs:252` the code loops while the line does not start with `+`, adds the contents of the line to the sequence, then reads the next line and increments `lines_read`:

```Rust
while !self.line_buffer.starts_with('+') {
    record.seq.push_str(&self.line_buffer.trim_end());
    self.line_buffer.clear();
    self.reader.read_line(&mut self.line_buffer)?;
    lines_read += 1;
}
```

The problem is that at the end of a file `read_line` will simply read an empty string. The empty string never starts with `+` so this will loop forever, even once you have reached the end of a file. This is not ideal and can cause your program to hang on certain invalid inputs.

I simply added a check for an empty line. If the `+` is missing this will now be considered an `IncompleteRecord` since it has no quality scores (as they are denoted by a plus). This seems good to me but I guess you could make the argument it could be more of an invalid data error.

I also added a test for this case. It will hang forever if this bug is there. The test can serve as steps to reproduce.