### PR TITLE
fix: sampled suffix array

### DIFF
--- a/src/data_structures/bwt.rs
+++ b/src/data_structures/bwt.rs
@@ -73,7 +73,7 @@ pub fn invert_bwt(bwt: &BWTSlice) -> Vec<u8> {
 }
 
 /// An occurrence array implementation.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Occ {
     occ: Vec<Vec<usize>>,
     k: u32,

--- a/src/data_structures/fmindex.rs
+++ b/src/data_structures/fmindex.rs
@@ -480,6 +480,21 @@ impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> FMDIndex<DBWT, D
 
         self.backward_ext(&interval.swapped(), comp_a).swapped()
     }
+
+    /// Construct a new instance of the FMD index (see Heng Li (2012) Bioinformatics)
+    /// without checking whether the text is over the DNA alphabet with N.
+    /// This expects a BWT that was created from a text over the DNA alphabet with N
+    /// (`alphabets::dna::n_alphabet()`) consisting of the
+    /// concatenation with its reverse complement, separated by the sentinel symbol `$`.
+    /// I.e., let T be the original text and R be its reverse complement.
+    /// Then, the expected text is T$R$. Further, multiple concatenated texts are allowed, e.g.
+    /// T1$R1$T2$R2$T3$R3$.
+    /// It is unsafe to construct an FMD index from an FM index that is not built on the DNA alphabet.
+    pub unsafe fn from_fmindex_unchecked(
+        fmindex: FMIndex<DBWT, DLess, DOcc>,
+    ) -> FMDIndex<DBWT, DLess, DOcc> {
+        FMDIndex { fmindex }
+    }
 }
 
 #[cfg(test)]

--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -199,6 +199,18 @@ impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>>
     pub fn sampling_rate(&self) -> usize {
         self.s
     }
+
+    pub fn bwt(&self) -> &BWT {
+        self.bwt.borrow()
+    }
+
+    pub fn less(&self) -> &Less {
+        self.less.borrow()
+    }
+
+    pub fn occ(&self) -> &Occ {
+        self.occ.borrow()
+    }
 }
 
 /// Construct suffix array for given text of length n.

--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -37,6 +37,8 @@ use vec_map::VecMap;
 
 use fxhash::FxHasher;
 
+use serde::{Serialize, Deserialize};
+
 use crate::alphabets::{Alphabet, RankTransform};
 use crate::data_structures::smallints::SmallInts;
 use crate::data_structures::bwt::{BWT, Less, Occ};
@@ -115,6 +117,7 @@ pub trait SuffixArray {
 }
 
 /// A sampled suffix array.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct SampledSuffixArray<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> {
     bwt: DBWT,
     less: DLess,

--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -104,7 +104,7 @@ pub trait SuffixArray {
             } else if bwt.borrow()[i] == sentinel {
                 // If bwt lookup will return a sentinel
                 // Text suffixes that begin right after a sentinel are always saved as extra rows
-                // to help deal with bwt inaccuracy when there are many sentinels
+                // to help deal with FM index last to front inaccuracy when there are many sentinels
                 extra_rows.insert(i, idx);
             }
         }
@@ -167,9 +167,9 @@ impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> SuffixArray
                 let c = self.bwt.borrow()[pos];
 
                 if c == self.sentinel {
-                    // Check if next character is the sentinel
-                    // If so, there must be a cached result to workaround bwt lookup
-                    // inaccuracy when there are multiple sentinels
+                    // Check if next character in the bwt is the sentinel
+                    // If so, there must be a cached result to workaround FM index last to front
+                    // mapping inaccuracy when there are multiple sentinels
                     // This branch should rarely be triggered so the performance impact
                     // of hashmap lookups would be low
                     return Some(self.extra_rows[&pos] + offset);


### PR DESCRIPTION
The sampled suffix array implementation has some issues (closes #70 and closes #446) from like 2016, so the code was commented out and the issues were never fixed... until now.

The issue is that wrong positions are returned when doing a last to front lookup that leads to a sentinel in the FM-index. This issue only happens when there are multiple sentinels. I think is due to how SAIS ranks the sentinels so they are different despite being the same character `$` so the final result will not be a fully lexicographical sorting. The FM-index doesn't know this so you get wrong results when looking up a sentinel in `occ` or `less` for the last to front mapping. Normally, you wouldn't look up sentinels so this issue wouldn't come up, but with a sampled suffix array, sometimes you need to follow the last to front mapping and cross a suffix that starts with the sentinel in order to reach the nearest sampled suffix.

The fix is to simply use a hashmap to store, for each sentinel in the text, the index for the suffix that comes immediately after. This will make sure that we never need to cross a sentinel suffix to reach the nearest sampled suffix. The memory and performance impact of this is minimal, since typically the number of characters in the text is much larger than the number of sentinels.

An alternative solution would be to use a different sentinel from the sentinel at the end, so all sentinels but the last one are all equal from the perspective of SAIS and they will be sorted correctly. However, this will require changes to user code to use different sentinels and that is annoying.