### PR TITLE
test: fix compilation for fmindex benchmark.

### DIFF
--- a/benches/fmindex.rs
+++ b/benches/fmindex.rs
@@ -4,7 +4,7 @@ extern crate test;
 
 use bio::alphabets;
 use bio::data_structures::bwt::{bwt, less, Occ};
-use bio::data_structures::fmindex::{FMIndex, FMIndexable};
+use bio::data_structures::fmindex::{BackwardSearchResult, FMIndex, FMIndexable};
 use bio::data_structures::suffix_array::suffix_array;
 use test::Bencher;
 
@@ -26,9 +26,13 @@ fn search_index_seeds(b: &mut Bencher) {
 
         let mut loc_temp = Vec::new();
         for (offset, seed) in seeds {
-            let interval = fmindex.backward_search(seed.iter());
-
-            loc_temp.extend((interval.lower..interval.upper).map(|i| (sa[i], offset)));
+            let interval = match fmindex.backward_search(seed.iter()) {
+                BackwardSearchResult::Complete(interval)
+                | BackwardSearchResult::Partial(interval, _) => {
+                    loc_temp.extend((interval.lower..interval.upper).map(|i| (sa[i], offset)))
+                }
+                _ => panic!("no search result"),
+            };
         }
     });
 }


### PR DESCRIPTION
This was broken by eb9d378c70bc43d1dcf477e48cb167802799a546.

Having compilation broken is an annoyence when one attempts to run
`cargo check --all-targets`.