### PR TITLE
feat: Add UPGMA, Neighbor-Joining, and Robinson-Foulds metric

### DIFF
--- a/benches/fmindex.rs
+++ b/benches/fmindex.rs
@@ -26,7 +26,7 @@ fn search_index_seeds(b: &mut Bencher) {
 
         let mut loc_temp = Vec::new();
         for (offset, seed) in seeds {
-            let interval = match fmindex.backward_search(seed.iter()) {
+            let _interval = match fmindex.backward_search(seed.iter()) {
                 BackwardSearchResult::Complete(interval)
                 | BackwardSearchResult::Partial(interval, _) => {
                     loc_temp.extend((interval.lower..interval.upper).map(|i| (sa[i], offset)))

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -6,3 +6,4 @@ pub mod fastq;
 pub mod gff;
 #[cfg(feature = "phylogeny")]
 pub mod newick;
+pub mod phylip;

--- a/src/io/newick.rs
+++ b/src/io/newick.rs
@@ -14,7 +14,7 @@
 //!  use bio::io::newick;
 //!
 //!  let tree = newick::from_string("(A:0.1,B:0.2,(C:0.3,D:0.4)E:0.5)F;").unwrap();
-//!  for taxon in tree.raw_nodes() {
+//!  for taxon in tree.g.raw_nodes() {
 //!      println!("{}", taxon.weight);
 //!  }
 //!  ```

--- a/src/io/newick.rs
+++ b/src/io/newick.rs
@@ -245,7 +245,7 @@ pub fn to_string(t: &Tree) -> Result<String> {
     }
 
     // Find the root of the tree.
-    let roots = t.g.externals(Incoming);
+    let mut roots = t.g.externals(Incoming);
     // Make sure there is exactly one vertex without incoming edges.
     let root = roots.next().ok_or(Error::NoUniqueRoot)?;
     if roots.next().is_some() {

--- a/src/io/phylip.rs
+++ b/src/io/phylip.rs
@@ -1,0 +1,190 @@
+//! A struct to read distance matrices in the [Phylip `.dist` format](https://mothur.org/wiki/phylip-formatted_distance_matrix/).
+//!
+//!  # Example
+//!
+//!  In this example, we parse a square distance matrix from a string.
+//!
+//!  ```
+//!  use bio::io::phylip;
+//!
+//!  let distances = phylip::from_string("2
+//!  A 0 1
+//!  B 1 0
+//!  ").unwrap();
+//!  assert_eq!(distances.matrix_type, bio_types::distancematrix::MatrixType::Square)
+//!  ```
+//!
+//!  In this example, we parse a lower triangular distance matrix from a string.
+//!
+//!  ```
+//!  use bio::io::phylip;
+//!
+//!  let distances = phylip::from_string("3
+//!  A
+//!  B 1
+//!  C 2 3
+//!  ").unwrap();
+//!  assert_eq!(distances.matrix_type, bio_types::distancematrix::MatrixType::Lower)
+//!  ```
+
+use bio_types::distancematrix::DistanceMatrix;
+use itertools::zip;
+use std::{
+    fs, io,
+    num::ParseIntError,
+    path::{Path, PathBuf},
+};
+use thiserror::Error;
+
+/// A `thiserror` error type gathering all the potential bad outcomes
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Error while opening {}: {}", filename.display(), source)]
+    OpenFile {
+        filename: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("Error while reading distance matrix: {0}")]
+    Read(#[from] std::io::Error),
+
+    #[error("Error while writing distance matrix: {0}")]
+    Write(std::io::Error),
+
+    #[error("DistanceMatrix contains invalid UTF-8: {0}")]
+    InvalidContent(#[from] std::str::Utf8Error),
+
+    #[error("Error while parsing distance matrix: {0}")]
+    ParsingError(String),
+}
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Reads a distance matrix from an `&str`-compatible type
+pub fn from_string<S: AsRef<str>>(content: S) -> Result<DistanceMatrix> {
+    let mut lines = content.as_ref().lines();
+    let n = lines
+        .next()
+        .ok_or(Error::ParsingError("Expected n, number of taxons".into()))?
+        .parse()
+        .map_err(|e: ParseIntError| Error::ParsingError(e.to_string()))?;
+
+    let mut names = Vec::with_capacity(n);
+    let mut distances = Vec::with_capacity(n);
+
+    for line in lines.into_iter() {
+        let mut it = line.split_ascii_whitespace();
+        names.push(
+            it.next()
+                .ok_or(Error::ParsingError(
+                    "Line does not start with a name".into(),
+                ))?
+                .to_string(),
+        );
+        distances.push(it.map(|chars| chars.parse().unwrap()).collect());
+    }
+
+    DistanceMatrix::new(names, distances).map_err(|e| Error::ParsingError(e.to_string()))
+}
+
+/// Reads a DistanceMatrix from a file
+pub fn from_file<P: AsRef<Path>>(path: P) -> Result<DistanceMatrix> {
+    fs::File::open(&path)
+        .map(read)
+        .map_err(|e| Error::OpenFile {
+            filename: path.as_ref().to_owned(),
+            source: e,
+        })?
+}
+
+/// Reads a DistanceMatrix from any type implementing `io::Read`
+pub fn read<R: io::Read>(reader: R) -> Result<DistanceMatrix> {
+    let content_bytes = reader
+        .bytes()
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(Error::Read)?;
+    let content_str = std::str::from_utf8(&content_bytes).map_err(Error::InvalidContent)?;
+    from_string(&content_str)
+}
+
+/// Convert the DistanceMatrix to the phylip format.
+pub fn to_string(m: &DistanceMatrix) -> String {
+    let mut s = String::new();
+    s += &m.len().to_string();
+    s += "\n";
+    for (name, ds) in zip(&m.names, &m.distances) {
+        s += &name;
+        for d in ds {
+            s += " ";
+            s += &d.to_string();
+        }
+        s += "\n";
+    }
+    s
+}
+
+/// Writes a distance matrix to a file.
+pub fn to_file<P: AsRef<Path>>(path: P, m: &DistanceMatrix) -> Result<()> {
+    fs::File::open(&path)
+        .map(|w| write(w, m))
+        .map_err(|e| Error::OpenFile {
+            filename: path.as_ref().to_owned(),
+            source: e,
+        })?
+}
+
+/// Writes a distance matrix to any type implementing `io::Write`.
+pub fn write<W: io::Write>(mut writer: W, m: &DistanceMatrix) -> Result<()> {
+    let s = to_string(&m);
+    writer.write_all(&s.into_bytes()).map_err(Error::Write)
+}
+
+#[cfg(test)]
+mod tests {
+    use bio_types::distancematrix::MatrixType;
+
+    use super::*;
+
+    #[test]
+    fn distance_matrix_from_to_string() {
+        let square = "3
+a 0 1 2
+B 1 0 3
+XYZ 2 3 0
+";
+        let lower = "3
+a
+B 1
+XYZ 2 3
+";
+        let upper = "3
+a 1 2
+B 3
+XYZ
+";
+        for (s, matrix_type) in zip(
+            [square, lower, upper],
+            [MatrixType::Square, MatrixType::Lower, MatrixType::Upper],
+        ) {
+            let t = from_string(s).unwrap();
+            assert_eq!(t.matrix_type, matrix_type);
+            assert_eq!(to_string(&t), s);
+        }
+    }
+
+    #[test]
+    fn floats_and_names() {
+        let s = "1
+some_long_name?! 1.0
+";
+        let t = from_string(s).unwrap();
+        assert_eq!(t[(0, 0)], 1.0);
+        assert_eq!(t.names[0], "some_long_name?!");
+
+        let s = "1
+ABCabc 1.0001
+";
+        let t = from_string(s).unwrap();
+        assert_eq!(t[(0, 0)], 1.0001);
+        assert_eq!(t.names[0], "ABCabc");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@
 //! ```rust
 //! use bio::alphabets;
 //! use bio::data_structures::bwt::{bwt, less, Occ};
-//! use bio::data_structures::fmindex::{BackwardSearchResult,FMIndex, FMIndexable};
+//! use bio::data_structures::fmindex::{BackwardSearchResult, FMIndex, FMIndexable};
 //! use bio::data_structures::suffix_array::suffix_array;
 //! use std::sync::Arc;
 //! use std::thread;
@@ -204,7 +204,7 @@
 //! for interval_calculator in interval_calculators {
 //!     let positions = match interval_calculator.join().unwrap() {
 //!         BackwardSearchResult::Complete(saint) => saint.occ(&sa),
-//!         _ => Vec::new()
+//!         _ => Vec::new(),
 //!     };
 //! }
 //! ```
@@ -257,6 +257,8 @@ pub mod alphabets;
 pub mod data_structures;
 pub mod io;
 pub mod pattern_matching;
+#[cfg(feature = "phylogeny")]
+pub mod phylogeny;
 pub mod scores;
 pub mod seq_analysis;
 pub mod stats;

--- a/src/phylogeny/mod.rs
+++ b/src/phylogeny/mod.rs
@@ -1,0 +1,324 @@
+//! This module contains algorithms related to phylogenetic trees.
+//!
+//! Currently, it contains two methods for phylogeny reconstruction:
+//! - [UPGMA](https://en.wikipedia.org/wiki/UPGMA)
+//! - [Neighbor Joining](https://en.wikipedia.org/wiki/Neighbor_joining)
+//!
+//! It also contains an implementation to compute the [Robinson-Foulds
+//! metric](https://en.wikipedia.org/wiki/Robinson%E2%80%93Foulds_metric).
+//!
+//! Each of these algorithms is also available as a command line tool in [`rust-bio-tools`](https://github.com/rust-bio/rust-bio-tools).
+
+use std::{
+    cmp::{max, min, Reverse},
+    collections::{BTreeSet, BinaryHeap, HashSet},
+    mem::swap,
+};
+
+use bio_types::{distancematrix::DistanceMatrix, phylogeny::Tree};
+use itertools::Itertools;
+use ordered_float::NotNan;
+use petgraph::{
+    graph::NodeIndex,
+    visit::EdgeRef,
+    EdgeDirection::{Incoming, Outgoing},
+};
+
+/// Helper function to join two nodes in a new node with the given distances.
+fn join(t: &mut Tree, u: NodeIndex, u_dist: f32, v: NodeIndex, v_dist: f32) -> NodeIndex {
+    let m = t.g.add_node("".into());
+    t.g.add_edge(m, u, u_dist);
+    t.g.add_edge(m, v, v_dist);
+    m
+}
+
+/// Run the UPGMA algorithm.
+///
+/// Compute the rooted phylogeny given a `DistanceMatrix`.
+pub fn upgma(distances: DistanceMatrix) -> Tree {
+    let DistanceMatrix {
+        names,
+        mut distances,
+        matrix_type: _,
+    } = distances;
+    let mut t = Tree::new();
+    let n = distances.len();
+    // Tuples of (subtree root, number of leafs in subtree, distance to leafs)
+    let mut parts: Vec<Option<(NodeIndex, usize, f32)>> = names
+        .into_iter()
+        .map(|name| (t.g.add_node(name), 1, 0.).into())
+        .collect();
+    let mut heap = BinaryHeap::with_capacity(n * n);
+    for (i, ds) in distances.iter().enumerate() {
+        for (j, &d) in ds.iter().enumerate() {
+            if i == j {
+                continue;
+            }
+            heap.push(Reverse((NotNan::new(d).unwrap(), i, j)));
+        }
+    }
+
+    while let Some(Reverse((d, i, j))) = heap.pop() {
+        assert!(i != j);
+        if parts[i].is_none() || parts[j].is_none() || distances[i][j] != *d {
+            continue;
+        }
+        let (i, j) = (min(i, j), max(i, j));
+        if let (Some((pi, si, di)), Some((pj, sj, dj))) = (parts[i].take(), parts[j].take()) {
+            // Merge phylogeny i and j, adding theirs sizes. Store the result in the lower of the two indices.
+            parts[i] = Some((
+                join(&mut t, pi, *d / 2. - di, pj, *d / 2. - dj),
+                si + sj,
+                *d / 2.,
+            ));
+            // Update the distances to other nodes
+            for k in 0..n {
+                if k == i || k == j {
+                    continue;
+                }
+                let dk =
+                    (si as f32 * distances[i][k] + sj as f32 * distances[j][k]) / (si + sj) as f32;
+                distances[i][k] = dk;
+                distances[k][i] = dk;
+                heap.push(Reverse((NotNan::new(dk).unwrap(), k, i)));
+            }
+        }
+    }
+
+    t
+}
+
+/// Run the Neighbor-Joining algorithm
+///
+/// Computes an unrooted phylogony given a `DistanceMatrix`.
+///
+/// The root vertex is arbitrarily chosen as the middle in between the last two remaining vertices.
+pub fn neighbor_joining(distances: DistanceMatrix) -> Tree {
+    let DistanceMatrix {
+        names,
+        mut distances,
+        matrix_type: _,
+    } = distances;
+    let mut t = Tree::new();
+
+    // Start with one node for each taxon.
+    let mut parts: Vec<Option<NodeIndex>> = names
+        .into_iter()
+        .map(|name| Some(t.g.add_node(name)))
+        .collect();
+
+    // A list of 'active' indices, indicating roots of the remaining subtrees.
+    let mut active: Vec<usize> = (0..distances.len()).collect();
+
+    while active.len() > 2 {
+        // The sum of all distances from index i to any other index.
+        let sum_d = |i: usize| -> f32 { active.iter().map(|&k| distances[i][k]).sum::<f32>() };
+
+        // Find i,j for which Q(i,j) is minimal.
+        let q = |&(&i, &j): &(&usize, &usize)| -> NotNan<f32> {
+            let r = NotNan::new((active.len() - 2) as f32 * distances[i][j] - sum_d(i) - sum_d(j))
+                .unwrap();
+            r
+        };
+
+        // Find minimal distance pair.
+        let (&i, &j) = active
+            .iter()
+            .cartesian_product(active.iter())
+            .filter(|&(&i, &j)| i != j)
+            .min_by_key(q)
+            .unwrap();
+
+        let (i, j) = (min(i, j), max(i, j));
+
+        // Compute distance from merged vertex to the nodes being merged.
+        let di = distances[i][j] / 2. + (sum_d(i) - sum_d(j)) / (2. * (active.len() as f32 - 2.));
+        let dj = distances[i][j] - di;
+
+        // Remove j from positions considered in later iterations.
+        active.remove(active.iter().position(|&x| x == j).unwrap());
+
+        // Compute all other distances.
+        active.iter().filter(|&&k| k != i).for_each(|&k| {
+            let dk = (distances[i][k] + distances[j][k] - distances[i][j]) / 2.;
+            distances[i][k] = dk;
+            distances[k][i] = dk;
+        });
+        parts[i] = Some(join(
+            &mut t,
+            parts[i].take().unwrap(),
+            di,
+            parts[j].take().unwrap(),
+            dj,
+        ));
+    }
+
+    // Merge the two remaining vertices with the given distance.
+    if let [i, j] = active[..] {
+        let d = distances[i][j] / 2.;
+        parts[i] = Some(join(
+            &mut t,
+            parts[i].take().unwrap(),
+            d,
+            parts[j].take().unwrap(),
+            d,
+        ));
+    }
+
+    t
+}
+
+/// Compute the Robingson-Foulds metric.
+///
+/// Also called the RF-distance, a distance metric between two phylogenetic trees.
+///
+/// Leaf nodes *must* be named. Names for internal nodes are ignored.
+/// Panics when the two trees have different sets of leafs.
+///
+/// The root is never considered as a leaf node.
+// The current implementation is relatively simple, and could probably be optimized further.
+//
+// It keeps a HashSet of all partitions, and each partition is stored as a sorted vector.
+// The DFS keeps a BTreeSet to efficiently insert and merge sets of leafs.
+pub fn robinson_foulds_distance(p: &Tree, q: &Tree) -> usize {
+    type Partition = BTreeSet<String>;
+    type Partitions = HashSet<Vec<String>>;
+
+    let leafs_p = p.g.externals(Outgoing).map(|u| p.g[u].clone()).collect();
+    let leafs_q = q.g.externals(Outgoing).map(|u| q.g[u].clone()).collect();
+    assert_eq!(leafs_p, leafs_q);
+
+    // Insert the set of names in a subtree to the hashset of all partitions seen so far.
+    // Also inserts the complement of this subtree into the hashset.
+    fn insert_part_and_complement(
+        subtree: &BTreeSet<String>,
+        universe: &BTreeSet<String>,
+        parts: &mut Partitions,
+    ) {
+        parts.insert(subtree.iter().cloned().collect());
+        parts.insert(universe.difference(subtree).cloned().collect());
+    }
+
+    // For each node, recurses into its children to collect all leafs in the
+    // subtree. Then adds this set of leafs and the complement into `parts`.
+    fn dfs(t: &Tree, node: NodeIndex, universe: &Partition, parts: &mut Partitions) -> Partition {
+        let mut subtree = Partition::new();
+        let mut iter = t.g.edges_directed(node, Outgoing).peekable();
+        if iter.peek().is_none() {
+            // For leafs, insert their name into the set of values seen so far.
+            subtree.insert(t.g[node].to_string());
+        } else {
+            // For internal nodes, recurse and merge all leafs.
+            for edge in iter {
+                let mut childtree = dfs(t, edge.target(), universe, parts);
+                // Merge the smaller of childtree and subtree into the larger
+                if childtree.len() > subtree.len() {
+                    swap(&mut subtree, &mut childtree);
+                }
+                for x in childtree.into_iter() {
+                    subtree.insert(x);
+                }
+            }
+        }
+        insert_part_and_complement(&subtree, universe, parts);
+        return subtree;
+    }
+    let (mut partitions_p, mut partitions_q) = (Partitions::new(), Partitions::new());
+    // Find the partitions of p and q by running a DFS from all roots.
+    p.g.externals(Incoming).for_each(|r| {
+        dfs(p, r, &leafs_p, &mut partitions_p);
+    });
+    q.g.externals(Incoming).for_each(|r| {
+        dfs(q, r, &leafs_q, &mut partitions_q);
+    });
+    if leafs_p.len() > 1 {
+        assert_eq!(partitions_p.len(), 4 * leafs_p.len() - 4);
+        assert_eq!(partitions_q.len(), 4 * leafs_p.len() - 4);
+    }
+
+    // Find the number of parts in one but not the other.
+    let cnt = partitions_p.symmetric_difference(&partitions_q).count();
+    assert!(cnt % 2 == 0);
+    cnt / 2
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::io::newick;
+
+    use super::*;
+
+    #[test]
+    fn upgma_wiki() {
+        // Sample from Wikipedia
+        let d = DistanceMatrix::new(
+            vec!["a", "b", "c", "d", "e"]
+                .iter()
+                .map(|&s| s.into())
+                .collect(),
+            vec![
+                vec![0., 17., 21., 31., 23.],
+                vec![17., 0., 30., 34., 21.],
+                vec![32., 40., 0., 28., 39.],
+                vec![31., 34., 28., 0., 43.],
+                vec![23., 21., 39., 43., 0.],
+            ],
+        )
+        .unwrap();
+        let s = "(((a:8.5,b:8.5):2.5,e:11):5.5,(c:14,d:14):2.5);";
+        assert_eq!(newick::to_string(&upgma(d)).unwrap(), s);
+    }
+
+    #[test]
+    fn neighbor_joining_wiki() {
+        // Sample from Wikipedia
+        let d = DistanceMatrix::new(
+            vec!["a", "b", "c", "d", "e"]
+                .iter()
+                .map(|&s| s.into())
+                .collect(),
+            vec![
+                vec![0., 5., 9., 9., 8.],
+                vec![5., 0., 10., 10., 9.],
+                vec![9., 10., 0., 8., 7.],
+                vec![9., 10., 8., 0., 3.],
+                vec![8., 9., 7., 3., 0.],
+            ],
+        )
+        .unwrap();
+        let s = "((((a:2,b:3):3,c:4):2,d:2):0.5,e:0.5);";
+        assert_eq!(newick::to_string(&neighbor_joining(d)).unwrap(), s);
+    }
+
+    #[test]
+    fn robinson_foulds_distance_small() {
+        let p1 = newick::from_string("a;").unwrap();
+        let p2 = newick::from_string("(a);").unwrap();
+        let p3 = newick::from_string("((a));").unwrap();
+        assert_eq!(robinson_foulds_distance(&p1, &p2), 0);
+        assert_eq!(robinson_foulds_distance(&p1, &p3), 0);
+        assert_eq!(robinson_foulds_distance(&p2, &p3), 0);
+
+        let p1 = newick::from_string("(a,b,c);").unwrap();
+        let p2 = newick::from_string("((c,a),b);").unwrap();
+        let p3 = newick::from_string("(c,(b,a));").unwrap();
+        assert_eq!(robinson_foulds_distance(&p1, &p2), 0);
+        assert_eq!(robinson_foulds_distance(&p1, &p3), 0);
+        assert_eq!(robinson_foulds_distance(&p2, &p3), 0);
+
+        let p1 = newick::from_string("((a,b),(c,d));").unwrap();
+        let p2 = newick::from_string("(((a,b),c),d);").unwrap();
+        let p3 = newick::from_string("((a,c),(b,d));").unwrap();
+        assert_eq!(robinson_foulds_distance(&p1, &p2), 0);
+        assert_eq!(robinson_foulds_distance(&p1, &p3), 2);
+        assert_eq!(robinson_foulds_distance(&p2, &p3), 2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn robinson_foulds_distance_different_labels() {
+        let p1 = newick::from_string("((a,b),(c,d));").unwrap();
+        let p2 = newick::from_string("(((a,B),c),d);").unwrap();
+        robinson_foulds_distance(&p1, &p2);
+    }
+}


### PR DESCRIPTION
This depends on #468 and #469.

It adds implementations of the UPGMA and Neighbor-Joining phylogeny reconstruction algorithms, and of the Robinson-Foulds metric used as a distance between two trees.