### PR TITLE
fix: added code to ignore commented lines in a bed file 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-# [0.38.1] - 2022-01-11
+# [0.39.1] - 2022-01-11
 - Fixed the bed reader to allow comment lines (@mrvollger).
 
 # [0.35.0] - 2021-07-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [0.38.1] - 2022-01-11
+- Fixed the bed reader to allow comment lines (@mrvollger).
+
 # [0.35.0] - 2021-07-05
 - Improved buffer control in Fasta and Fastq API (@natir).
 - Fixed an indexing bug in ArrayBackedIntervalTree (@wabain).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-# [0.39.1] - 2022-01-11
+# [Unreleased](https://github.com/rust-bio/rust-bio/compare/v0.39.0...HEAD)
 - Fixed the bed reader to allow comment lines (@mrvollger).
 
 # [0.35.0] - 2021-07-05


### PR DESCRIPTION
Added code to ignore commented lines in a bed file and also added a simple test function. I think this resolves https://github.com/rust-bio/rust-bio/issues/473. 