### PR TITLE
docs: reorder CHANGELOG and fix headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,121 +2,6 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-# [Unreleased](https://github.com/rust-bio/rust-bio/compare/v0.39.0...HEAD)
-- Fixed the bed reader to allow comment lines (@mrvollger).
-
-# [0.35.0] - 2021-07-05
-- Improved buffer control in Fasta and Fastq API (@natir).
-- Fixed an indexing bug in ArrayBackedIntervalTree (@wabain).
-- Fixed a corner case where the FASTX parser could have looped infinitely (@morsecodist).
-- Fixed compiler warnings (@fxwiegand).
-- Improved documentation for FASTA index (@mbhall88).
-
-
-# [0.34.0] - 2021-05-04
-- Bayesian model framework now relies on Hash instead of Ord for accessing events (@johanneskoester).
-- Added wavelet matrix datastructure (@Identi, @tedil).
-
-
-# [0.33.0] - 2021-03-09
-- Fixed a floating point error in gcn_content (@tedil).
-- Improved error messages in io module (@fxwiegand).
-- Better memory usage of HomopolypairHMM (@tedil).
-- Improved documentation (@TianShi2001, @m0ssc0de, @dcroote).
-- Support for reading compact BED files (@manzt).
-- API improvements for `Alphabet` and GFF reader (@tshauck).
-- Switched to thiserror for error handling (@delehef).
-- Removed unsafe code (@huonw).
-- Fixed overflow in ShiftAnd algorithm (@dcroote).
-- Various additional test cases (@dcroote).
-- Extended API for SMEM computation on FMDIndex (@Identi).
-- Added a parser for Newick phylogenetic trees (@delehef).
-
-
-# [0.32.0] - 2020-07-28
-This release mostly comprises of the documentation improvements made
-by the recent Docathon. Lots of new doctests and a bunch of time and
-memory complexity annotations. Big thanks to @tedil, @dcroote,
-@TomKellyGenetics, @natir, @thomasmulvaney, @mbhall88, @jafors,
-@HenningTimm, @luizirber, @dlaehnemann, @johanneskoester.
-Further additions in this release are:
-- homopolymer-error-aware pairHMM implementation (thanks to @tedil).
-- SIMD-accelerated edit distance routines (thanks to @Daniel-Liu-c0deb0t).
-- BitEnc derives more traits (thanks to @FelixMoelder).
-- wider pinning of some dependencies' version numbers (thanks to @pmarks).
-
-
-# [0.31.0] - 2020-06-02
-- Bugfix for pHMM implementation (thanks to @tedil).
-- Sorted array-backed interval trees (thanks to @tedil).
-
-
-# [0.30.1] - 2020-05-13
-- Improved occ counting speed for FM index (thanks to @thomasmulvaney)
-- Various small bug fixes and code cleanups and linter fixes.
-
-# [0.30.0] - 2019-11-14
-- Bayesian models now allow to access internals.
-- Various small bug fixes.
-
-# [0.29.0] - 2019-09-27
-- Migrate error handling to the snafu crate (this is an API breaking change).
-- Fix edge cases in pairwise alignment.
-- Fix error in backward search if symbol isn't found.
-
-# [0.28.1] - 2019-06-28
-- Fix select in RankSelect in cases where many superblocks have the same rank.
-
-# [0.28.0] - 2019-06-19
-- Myers bit-parallel pattern matching now supports arbitrarily long patterns via bit vectors (thanks to @markschl).
-- Minor documentation updates (thanks to @anders-was-here).
-
-# [0.27.0] - 2019-05-31
-- Implement sequence-read-trait for FASTQ records.
-- Cleanup dependencies.
-
-# [0.26.1] - 2019-05-10
-- Fix a bug in `select_1` and `select_0` that would lead to too large answers.
-
-# [0.26.0] - 2019-05-09
-- Added a trait system for computing Bayesian statistical models.
-- Added an implementation of MSA via partial order alignment.
-- Performance improvements to FASTQ reader.
-
-# [0.25.0] - 2018-12-12
-- Added `FQRead` and `FARead` traits to `FastaReader` and `FastqReader` to be more flexible with input types. This allows to use readers on gzipped and on plain text input interchangeably.
-- Added an implementation of Bayes Factors and evidence scoring using the method of Kass and Raftery.
-
-# [0.24.0] - 2018-11-26
-- API overhaul to become more flexible when accepting text iterators. Now, anything that iterates over something can be borrowed as u8 is allowed.
-- FMIndex and FMDIndex now also allow plain owned versions of BWT, Less and Occ. This should greatly simplify their usage.
-- PairHMM and LogProb implementation has seen extensive performance improvements. Among that, (a) the usage of a fast approximation of exp() as presented by [Kopczynsi 2017](https://eldorado.tu-dortmund.de/bitstream/2003/36203/1/Dissertation_Kopczynski.pdf), and (b) banding of the pairHMM matrix with a given maximum edit distance.
-- All IO records now support serde.
-
-# [0.23.0] - 2018-11-06
-- Generalized Myers pattern matching algorithm to arbitrary unsigned integer types (u64, u128) (thanks to @markschl).
-- Implemented optional traceback and alignment output for Myers pattern matching algorithm (thanks to @markschl).
-- Use Strand type from bio-types crate in BED module (thanks to @ingolia).
-- Added an IntervalTree based data structure for looking up overlaps between annotation types (thanks to @ingolia).
-- Various bug fixes.
-
-# [0.22.0] - 2018-08-01
-- Added HMM implementation (thanks to @holtgrewe).
-- Moved Alignment types to `bio_types` crate (thanks to @pmarks).
-- Ignore comment lines in GTF/GFF files (thanks to Yasunobu Okamura).
-- API usability improvements.
-
-# [0.21.0] - 2018-06-19
-- Added PSSM implementation (thanks to @hervold).
-
-# [0.20.0] - 2018-06-01
-- Refactored RankSelect API to consistently use u64.
-- Use bv crate in suffix array implementation.
-
-# [0.19.0] - 2018-05-25
-- rank-0 and select-0 in RankSelect.
-- use bv crate for RankSelect.
-
 ### [0.39.1](https://www.github.com/rust-bio/rust-bio/compare/v0.39.0...v0.39.1) (2022-01-12)
 
 
@@ -166,6 +51,119 @@ Further additions in this release are:
 
 * Baum-Welch algorithm for Discrete HMM ([#432](https://www.github.com/rust-bio/rust-bio/issues/432)) ([eb8b8cb](https://www.github.com/rust-bio/rust-bio/commit/eb8b8cbad0016b0ab91861cb8d33f7fb624fb157))
 
+
+## [0.35.0] - 2021-07-05
+- Improved buffer control in Fasta and Fastq API (@natir).
+- Fixed an indexing bug in ArrayBackedIntervalTree (@wabain).
+- Fixed a corner case where the FASTX parser could have looped infinitely (@morsecodist).
+- Fixed compiler warnings (@fxwiegand).
+- Improved documentation for FASTA index (@mbhall88).
+
+
+## [0.34.0] - 2021-05-04
+- Bayesian model framework now relies on Hash instead of Ord for accessing events (@johanneskoester).
+- Added wavelet matrix datastructure (@Identi, @tedil).
+
+
+## [0.33.0] - 2021-03-09
+- Fixed a floating point error in gcn_content (@tedil).
+- Improved error messages in io module (@fxwiegand).
+- Better memory usage of HomopolypairHMM (@tedil).
+- Improved documentation (@TianShi2001, @m0ssc0de, @dcroote).
+- Support for reading compact BED files (@manzt).
+- API improvements for `Alphabet` and GFF reader (@tshauck).
+- Switched to thiserror for error handling (@delehef).
+- Removed unsafe code (@huonw).
+- Fixed overflow in ShiftAnd algorithm (@dcroote).
+- Various additional test cases (@dcroote).
+- Extended API for SMEM computation on FMDIndex (@Identi).
+- Added a parser for Newick phylogenetic trees (@delehef).
+
+
+## [0.32.0] - 2020-07-28
+This release mostly comprises of the documentation improvements made
+by the recent Docathon. Lots of new doctests and a bunch of time and
+memory complexity annotations. Big thanks to @tedil, @dcroote,
+@TomKellyGenetics, @natir, @thomasmulvaney, @mbhall88, @jafors,
+@HenningTimm, @luizirber, @dlaehnemann, @johanneskoester.
+Further additions in this release are:
+- homopolymer-error-aware pairHMM implementation (thanks to @tedil).
+- SIMD-accelerated edit distance routines (thanks to @Daniel-Liu-c0deb0t).
+- BitEnc derives more traits (thanks to @FelixMoelder).
+- wider pinning of some dependencies' version numbers (thanks to @pmarks).
+
+
+## [0.31.0] - 2020-06-02
+- Bugfix for pHMM implementation (thanks to @tedil).
+- Sorted array-backed interval trees (thanks to @tedil).
+
+
+### [0.30.1] - 2020-05-13
+- Improved occ counting speed for FM index (thanks to @thomasmulvaney)
+- Various small bug fixes and code cleanups and linter fixes.
+
+## [0.30.0] - 2019-11-14
+- Bayesian models now allow to access internals.
+- Various small bug fixes.
+
+## [0.29.0] - 2019-09-27
+- Migrate error handling to the snafu crate (this is an API breaking change).
+- Fix edge cases in pairwise alignment.
+- Fix error in backward search if symbol isn't found.
+
+### [0.28.1] - 2019-06-28
+- Fix select in RankSelect in cases where many superblocks have the same rank.
+
+## [0.28.0] - 2019-06-19
+- Myers bit-parallel pattern matching now supports arbitrarily long patterns via bit vectors (thanks to @markschl).
+- Minor documentation updates (thanks to @anders-was-here).
+
+## [0.27.0] - 2019-05-31
+- Implement sequence-read-trait for FASTQ records.
+- Cleanup dependencies.
+
+### [0.26.1] - 2019-05-10
+- Fix a bug in `select_1` and `select_0` that would lead to too large answers.
+
+## [0.26.0] - 2019-05-09
+- Added a trait system for computing Bayesian statistical models.
+- Added an implementation of MSA via partial order alignment.
+- Performance improvements to FASTQ reader.
+
+## [0.25.0] - 2018-12-12
+- Added `FQRead` and `FARead` traits to `FastaReader` and `FastqReader` to be more flexible with input types. This allows to use readers on gzipped and on plain text input interchangeably.
+- Added an implementation of Bayes Factors and evidence scoring using the method of Kass and Raftery.
+
+## [0.24.0] - 2018-11-26
+- API overhaul to become more flexible when accepting text iterators. Now, anything that iterates over something can be borrowed as u8 is allowed.
+- FMIndex and FMDIndex now also allow plain owned versions of BWT, Less and Occ. This should greatly simplify their usage.
+- PairHMM and LogProb implementation has seen extensive performance improvements. Among that, (a) the usage of a fast approximation of exp() as presented by [Kopczynsi 2017](https://eldorado.tu-dortmund.de/bitstream/2003/36203/1/Dissertation_Kopczynski.pdf), and (b) banding of the pairHMM matrix with a given maximum edit distance.
+- All IO records now support serde.
+
+## [0.23.0] - 2018-11-06
+- Generalized Myers pattern matching algorithm to arbitrary unsigned integer types (u64, u128) (thanks to @markschl).
+- Implemented optional traceback and alignment output for Myers pattern matching algorithm (thanks to @markschl).
+- Use Strand type from bio-types crate in BED module (thanks to @ingolia).
+- Added an IntervalTree based data structure for looking up overlaps between annotation types (thanks to @ingolia).
+- Various bug fixes.
+
+## [0.22.0] - 2018-08-01
+- Added HMM implementation (thanks to @holtgrewe).
+- Moved Alignment types to `bio_types` crate (thanks to @pmarks).
+- Ignore comment lines in GTF/GFF files (thanks to Yasunobu Okamura).
+- API usability improvements.
+
+## [0.21.0] - 2018-06-19
+- Added PSSM implementation (thanks to @hervold).
+
+## [0.20.0] - 2018-06-01
+- Refactored RankSelect API to consistently use u64.
+- Use bv crate in suffix array implementation.
+
+## [0.19.0] - 2018-05-25
+- rank-0 and select-0 in RankSelect.
+- use bv crate for RankSelect.
+
 ## [0.18.0] - 2018-05-04
 - More flexible FASTA API.
 - Fixed bug in KMP.
@@ -177,7 +175,7 @@ Further additions in this release are:
 ## [0.16.0] - 2018-01-05
 - Pairwise alignment has been rewritten to support banded alignment and clips.
 - Various minor API additions and improvements.
-- Several small bug fixes. 
+- Several small bug fixes.
 
 ## [0.15.0] - 2017-11-20
 - Add pair hidden markov model implementation to calculate the probability of two sequences being related.


### PR DESCRIPTION
Currently the CHANGELOG is out of order and has inconsistent use of headers i.e. `#` vs. `##` vs. `###`. This PR fixes the ordering and updates headers to the format used by the release bot (`##` for minor, `###` for patch).