### PR TITLE
fix: overflow in `qgrams` for k=32

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Install MSRV toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.51.0
+          toolchain: 1.53.0
           override: true
 
       - name: check if README matches MSRV defined here
-        run: grep '1.51.0' README.md
+        run: grep '1.53.0' README.md
 
       - name: Run tests
         uses: actions-rs/cargo@v1

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For extra credit, feel free to familiarize yourself with:
 
 ## Minimum supported Rust version
 
-Currently the minimum supported Rust version is 1.51.0.
+Currently the minimum supported Rust version is 1.53.0.
 
 ## License
 

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -448,4 +448,13 @@ mod tests {
         assert_eq!(Alphabet::new(b"ATCG"), Alphabet::new(b"TAGC"));
         assert_ne!(Alphabet::new(b"ATCG"), Alphabet::new(b"ATC"));
     }
+
+    /// When `q * bits == usize::BITS`, make sure that `1<<(1*bits)` does not overflow.
+    #[test]
+    fn test_qgram_shiftleft_overflow() {
+        let alphabet = Alphabet::new(b"ACTG");
+        let transform = RankTransform::new(&alphabet);
+        let text = b"ACTG".repeat(100);
+        transform.qgrams(usize::BITS / 2, text);
+    }
 }

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -326,7 +326,7 @@ impl RankTransform {
             text: text.into_iter(),
             ranks: self,
             bits,
-            mask: (1 << (q * bits)) - 1,
+            mask: 1usize.checked_shl(q * bits).unwrap_or(0).wrapping_sub(1),
             qgram: 0,
         };
 


### PR DESCRIPTION
For k exactly equal to 32 (or generally when the assertion above has exact
equality), the `1<<(q*bits)` overflows, which is undefined in rust. This PR
makes it defined behaviour.