### PR TITLE
pub use BaseSpecificHopParameters

### DIFF
--- a/src/stats/pairhmm/mod.rs
+++ b/src/stats/pairhmm/mod.rs
@@ -97,7 +97,7 @@
 //! let prob_expected = LogProb::from(Prob(PROB_NO_SUBSTITUION.powi(3) * PROB_SUBSTITUTION / 3.));
 //! assert_relative_eq!(*prob_related, *prob_expected, epsilon = 1e-5);
 //! ```
-pub use homopolypairhmm::{HomopolyPairHMM, HopParameters};
+pub use homopolypairhmm::{BaseSpecificHopParameters, HomopolyPairHMM, HopParameters};
 pub use pairhmm::PairHMM;
 
 use crate::stats::LogProb;


### PR DESCRIPTION
Make trait `BaseSpecificHopParameters` publicly available, so it can actually be used.