### PR TITLE
Write fasta with fix line width

### DIFF
--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -870,8 +870,17 @@ impl<W: io::Write> Writer<W> {
             self.writer.write_all(desc.as_bytes())?;
         }
         self.writer.write_all(b"\n")?;
-        self.writer.write_all(seq)?;
-        self.writer.write_all(b"\n")?;
+        let mut i = 0;
+        let lw = 60;
+        while i < seq.len() {
+            let mut to = i + lw;
+            if to > seq.len() {
+                to = seq.len();
+            }
+            self.writer.write_all(&seq[i..to])?;
+            self.writer.write_all(b"\n")?;
+            i = i + lw;
+        }
 
         Ok(())
     }

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -860,6 +860,10 @@ impl<W: io::Write> Writer<W> {
     pub fn write_record(&mut self, record: &Record) -> io::Result<()> {
         self.write(record.id(), record.desc(), record.seq())
     }
+    pub fn write_record_formated(&mut self, record: &Record) -> io::Result<()> {
+        let width = 60;
+        self.write_width(record.id(), record.desc(), record.seq(), width)
+    }
 
     /// Write a Fasta record with given id, optional description and sequence.
     pub fn write(&mut self, id: &str, desc: Option<&str>, seq: TextSlice<'_>) -> io::Result<()> {
@@ -870,16 +874,35 @@ impl<W: io::Write> Writer<W> {
             self.writer.write_all(desc.as_bytes())?;
         }
         self.writer.write_all(b"\n")?;
+        self.writer.write_all(seq)?;
+        self.writer.write_all(b"\n")?;
+
+        Ok(())
+    }
+    /// Write a Fasta record with given id, optional description and sequence with a line width.
+    pub fn write_width(
+        &mut self,
+        id: &str,
+        desc: Option<&str>,
+        seq: TextSlice<'_>,
+        width: usize,
+    ) -> io::Result<()> {
+        self.writer.write_all(b">")?;
+        self.writer.write_all(id.as_bytes())?;
+        if let Some(desc) = desc {
+            self.writer.write_all(b" ")?;
+            self.writer.write_all(desc.as_bytes())?;
+        }
+        self.writer.write_all(b"\n")?;
         let mut i = 0;
-        let lw = 60;
         while i < seq.len() {
-            let mut to = i + lw;
+            let mut to = i + width;
             if to > seq.len() {
                 to = seq.len();
             }
             self.writer.write_all(&seq[i..to])?;
             self.writer.write_all(b"\n")?;
-            i = i + lw;
+            i = i + width;
         }
 
         Ok(())


### PR DESCRIPTION
Writing fasta files often is best with line breaks. Currently `write_record` does not break lines.

I am not sure if there is already functionality for this, if so, please just close this issue. 
If not, I propose these changes which introduces a new function `write_record_width`, which basically just adds a line break after every nth char.

This would make the output consistent with reference databases, such as NCBI RefSeq or the hg38 genome.

One could have a default line width, currently it is a exposed parameter. It could be 60 chars (thats what SPAdes outputs) but also 70 (NCBI) or 50 (hg38).

Tests are not yet adjusted for this. 
