### PR TITLE
chore: Fix lints from clippy 1.63.

### DIFF
--- a/src/alignment/pairwise/mod.rs
+++ b/src/alignment/pairwise/mod.rs
@@ -1008,15 +1008,9 @@ impl<F: MatchFunc> Aligner<F> {
 /// Possible traceback moves include : start, insert, delete, match, substitute,
 /// prefix clip and suffix clip for x & y. So we need 4 bits each for matrices I, D, S
 /// to keep track of these 9 moves.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct TracebackCell {
     v: u16,
-}
-
-impl Default for TracebackCell {
-    fn default() -> Self {
-        TracebackCell { v: 0 }
-    }
 }
 
 // Traceback bit positions (LSB)

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -27,7 +27,7 @@ pub mod rna;
 pub type SymbolRanks = VecMap<u8>;
 
 /// Representation of an alphabet.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Alphabet {
     pub symbols: BitSet,
 }

--- a/src/data_structures/fmindex.rs
+++ b/src/data_structures/fmindex.rs
@@ -177,24 +177,24 @@ pub trait FMIndexable {
             // if we matched the full pattern length we
             // have a complete match
             if complete_match {
-                return BackwardSearchResult::Complete(Interval {
+                BackwardSearchResult::Complete(Interval {
                     lower: l,
                     upper: r + 1,
-                });
+                })
             } else {
                 // if we matched less than the full pattern length, we have
                 // a partial suffix match
-                return BackwardSearchResult::Partial(
+                BackwardSearchResult::Partial(
                     Interval {
                         lower: pl,
                         upper: pr + 1,
                     },
                     matched_len,
-                );
+                )
             }
         } else {
             // if we matched nothing we have an absent result
-            return BackwardSearchResult::Absent;
+            BackwardSearchResult::Absent
         }
     }
 }

--- a/src/data_structures/qgram_index.rs
+++ b/src/data_structures/qgram_index.rs
@@ -242,7 +242,7 @@ impl cmp::PartialOrd for Match {
 }
 
 /// An exact match between the pattern and the text.
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub struct ExactMatch {
     pub pattern: Interval,
     pub text: Interval,

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -722,7 +722,7 @@ struct IndexRecord {
 }
 
 /// A sequence record returned by the FASTA index.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Sequence {
     pub name: String,
     pub len: u64,

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -295,7 +295,7 @@ where
 }
 
 /// A FastQ record.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Record {
     id: String,
     desc: Option<String>,

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -41,7 +41,7 @@ use bio_types::strand::Strand;
 /// We have three format in the GFF family.
 /// The change is in the last field of GFF.
 /// For each type we have key value separator and field separator
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GffType {
     /// Attribute format is: key1=value; key2=value1,value2
     GFF3,

--- a/src/pattern_matching/pssm/errors.rs
+++ b/src/pattern_matching/pssm/errors.rs
@@ -6,7 +6,7 @@
 //! Error definitions for the `pssm` module.
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum Error {
     #[error(
         "query length {} is shorter than motif length {}",

--- a/src/seq_analysis/orf.rs
+++ b/src/seq_analysis/orf.rs
@@ -84,7 +84,7 @@ impl Finder {
 /// An ORF representation with start and end position of said ORF,
 /// as well as offset of the reading frame (1,2,3) and strand location
 // (current: +, reverse complementary: -).
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Orf {
     pub start: usize,
     pub end: usize,

--- a/src/stats/hmm/errors.rs
+++ b/src/stats/hmm/errors.rs
@@ -6,7 +6,7 @@
 //! Error definitions for the `hmm` module.
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum Error {
     #[error(
         "inferred from A: N_0={}, N_1={} (must be equal), from B: N={}, M={}, from pi: N={}",

--- a/src/stats/hmm/mod.rs
+++ b/src/stats/hmm/mod.rs
@@ -105,6 +105,7 @@ custom_derive! {
         NewtypeFrom,
         NewtypeDeref,
         PartialEq,
+        Eq,
         Copy,
         Clone,
         Debug
@@ -144,7 +145,7 @@ impl Iterator for StateIter {
 }
 
 /// Transition between two states in a `Model`.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StateTransition {
     /// Source of the transition.
     pub src: State,
@@ -882,16 +883,7 @@ pub mod discrete_emission_opt_end {
                 .map(|_x| Prob(1.0))
                 .collect::<Array1<Prob>>();
 
-            let has_end_state;
-
-            match end {
-                Some(_p) => {
-                    has_end_state = true;
-                }
-                None => {
-                    has_end_state = false;
-                }
-            }
+            let has_end_state = end.is_some();
 
             let end_un = end.unwrap_or(&end_possible);
 
@@ -916,16 +908,7 @@ pub mod discrete_emission_opt_end {
             let end_possible = (0..initial_dim).map(|_x| 1.0).collect::<Array1<f64>>();
             let end_un = end.unwrap_or(&end_possible);
 
-            let has_end_state;
-
-            match end {
-                Some(_p) => {
-                    has_end_state = true;
-                }
-                None => {
-                    has_end_state = false;
-                }
-            }
+            let has_end_state = end.is_some();
 
             Self::new(
                 RefCell::new(transition.map(|x| LogProb::from(Prob(*x)))),

--- a/src/stats/probs/mod.rs
+++ b/src/stats/probs/mod.rs
@@ -377,7 +377,7 @@ impl<'a> iter::Sum<&'a LogProb> for LogProb {
     }
 }
 
-impl<'a> iter::Sum<LogProb> for LogProb {
+impl iter::Sum<LogProb> for LogProb {
     fn sum<I: Iterator<Item = LogProb>>(iter: I) -> Self {
         iter.fold(LogProb(0.0), |a, b| a + b)
     }

--- a/src/utils/interval/errors.rs
+++ b/src/utils/interval/errors.rs
@@ -6,7 +6,7 @@
 //! Error definitions for the `interval` module.
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum Error {
     #[error("an Interval must have a Range with a positive width")]
     InvalidRange,


### PR DESCRIPTION
Mostly things that could be #[derive(Eq)] but weren't.