### PR TITLE
chore: Fix MSRV build.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,6 +98,10 @@ jobs:
       - name: check if README matches MSRV defined here
         run: grep '1.53.0' README.md
 
+      - name: pin dependency versions for MSRV
+        run: |
+          cargo update -p indexmap --precise 1.8.2
+
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Pin the version of indexmap (transitive dependency) to 1.8.2, the last
version before they switched to edition 2021, which requires rust 1.56.