### PR TITLE
chore: widen range on statrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ ordered-float = "2.0"
 regex = { version = "1.3", default-features = false, features = ["std", "perf"] }
 multimap = ">=0.6, <0.9"
 fxhash = "0.2"
-statrs = ">= 0.11, < 0.16"
+statrs = ">= 0.11, < 0.17"
 bio-types = ">=0.11.0"
 pest = { version = "2", optional = true }
 pest_derive = { version = "2", optional = true }


### PR DESCRIPTION
They didn't actually make breaking changes.

Also, due to a disagreement between the common meaning of semver for
pre-1.0 releases and how the release-please bot works, someone needs to
merge a commit with this line in it, so it might as well be this one:

Release-As: 0.42.0