### PR TITLE
feat: add standard derives to all public types

### DIFF
--- a/benches/pairhmm.rs
+++ b/benches/pairhmm.rs
@@ -22,9 +22,6 @@ fn prob_emit_x_or_y() -> LogProb {
     LogProb::from(Prob(1.0) - PROB_ILLUMINA_SUBST)
 }
 
-#[derive(
-    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
-)]
 pub struct TestEmissionParams {
     x: &'static [u8],
     y: &'static [u8],
@@ -56,9 +53,6 @@ impl EmissionParameters for TestEmissionParams {
     }
 }
 
-#[derive(
-    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
-)]
 pub struct SemiglobalGapParams;
 
 impl GapParameters for SemiglobalGapParams {
@@ -79,9 +73,6 @@ impl GapParameters for SemiglobalGapParams {
     }
 }
 
-#[derive(
-    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
-)]
 pub struct SemiglobalAlignment;
 
 impl StartEndGapParameters for SemiglobalAlignment {

--- a/benches/pairhmm.rs
+++ b/benches/pairhmm.rs
@@ -22,6 +22,9 @@ fn prob_emit_x_or_y() -> LogProb {
     LogProb::from(Prob(1.0) - PROB_ILLUMINA_SUBST)
 }
 
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct TestEmissionParams {
     x: &'static [u8],
     y: &'static [u8],
@@ -53,6 +56,9 @@ impl EmissionParameters for TestEmissionParams {
     }
 }
 
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct SemiglobalGapParams;
 
 impl GapParameters for SemiglobalGapParams {
@@ -73,6 +79,9 @@ impl GapParameters for SemiglobalGapParams {
     }
 }
 
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct SemiglobalAlignment;
 
 impl StartEndGapParameters for SemiglobalAlignment {

--- a/src/alignment/pairwise/banded.rs
+++ b/src/alignment/pairwise/banded.rs
@@ -108,6 +108,7 @@ const DEFAULT_MATCH_SCORE: i32 = 2;
 /// in the band is less than MAX_CELLS (currently set to 10 million), otherwise it returns an
 /// empty alignment
 #[allow(non_snake_case)]
+#[derive(Default, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
 pub struct Aligner<F: MatchFunc> {
     S: [Vec<i32>; 2],
     I: [Vec<i32>; 2],
@@ -1029,13 +1030,13 @@ trait MatchPair {
 impl MatchPair for (u32, u32) {
     fn continues(&self, p: Option<(u32, u32)>) -> bool {
         match p {
-            Some(_p) => (self.0 == _p.0 + 1 && self.1 == _p.1 + 1),
+            Some(_p) => self.0 == _p.0 + 1 && self.1 == _p.1 + 1,
             None => false,
         }
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Default, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
 struct Band {
     rows: usize,
     cols: usize,

--- a/src/alignment/pairwise/mod.rs
+++ b/src/alignment/pairwise/mod.rs
@@ -171,7 +171,9 @@ pub trait MatchFunc {
 
 /// A concrete data structure which implements trait MatchFunc with constant
 /// match and mismatch scores
-#[derive(Debug, Clone)]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct MatchParams {
     pub match_score: i32,
     pub mismatch_score: i32,
@@ -221,7 +223,9 @@ where
 /// An [affine gap score model](https://en.wikipedia.org/wiki/Gap_penalty#Affine)
 /// is used so that the gap score for a length `k` is:
 /// `GapScore(k) = gap_open + gap_extend * k`
-#[derive(Debug, Clone)]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct Scoring<F: MatchFunc> {
     pub gap_open: i32,
     pub gap_extend: i32,
@@ -455,6 +459,7 @@ impl<F: MatchFunc> Scoring<F> {
 ///
 /// `scoring` - see [`bio::alignment::pairwise::Scoring`](struct.Scoring.html)
 #[allow(non_snake_case)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Aligner<F: MatchFunc> {
     I: [Vec<i32>; 2],
     D: [Vec<i32>; 2],
@@ -1008,7 +1013,9 @@ impl<F: MatchFunc> Aligner<F> {
 /// Possible traceback moves include : start, insert, delete, match, substitute,
 /// prefix clip and suffix clip for x & y. So we need 4 bits each for matrices I, D, S
 /// to keep track of these 9 moves.
-#[derive(Copy, Clone, Default)]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct TracebackCell {
     v: u16,
 }
@@ -1100,6 +1107,7 @@ impl TracebackCell {
 }
 
 /// Internal traceback.
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 struct Traceback {
     rows: usize,
     cols: usize,

--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -53,20 +53,21 @@ pub type POAGraph = Graph<u8, i32, Directed, usize>;
 // traceback matrix. I have not yet figured out what the best level of
 // detail to store is, so Match and Del operations remember In and Out
 // nodes on the reference graph.
-#[derive(Debug, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub enum AlignmentOperation {
     Match(Option<(usize, usize)>),
     Del(Option<(usize, usize)>),
     Ins(Option<usize>),
 }
 
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Alignment {
     pub score: i32,
     //    xstart: Edge,
     operations: Vec<AlignmentOperation>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct TracebackCell {
     score: i32,
     op: AlignmentOperation,
@@ -94,6 +95,7 @@ impl PartialEq for TracebackCell {
 
 impl Eq for TracebackCell {}
 
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct Traceback {
     rows: usize,
     cols: usize,
@@ -233,6 +235,7 @@ impl Traceback {
 /// A partially ordered aligner builder
 ///
 /// Uses consuming builder pattern for constructing partial order alignments with method chaining
+#[derive(Default, Clone, Debug)]
 pub struct Aligner<F: MatchFunc> {
     traceback: Traceback,
     query: Vec<u8>,
@@ -278,6 +281,7 @@ impl<F: MatchFunc> Aligner<F> {
 ///
 /// A directed acyclic graph datastructure that represents the topology of a
 /// traceback matrix.
+#[derive(Default, Clone, Debug)]
 pub struct Poa<F: MatchFunc> {
     scoring: Scoring<F>,
     pub graph: POAGraph,

--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -198,7 +198,7 @@ impl Traceback {
         while i > 0 && j > 0 {
             // push operation and edge corresponding to (one of the) optimal
             // routes
-            ops.push(self.matrix[i][j].op.clone());
+            ops.push(self.matrix[i][j].op);
             match self.matrix[i][j].op {
                 AlignmentOperation::Match(Some((p, _))) => {
                     i = p + 1;

--- a/src/alignment/sparse.rs
+++ b/src/alignment/sparse.rs
@@ -36,7 +36,7 @@ use std::hash::BuildHasherDefault;
 pub type HashMapFx<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
 
 /// Result of a sparse alignment
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct SparseAlignmentResult {
     /// LCSk++ path, represented as vector of indices into the input matches vector.
     pub path: Vec<usize>,

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -27,7 +27,7 @@ pub mod rna;
 pub type SymbolRanks = VecMap<u8>;
 
 /// Representation of an alphabet.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Alphabet {
     pub symbols: BitSet,
 }
@@ -217,7 +217,7 @@ impl Alphabet {
 ///
 /// `RankTransform` can be used in to perform bit encoding for texts over a
 /// given alphabet via `bio::data_structures::bitenc`.
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct RankTransform {
     pub ranks: SymbolRanks,
 }
@@ -384,6 +384,7 @@ impl RankTransform {
 }
 
 /// Iterator over q-grams.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
 pub struct QGrams<'a, C, T>
 where
     C: Borrow<u8>,

--- a/src/data_structures/annot_map.rs
+++ b/src/data_structures/annot_map.rs
@@ -47,7 +47,7 @@ use bio_types::annot::loc::Loc;
 ///
 /// Thus, the overlapping annotations identified by querying a
 /// `AnnotMap` may need further filtering.
-#[derive(Debug, Clone)]
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct AnnotMap<R, T>
 where
     R: Hash + Eq,
@@ -180,7 +180,7 @@ where
 }
 
 /// A view of one annotation in a `AnnotMap` container.
-#[derive(Debug, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize)]
 pub struct Entry<'a, R, T>
 where
     R: Eq + Hash,
@@ -213,6 +213,7 @@ where
 /// `AnnotMap`.
 ///
 /// This struct is created by the `find` function on `AnnotMap`.
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize)]
 pub struct AnnotMapIterator<'a, R, T>
 where
     R: Eq + Hash,

--- a/src/data_structures/bit_tree.rs
+++ b/src/data_structures/bit_tree.rs
@@ -41,6 +41,7 @@ pub trait PrefixOp<T> {
 /// a smaller element at the same index.
 /// Time Complexity: O(n) to build a new tree or O(log n) for get() and set() operations,
 /// where `n = tree.len()`.
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct FenwickTree<T: Default + Ord, Op: PrefixOp<T>> {
     tree: Vec<T>,
     phantom: PhantomData<Op>,
@@ -84,6 +85,9 @@ impl<T: Ord + Default + Copy, Op: PrefixOp<T>> FenwickTree<T, Op> {
     }
 }
 
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct MaxOp;
 impl<T: Copy + Ord> PrefixOp<T> for MaxOp {
     fn operation(t1: T, t2: T) -> T {
@@ -94,6 +98,9 @@ impl<T: Copy + Ord> PrefixOp<T> for MaxOp {
 /// Fenwick tree specialized for prefix-max
 pub type MaxBitTree<T> = FenwickTree<T, MaxOp>;
 
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct SumOp;
 impl<T: Copy + Add> PrefixOp<T> for SumOp
 where

--- a/src/data_structures/bitenc.rs
+++ b/src/data_structures/bitenc.rs
@@ -46,7 +46,7 @@
 /// For values that are not a divider of 32, some bits will remain unused.
 /// For example for `width = 7` only `4 * 7 = 28` bits are used.
 /// Five 7-bit values are stored in 2 blocks.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct BitEnc {
     storage: Vec<u32>,
     width: usize,
@@ -385,7 +385,7 @@ impl BitEnc {
     /// // Add another 2 to create a second block
     /// bitenc.push(2);
     /// assert_eq!(bitenc.nr_blocks(), 2);
-    /// ```    
+    /// ```
     pub fn nr_blocks(&self) -> usize {
         self.storage.len()
     }
@@ -408,7 +408,7 @@ impl BitEnc {
     /// assert_eq!(bitenc.nr_symbols(), 4);
     /// bitenc.push(2);
     /// assert_eq!(bitenc.nr_symbols(), 5);
-    /// ```    
+    /// ```
     pub fn nr_symbols(&self) -> usize {
         self.len
     }
@@ -436,6 +436,7 @@ impl BitEnc {
 
 /// Iterator over values of a bitencoded sequence (values will be unpacked into bytes).
 /// Used to implement the `iter` method of `BitEnc`.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
 pub struct BitEncIter<'a> {
     bitenc: &'a BitEnc,
     i: usize,

--- a/src/data_structures/bwt.rs
+++ b/src/data_structures/bwt.rs
@@ -73,7 +73,7 @@ pub fn invert_bwt(bwt: &BWTSlice) -> Vec<u8> {
 }
 
 /// An occurrence array implementation.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Occ {
     occ: Vec<Vec<usize>>,
     k: u32,

--- a/src/data_structures/fmindex.rs
+++ b/src/data_structures/fmindex.rs
@@ -63,7 +63,9 @@ use crate::data_structures::suffix_array::SuffixArray;
 use std::mem::swap;
 
 /// A suffix array interval.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct Interval {
     pub lower: usize,
     pub upper: usize,
@@ -86,7 +88,7 @@ impl Interval {
 /// The interval returned is the range of suffix array indices for the maximal
 /// matching suffix, and the `usize` is the length of the maximal matching suffix.
 /// Absent - None suffix of the pattern matched in the text.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub enum BackwardSearchResult {
     Complete(Interval),
     Partial(Interval, usize),
@@ -201,7 +203,9 @@ pub trait FMIndexable {
 
 /// The Fast Index in Minute space (FM-Index, Ferragina and Manzini, 2000) for finding suffix array
 /// intervals matching a given pattern.
-#[derive(Serialize, Deserialize)]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct FMIndex<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> {
     bwt: DBWT,
     less: DLess,
@@ -237,7 +241,9 @@ impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> FMIndex<DBWT, DL
 }
 
 /// A bi-interval on suffix array of the forward and reverse strand of a DNA text.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct BiInterval {
     lower: usize,
     lower_rev: usize,
@@ -271,7 +277,9 @@ impl BiInterval {
 
 /// The FMD-Index for linear time search of supermaximal exact matches on forward and reverse
 /// strand of DNA texts (Li, 2012).
-#[derive(Serialize, Deserialize)]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct FMDIndex<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> {
     fmindex: FMIndex<DBWT, DLess, DOcc>,
 }

--- a/src/data_structures/interpolation_table.rs
+++ b/src/data_structures/interpolation_table.rs
@@ -36,6 +36,7 @@ pub fn interpolate(a: f64, b: f64, fraction: f64) -> f64 {
 /// Input values are sampled with a given precision and results are stored in a vector.
 /// During lookup, infimum and supremum of a given value are calculated and the result is
 /// interpolated.
+#[derive(Default, Clone, PartialEq, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct InterpolationTable<F: Fn(f64) -> f64> {
     inner: Vec<f64>,
     func: F,

--- a/src/data_structures/interval_tree/array_backed_interval_tree.rs
+++ b/src/data_structures/interval_tree/array_backed_interval_tree.rs
@@ -39,7 +39,7 @@ use std::iter::FromIterator;
 
 /// A `find` query on the interval tree does not directly return references to the intervals in the
 /// tree but wraps the fields `interval` and `data` in an `Entry`.
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
 struct InternalEntry<N: Ord + Clone + Copy, D> {
     data: D,
     interval: Interval<N>,
@@ -48,7 +48,7 @@ struct InternalEntry<N: Ord + Clone + Copy, D> {
 
 /// A `find` query on the interval tree does not directly return references to the nodes in the tree, but
 /// wraps the fields `interval` and `data` in an `Entry`.
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize)]
 pub struct Entry<'a, N: Ord + Clone, D> {
     data: &'a D,
     interval: &'a Interval<N>,
@@ -76,6 +76,7 @@ impl<N: Ord + Clone + Copy, D> Default for ArrayBackedIntervalTree<N, D> {
     }
 }
 
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
 pub struct ArrayBackedIntervalTree<N: Ord + Clone + Copy, D> {
     entries: Vec<InternalEntry<N, D>>,
     max_level: usize,

--- a/src/data_structures/interval_tree/avl_interval_tree.rs
+++ b/src/data_structures/interval_tree/avl_interval_tree.rs
@@ -30,8 +30,9 @@ use crate::utils::Interval;
 use std::cmp;
 use std::iter::FromIterator;
 use std::mem;
+
 /// An interval tree for storing intervals with data
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
 pub struct IntervalTree<N: Ord + Clone, D> {
     root: Option<Node<N, D>>,
 }
@@ -44,7 +45,7 @@ impl<N: Ord + Clone, D> Default for IntervalTree<N, D> {
 
 /// A `find` query on the interval tree does not directly return references to the nodes in the tree, but
 /// wraps the fields `interval` and `data` in an `Entry`.
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize)]
 pub struct Entry<'a, N: Ord + Clone, D> {
     data: &'a D,
     interval: &'a Interval<N>,
@@ -64,6 +65,7 @@ impl<'a, N: Ord + Clone + 'a, D: 'a> Entry<'a, N, D> {
 
 /// An `IntervalTreeIterator` is returned by `Intervaltree::find` and iterates over the entries
 /// overlapping the query
+#[derive(Default, Clone, Eq, PartialEq, Hash, Debug, Serialize)]
 pub struct IntervalTreeIterator<'a, N: Ord + Clone, D> {
     nodes: Vec<&'a Node<N, D>>,
     interval: Interval<N>,
@@ -108,7 +110,7 @@ impl<'a, N: Ord + Clone + 'a, D: 'a> Iterator for IntervalTreeIterator<'a, N, D>
 /// A `find_mut` query on the interval tree does not directly return references to the nodes in the tree, but
 /// wraps the fields `interval` and `data` in an `EntryMut`. Only the data part can be mutably accessed
 /// using the `data` method
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Eq, PartialEq, Hash, Debug, Serialize)]
 pub struct EntryMut<'a, N: Ord + Clone, D> {
     data: &'a mut D,
     interval: &'a Interval<N>,
@@ -128,6 +130,7 @@ impl<'a, N: Ord + Clone + 'a, D: 'a> EntryMut<'a, N, D> {
 
 /// An `IntervalTreeIteratorMut` is returned by `Intervaltree::find_mut` and iterates over the entries
 /// overlapping the query allowing mutable access to the data `D`, not the `Interval`.
+#[derive(Default, Eq, PartialEq, Hash, Debug, Serialize)]
 pub struct IntervalTreeIteratorMut<'a, N: Ord + Clone, D> {
     nodes: Vec<&'a mut Node<N, D>>,
     interval: Interval<N>,
@@ -229,7 +232,7 @@ impl<N: Clone + Ord, D, R: Into<Interval<N>>> FromIterator<(R, D)> for IntervalT
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
 struct Node<N: Ord + Clone, D> {
     // actual interval data
     interval: Interval<N>,

--- a/src/data_structures/qgram_index.rs
+++ b/src/data_structures/qgram_index.rs
@@ -38,7 +38,7 @@ use crate::utils;
 /// A classical, flexible, q-gram index implementation.
 ///
 /// Uses |alphabet|^q + k words of memory, where k is the number of q-grams in the text with count at most `max_count` (if specified).
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct QGramIndex {
     q: u32,
     // For each q-gram, the position in `pos` where positions for this q-gram are stored.
@@ -208,7 +208,9 @@ impl QGramIndex {
 }
 
 /// An interval, consisting of start and stop position (the latter exclusive).
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct Interval {
     pub start: usize,
     pub stop: usize,
@@ -222,7 +224,7 @@ impl Interval {
 }
 
 /// A match between the pattern and the text.
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
 pub struct Match {
     pub pattern: Interval,
     pub text: Interval,
@@ -242,7 +244,9 @@ impl cmp::PartialOrd for Match {
 }
 
 /// An exact match between the pattern and the text.
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct ExactMatch {
     pub pattern: Interval,
     pub text: Interval,

--- a/src/data_structures/rank_select.rs
+++ b/src/data_structures/rank_select.rs
@@ -31,7 +31,7 @@ use bv::BitVec;
 use bv::Bits;
 
 /// A rank/select data structure.
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct RankSelect {
     n: usize,
     bits: BitVec<u8>,
@@ -204,7 +204,7 @@ impl RankSelect {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
 pub enum SuperblockRank {
     First(u64),
     Some(u64),

--- a/src/data_structures/smallints.rs
+++ b/src/data_structures/smallints.rs
@@ -39,7 +39,7 @@ use num_traits::{cast, Bounded, Num, NumCast};
 
 /// Data structure for storing a sequence of small integers with few big ones space efficiently
 /// while supporting classical vector operations.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct SmallInts<F: Integer + Bounded + NumCast + Copy, B: Integer + NumCast + Copy> {
     smallints: Vec<F>,
     bigints: BTreeMap<usize, B>,
@@ -166,6 +166,7 @@ impl<S: Integer + Bounded + NumCast + Copy, B: Integer + NumCast + Copy> SmallIn
 }
 
 /// Iterator over the elements of a `SmallInts` sequence.
+#[derive(Clone, Debug)]
 pub struct Iter<'a, S, B>
 where
     S: Integer + Bounded + NumCast + Copy,

--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -37,8 +37,6 @@ use vec_map::VecMap;
 
 use fxhash::FxHasher;
 
-use serde::{Deserialize, Serialize};
-
 use crate::alphabets::{Alphabet, RankTransform};
 use crate::data_structures::bwt::{Less, Occ, BWT};
 use crate::data_structures::smallints::SmallInts;
@@ -122,7 +120,7 @@ pub trait SuffixArray {
 }
 
 /// A sampled suffix array.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Default, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct SampledSuffixArray<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> {
     bwt: DBWT,
     less: DLess,

--- a/src/data_structures/wavelet_matrix.rs
+++ b/src/data_structures/wavelet_matrix.rs
@@ -33,7 +33,7 @@ const DNA2INT: [u8; 128] = [
     0, 0, 0, 0, 0, 0, 0, 0,
 ]; // 120
 
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct WaveletMatrix {
     width: usize,  // levels[0].len()
     height: usize, // zeros.len() == levels.len()

--- a/src/io/bed.rs
+++ b/src/io/bed.rs
@@ -119,7 +119,7 @@ impl<W: io::Write> Writer<W> {
 
 /// A BED record as defined by BEDtools
 /// (http://bedtools.readthedocs.org/en/latest/content/general-usage.html)
-#[derive(Debug, Serialize, Default, Deserialize, Clone)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Record {
     chrom: String,
     start: u64,

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -151,7 +151,7 @@ pub trait FastaRead {
 }
 
 /// A FASTA reader.
-#[derive(Debug)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Reader<B> {
     reader: B,
     line: String,
@@ -345,7 +345,7 @@ where
 }
 
 /// A FASTA index as created by SAMtools (.fai).
-#[derive(Debug, Clone)]
+#[derive(Default, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Index {
     inner: Vec<IndexRecord>,
     name_to_rid: collections::HashMap<String, usize>,
@@ -712,7 +712,7 @@ impl<R: io::Read + io::Seek> IndexedReader<R> {
 }
 
 /// Record of a FASTA index.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 struct IndexRecord {
     name: String,
     len: u64,
@@ -722,12 +722,13 @@ struct IndexRecord {
 }
 
 /// A sequence record returned by the FASTA index.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Sequence {
     pub name: String,
     pub len: u64,
 }
 
+#[derive(Debug)]
 pub struct IndexedReaderIterator<'a, R: io::Read + io::Seek> {
     reader: &'a mut IndexedReader<R>,
     record: IndexRecord,
@@ -883,7 +884,7 @@ impl<W: io::Write> Writer<W> {
 }
 
 /// A FASTA record.
-#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Record {
     id: String,
     desc: Option<String>,
@@ -1009,6 +1010,7 @@ impl fmt::Display for Record {
 }
 
 /// An iterator over the records of a Fasta file.
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Records<B>
 where
     B: io::BufRead,

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -136,7 +136,7 @@ pub trait FastqRead {
 }
 
 /// A FastQ reader.
-#[derive(Debug)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Reader<B> {
     reader: B,
     line_buffer: String,
@@ -295,7 +295,7 @@ where
 }
 
 /// A FastQ record.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Record {
     id: String,
     desc: Option<String>,
@@ -487,7 +487,7 @@ impl SequenceRead for Record {
 }
 
 /// An iterator over the records of a FastQ file.
-#[derive(Debug)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Records<R: io::Read> {
     reader: Reader<R>,
 }

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -41,7 +41,7 @@ use bio_types::strand::Strand;
 /// We have three format in the GFF family.
 /// The change is in the last field of GFF.
 /// For each type we have key value separator and field separator
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub enum GffType {
     /// Attribute format is: key1=value; key2=value1,value2
     GFF3,
@@ -258,7 +258,7 @@ impl<W: io::Write> Writer<W> {
 }
 
 /// A GFF record
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[derive(Default, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Record {
     seqname: String,
     source: String,

--- a/src/io/newick.rs
+++ b/src/io/newick.rs
@@ -29,21 +29,7 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 /// A `thiserror` error type gathering all the potential bad outcomes
-#[derive(
-    Debug,
-    Error,
-    Default,
-    Copy,
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Debug,
-    Serialize,
-    Deserialize,
-)]
+#[derive(Debug, Error)]
 pub enum Error {
     #[error("Error while opening {}: {}", filename.display(), source)]
     OpenFile {

--- a/src/io/newick.rs
+++ b/src/io/newick.rs
@@ -29,7 +29,21 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 /// A `thiserror` error type gathering all the potential bad outcomes
-#[derive(Debug, Error)]
+#[derive(
+    Debug,
+    Error,
+    Default,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Debug,
+    Serialize,
+    Deserialize,
+)]
 pub enum Error {
     #[error("Error while opening {}: {}", filename.display(), source)]
     OpenFile {
@@ -52,6 +66,9 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 /// file
 #[derive(Parser)]
 #[grammar = "io/newick.pest"]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct NewickParser;
 
 /// A hidden, temporary datatype used to collect the parser result

--- a/src/pattern_matching/bndm.rs
+++ b/src/pattern_matching/bndm.rs
@@ -23,6 +23,7 @@ use crate::utils::TextSlice;
 use std::borrow::Borrow;
 
 /// BNDM algorithm.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct BNDM {
     m: usize,
     masks: [u64; 256],
@@ -58,6 +59,7 @@ impl BNDM {
 }
 
 /// Iterator over start positions of matches.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Matches<'a> {
     bndm: &'a BNDM,
     window: usize,

--- a/src/pattern_matching/bom.rs
+++ b/src/pattern_matching/bom.rs
@@ -26,6 +26,7 @@ use std::iter::repeat;
 use vec_map::VecMap;
 
 /// Backward oracle matching algorithm.
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct BOM {
     m: usize,
     table: Vec<VecMap<usize>>,
@@ -103,6 +104,7 @@ impl BOM {
 }
 
 /// Iterator over start positions of matches.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
 pub struct Matches<'a> {
     bom: &'a BOM,
     text: TextSlice<'a>,

--- a/src/pattern_matching/horspool.rs
+++ b/src/pattern_matching/horspool.rs
@@ -41,6 +41,7 @@
 use crate::utils::TextSlice;
 
 /// Algorithm of Horspool.
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
 pub struct Horspool<'a> {
     shift: Vec<usize>,
     m: usize,
@@ -75,6 +76,7 @@ impl<'a> Horspool<'a> {
 }
 
 /// Iterator over start positions of matches.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
 pub struct Matches<'a> {
     horspool: &'a Horspool<'a>,
     text: TextSlice<'a>,

--- a/src/pattern_matching/kmp.rs
+++ b/src/pattern_matching/kmp.rs
@@ -30,6 +30,7 @@ use crate::utils::TextSlice;
 type Lps = Vec<usize>;
 
 /// KMP algorithm.
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
 pub struct KMP<'a> {
     m: usize,
     lps: Lps,
@@ -88,6 +89,7 @@ fn lps(pattern: &[u8]) -> Lps {
 }
 
 /// Iterator over start positions of matches.
+#[derive(Clone, Debug)]
 pub struct Matches<'a, C, T>
 where
     C: Borrow<u8>,

--- a/src/pattern_matching/myers/builder.rs
+++ b/src/pattern_matching/myers/builder.rs
@@ -47,7 +47,7 @@ use super::{BitVec, Myers};
 /// Note that only ambiguities in the pattern are recognized. The reverse is not true; ambiguities
 /// in the search text are not matched by multiple symbols in the pattern. This would require
 /// specifying additional ambiguities (`builder.ambig(b'A', b"MRWVHDN")`, etc...).
-#[derive(Default, Clone, Eq, PartialEq)]
+#[derive(Default, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct MyersBuilder {
     ambigs: HashMap<u8, Vec<u8>>,
     wildcards: Vec<u8>,

--- a/src/pattern_matching/myers/long.rs
+++ b/src/pattern_matching/myers/long.rs
@@ -367,8 +367,8 @@ impl<'a, T: BitVec> LongTracebackHandler<'a, T> {
         LongTracebackHandler {
             block_pos: n_blocks - 1,
             left_block_pos: n_blocks - 1,
-            block: col.last().unwrap().clone(),
-            left_block: left_col.last().unwrap().clone(),
+            block: *col.last().unwrap(),
+            left_block: *left_col.last().unwrap(),
             col,
             left_col,
             states_iter,
@@ -420,7 +420,7 @@ impl<'a, T: BitVec + 'a> TracebackHandler<'a, T, usize> for LongTracebackHandler
             self.pos_bitvec = T::one() << (word_size::<T>() - 1);
             self.block_pos -= 1;
             if adjust_dist {
-                self.block = self.col[self.block_pos].clone();
+                self.block = self.col[self.block_pos];
             }
         }
     }
@@ -441,7 +441,7 @@ impl<'a, T: BitVec + 'a> TracebackHandler<'a, T, usize> for LongTracebackHandler
             self.left_mask = T::zero();
             self.left_block_pos -= 1;
             if adjust_dist {
-                self.left_block = self.left_col[self.left_block_pos].clone();
+                self.left_block = self.left_col[self.left_block_pos];
             }
         }
     }
@@ -450,10 +450,7 @@ impl<'a, T: BitVec + 'a> TracebackHandler<'a, T, usize> for LongTracebackHandler
     fn move_to_left(&mut self) {
         self.col = self.left_col;
         self.left_col = self.states_iter.next().unwrap();
-        self.block = replace(
-            &mut self.left_block,
-            self.left_col[self.left_block_pos].clone(),
-        );
+        self.block = replace(&mut self.left_block, self.left_col[self.left_block_pos]);
         self.left_block.adjust_by_mask(self.left_mask);
     }
 
@@ -469,7 +466,7 @@ impl<'a, T: BitVec + 'a> TracebackHandler<'a, T, usize> for LongTracebackHandler
             // more complicated: at lower block boundary, and there is a lower block
             if b.mv & T::one() == T::one() {
                 let d = self.left_block().dist - 1;
-                self.left_block = b.clone();
+                self.left_block = *b;
                 self.left_block.dist = d;
                 return true;
             }

--- a/src/pattern_matching/myers/long.rs
+++ b/src/pattern_matching/myers/long.rs
@@ -25,12 +25,14 @@ use crate::pattern_matching::myers::{ceil_div, State};
 use super::word_size;
 use super::BitVec;
 
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 struct Peq<T: BitVec> {
     peq: [T; 256],
     bound: T,
 }
 
 /// Myers algorithm.
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Myers<T = u64>
 where
     T: BitVec,
@@ -164,6 +166,7 @@ fn advance_block<T: BitVec>(state: &mut State<T, usize>, p: &Peq<T>, a: u8, hin:
     hout
 }
 
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub(super) struct States<T: BitVec> {
     states: Vec<State<T, usize>>,
     max_block: usize,
@@ -243,7 +246,9 @@ where
     }
 }
 
-#[derive(Default)]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub(super) struct LongStatesHandler<'a> {
     n_blocks: usize,
     _a: PhantomData<&'a ()>,

--- a/src/pattern_matching/myers/myers_impl.rs
+++ b/src/pattern_matching/myers/myers_impl.rs
@@ -2,7 +2,9 @@ use crate::pattern_matching::myers::{BitVec, DistType};
 use num_traits::ToPrimitive;
 
 /// The current algorithm state.
-#[derive(Clone, Default, Debug)]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub(crate) struct State<T, D>
 where
     T: BitVec,
@@ -221,6 +223,7 @@ impl<T: BitVec> $Myers {
 }
 
 /// Iterator over pairs of end positions and distance of matches.
+#[derive(Clone, Debug)]
 pub struct Matches<'a, T, C, I>
 where
     T: BitVec,
@@ -274,6 +277,7 @@ where
 
 /// Iterator over tuples of starting position, end position and distance of matches. In addition,
 /// methods for obtaining the hit alignment path are provided.
+#[derive(Debug)]
 pub struct FullMatches<'a, T, C, I>
 where
     T: BitVec,
@@ -468,6 +472,7 @@ where
 
 /// Iterator over tuples of end position and distance of matches. In addition,
 /// methods for obtaining the hit alignment path are provided.
+#[derive(Debug)]
 pub struct LazyMatches<'a, T, C, I>
 where
     T: BitVec,

--- a/src/pattern_matching/myers/simple.rs
+++ b/src/pattern_matching/myers/simple.rs
@@ -12,6 +12,7 @@ use crate::pattern_matching::myers::traceback::{StatesHandler, TracebackHandler}
 use crate::pattern_matching::myers::{BitVec, State};
 
 /// Myers algorithm.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Myers<T = u64>
 where
     T: BitVec,
@@ -121,7 +122,9 @@ impl<T: BitVec> Myers<T> {
     }
 }
 
-#[derive(Default)]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub(super) struct ShortStatesHandler<'a>(PhantomData<&'a ()>);
 
 impl<'a> ShortStatesHandler<'a> {

--- a/src/pattern_matching/myers/simple.rs
+++ b/src/pattern_matching/myers/simple.rs
@@ -157,7 +157,7 @@ impl<'a, T: BitVec + 'a> StatesHandler<'a, T, T::DistType> for ShortStatesHandle
         states: &mut [State<T, T::DistType>],
     ) {
         //states[pos] = source.clone();
-        *unsafe { states.get_unchecked_mut(pos) } = source.clone();
+        *unsafe { states.get_unchecked_mut(pos) } = *source;
     }
 
     #[inline]
@@ -200,8 +200,8 @@ impl<'a, T: BitVec> ShortTracebackHandler<'a, T> {
         // let mut states = states.iter().rev().cycle().skip(states.len() - pos - 1);
 
         ShortTracebackHandler {
-            state: states_iter.next().unwrap().clone(),
-            left_state: states_iter.next().unwrap().clone(),
+            state: *states_iter.next().unwrap(),
+            left_state: *states_iter.next().unwrap(),
             states_iter,
             max_mask: mask0,
             pos_bitvec: mask0,
@@ -258,10 +258,7 @@ where
 
     #[inline]
     fn move_to_left(&mut self) {
-        self.state = replace(
-            &mut self.left_state,
-            self.states_iter.next().unwrap().clone(),
-        );
+        self.state = replace(&mut self.left_state, *self.states_iter.next().unwrap());
         self.left_state.adjust_by_mask(self.left_mask);
     }
 

--- a/src/pattern_matching/myers/traceback.rs
+++ b/src/pattern_matching/myers/traceback.rs
@@ -170,6 +170,7 @@ where
     }
 }
 
+#[derive(Clone, Debug)]
 pub(super) struct Traceback<'a, T, D, H>
 where
     T: BitVec + 'a,

--- a/src/pattern_matching/pssm/dnamotif.rs
+++ b/src/pattern_matching/pssm/dnamotif.rs
@@ -9,7 +9,7 @@ use std::f32;
 use std::f32::{INFINITY, NEG_INFINITY};
 
 /// Position-specific scoring matrix for DNA sequences
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Default, Clone, PartialEq, Debug)]
 pub struct DNAMotif {
     /// matrix holding weights at each position, indexed by [position, base]
     pub scores: Array2<f32>,

--- a/src/pattern_matching/pssm/errors.rs
+++ b/src/pattern_matching/pssm/errors.rs
@@ -6,7 +6,9 @@
 //! Error definitions for the `pssm` module.
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(
+    Error, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub enum Error {
     #[error(
         "query length {} is shorter than motif length {}",

--- a/src/pattern_matching/pssm/mod.rs
+++ b/src/pattern_matching/pssm/mod.rs
@@ -54,7 +54,7 @@ pub const EPSILON: f32 = 1e-5;
 pub const INVALID_MONO: u8 = 255;
 
 /// Represents motif score & location of match
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct ScoredPos {
     pub loc: usize,
     pub sum: f32,

--- a/src/pattern_matching/pssm/protmotif.rs
+++ b/src/pattern_matching/pssm/protmotif.rs
@@ -9,7 +9,7 @@ use std::f32;
 use std::f32::{INFINITY, NEG_INFINITY};
 
 /// Position-specific scoring matrix for protein sequences
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Default, Clone, PartialEq, Debug)]
 pub struct ProtMotif {
     /// matrix holding weights at each position, indexed by [position, base]
     pub scores: Array2<f32>,

--- a/src/pattern_matching/shift_and.rs
+++ b/src/pattern_matching/shift_and.rs
@@ -22,6 +22,7 @@ use std::borrow::Borrow;
 use std::iter::Enumerate;
 
 /// `ShiftAnd` algorithm.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct ShiftAnd {
     m: usize,
     masks: [u64; 256],
@@ -78,6 +79,7 @@ where
 }
 
 /// Iterator over start positions of matches.
+#[derive(Clone, Debug)]
 pub struct Matches<'a, C, T>
 where
     C: Borrow<u8>,

--- a/src/pattern_matching/ukkonen.rs
+++ b/src/pattern_matching/ukkonen.rs
@@ -38,6 +38,7 @@ pub fn unit_cost(a: u8, b: u8) -> u32 {
 
 /// Ukkonens algorithm.
 #[allow(non_snake_case)]
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Ukkonen<F>
 where
     F: Fn(u8, u8) -> u32,
@@ -88,6 +89,7 @@ where
 }
 
 /// Iterator over pairs of end positions and distance of matches.
+#[derive(Debug)]
 pub struct Matches<'a, F, C, T>
 where
     F: Fn(u8, u8) -> u32,

--- a/src/seq_analysis/orf.rs
+++ b/src/seq_analysis/orf.rs
@@ -40,6 +40,7 @@ use std::iter;
 // codons because a VecDeque<u8> is used to represent a sliding codon
 // (see: State.codon) window which unfortunately, cannot be compared
 // to [u8; 3].
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Finder {
     start_codons: Vec<VecDeque<u8>>,
     stop_codons: Vec<VecDeque<u8>>,
@@ -84,7 +85,9 @@ impl Finder {
 /// An ORF representation with start and end position of said ORF,
 /// as well as offset of the reading frame (1,2,3) and strand location
 // (current: +, reverse complementary: -).
-#[derive(Debug, PartialEq, Eq)]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct Orf {
     pub start: usize,
     pub end: usize,
@@ -92,6 +95,7 @@ pub struct Orf {
 }
 
 /// The current algorithm state.
+#[derive(Clone, Debug)]
 struct State {
     start_pos: [Vec<usize>; 3],
     codon: VecDeque<u8>,
@@ -110,6 +114,7 @@ impl State {
 }
 
 /// Iterator over offset, start position, end position and sequence of matched ORFs.
+#[derive(Clone, Debug)]
 pub struct Matches<'a, C, T>
 where
     C: Borrow<u8>,

--- a/src/stats/bayesian/bayes_factors.rs
+++ b/src/stats/bayesian/bayes_factors.rs
@@ -35,15 +35,7 @@ pub mod evidence {
 
 custom_derive! {
     /// A newtype for Bayes factors.
-    #[derive(
-        NewtypeFrom,
-        NewtypeDeref,
-        PartialEq,
-        PartialOrd,
-        Copy,
-        Clone,
-        Debug,
-    )]
+    #[derive(NewtypeFrom, NewtypeDeref, NewtypeAdd(*), NewtypeSub(*), Default, Copy, Clone, PartialEq, PartialOrd, Debug)]
     pub struct BayesFactor(pub f64);
 }
 

--- a/src/stats/bayesian/model.rs
+++ b/src/stats/bayesian/model.rs
@@ -53,7 +53,21 @@ pub trait Posterior {
 /// This can be used to define custom caching mechanisms. See
 /// [here](https://github.com/varlociraptor/varlociraptor/blob/694e994547e8f523e5b0013fdf951b694f3870fa/src/model/modes/generic.rs#L200)
 /// for an example.
-#[derive(Clone, Debug, Getters, MutGetters)]
+#[derive(
+    Default,
+    Getters,
+    MutGetters,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Debug,
+    Serialize,
+    Deserialize,
+)]
 pub struct Model<L, Pr, Po, Payload = ()>
 where
     L: Likelihood<Payload>,
@@ -182,6 +196,7 @@ pub trait Marginal {
 
 /// Instance of a model for given data and event universe.
 /// From the instance, posterior, marginal and MAP can be computed.
+#[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct ModelInstance<Event, PosteriorEvent>
 where
     Event: Hash + Eq,

--- a/src/stats/hmm/errors.rs
+++ b/src/stats/hmm/errors.rs
@@ -6,7 +6,9 @@
 //! Error definitions for the `hmm` module.
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(
+    Error, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub enum Error {
     #[error(
         "inferred from A: N_0={}, N_1={} (must be equal), from B: N={}, M={}, from pi: N={}",

--- a/src/stats/hmm/mod.rs
+++ b/src/stats/hmm/mod.rs
@@ -101,20 +101,41 @@ use std::collections::BTreeMap;
 
 custom_derive! {
     /// A newtype for HMM states.
+    // #[derive(
+    //     NewtypeFrom,
+    //     NewtypeDeref,
+    //     Default,
+    //     Copy,
+    //     Clone,
+    //     Eq,
+    //     PartialEq,
+    //     Ord,
+    //     PartialOrd,
+    //     Hash,
+    //     Debug,
+    // )]
+    // #[derive(Serialize, Deserialize)]
     #[derive(
         NewtypeFrom,
         NewtypeDeref,
-        PartialEq,
-        Eq,
+        Default,
         Copy,
         Clone,
-        Debug
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd,
+        Hash,
+        Debug,
     )]
-    // #[derive(Serialize, Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     pub struct State(pub usize);
 }
 
 /// Iterate over the states of a `Model`.
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct StateIter {
     nxt: usize,
     max: usize,
@@ -145,7 +166,9 @@ impl Iterator for StateIter {
 }
 
 /// Transition between two states in a `Model`.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct StateTransition {
     /// Source of the transition.
     pub src: State,
@@ -161,6 +184,9 @@ impl StateTransition {
 }
 
 /// Iterate over all state transitions of a `Model`.
+#[derive(
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct StateTransitionIter {
     nxt_a: usize,
     nxt_b: usize,
@@ -697,7 +723,7 @@ pub mod discrete_emission {
     /// The state transition matrix with dimensions `NxN` is `A`, the observation probability
     /// distribution is the matrix `B` with dimensions `NxM` and the initial state distribution `pi`
     /// has length `N`.
-    #[derive(Debug, PartialEq)]
+    #[derive(Default, Clone, PartialEq, Debug)]
     pub struct Model {
         /// The state transition matrix (size `NxN`), `A` in Rabiner's tutorial.
         transition: Array2<LogProb>,
@@ -821,7 +847,7 @@ pub mod discrete_emission_opt_end {
     /// has length `N`. We also included a silent end state `ε` with vector length `N` that do not emit symbols for
     /// modelling the end of sequences. It's optional to supply the end probabilities at the creation of the model.
     /// If this happens, we'll create a dummy end state to simulate as if the end state has not been included.
-    #[derive(Debug, PartialEq)]
+    #[derive(Default, Clone, PartialEq, Debug)]
     pub struct Model {
         /// The state transition matrix (size `NxN`), `A` in Rabiner's tutorial.
         transition: RefCell<Array2<LogProb>>,
@@ -1094,6 +1120,7 @@ pub mod univariate_continuous_emission {
     /// Implementation of a `hmm::Model` with emission values from univariate continuous distributions.
     ///
     /// Log-scale probabilities are used for numeric stability.
+    #[derive(Default, Clone, PartialEq, Debug)]
     pub struct Model<Dist: Continuous<f64, f64>> {
         /// The state transition matrix (size `NxN`), `A` in Rabiner's tutorial.
         transition: Array2<LogProb>,

--- a/src/stats/pairhmm/homopolypairhmm.rs
+++ b/src/stats/pairhmm/homopolypairhmm.rs
@@ -83,8 +83,10 @@ use crate::stats::probs::LogProb;
 use crate::stats::Prob;
 use std::collections::HashMap;
 
-#[derive(Eq, PartialEq, Debug, Enum, Clone, Copy)]
 #[repr(usize)]
+#[derive(
+    Enum, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub enum State {
     MatchA = 0,
     MatchC = 1,
@@ -213,7 +215,7 @@ impl<H: HopParameters> BaseSpecificHopParameters for H {
 /// Current Topics in Genome Analysis 2008. http://doi.org/10.1017/CBO9780511790492.
 /// The default model has been extended to consider homopolymer errors, at the cost of more states
 /// and transitions.
-#[derive(Debug, Clone)]
+#[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct HomopolyPairHMM {
     transition_probs: HashMap<usize, LogProb>,
 }

--- a/src/stats/pairhmm/mod.rs
+++ b/src/stats/pairhmm/mod.rs
@@ -176,7 +176,7 @@ pub trait StartEndGapParameters {
     fn free_end_gap_x(&self) -> bool;
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Serialize, Deserialize)]
 pub enum XYEmission {
     Match(LogProb),
     Mismatch(LogProb),

--- a/src/stats/pairhmm/pairhmm.rs
+++ b/src/stats/pairhmm/pairhmm.rs
@@ -44,7 +44,7 @@ fn ln_sum3_exp_approx(mut p0: LogProb, mut p1: LogProb, mut p2: LogProb) -> LogP
 /// A pair Hidden Markov Model for comparing sequences x and y as described by
 /// Durbin, R., Eddy, S., Krogh, A., & Mitchison, G. (1998). Biological Sequence Analysis.
 /// Current Topics in Genome Analysis 2008. http://doi.org/10.1017/CBO9780511790492.
-#[derive(Debug, Clone)]
+#[derive(Default, Clone, PartialEq, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct PairHMM {
     fm: [Vec<LogProb>; 2],
     fx: [Vec<LogProb>; 2],
@@ -54,7 +54,7 @@ pub struct PairHMM {
     gap_params: GapParamCache,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Clone, PartialEq, PartialOrd, Debug, Serialize, Deserialize)]
 struct GapParamCache {
     prob_no_gap: LogProb,
     prob_no_gap_x_extend: LogProb,

--- a/src/stats/probs/cdf.rs
+++ b/src/stats/probs/cdf.rs
@@ -106,7 +106,7 @@ use crate::stats::LogProb;
 
 /// An `Entry` associates a `LogProb` with a value on an ordered axis. It can for example be
 /// used to set up probability mass functions or cumulative distribution functions ([CDF](struct.CDF)).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Copy, Clone, PartialEq, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct Entry<T: Ord> {
     /// A `value` on the ordered axis, which has to have the Trait [`std::cmp::Ord`](https://doc.rust-lang.org/std/cmp/trait.Ord.html) implemented.
     pub value: T,
@@ -136,7 +136,7 @@ impl<T: Ord> Entry<T> {
 }
 
 /// Implementation of a cumulative distribution function as a vector of `Entry`s.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Clone, PartialEq, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct CDF<T: Ord> {
     inner: Vec<Entry<T>>,
 }

--- a/src/stats/probs/errors.rs
+++ b/src/stats/probs/errors.rs
@@ -6,7 +6,7 @@
 //! Error definitions for the `probs` module.
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Copy, Clone, PartialEq, PartialOrd, Debug, Serialize, Deserialize)]
 pub enum Error {
     #[error("probabilty {} not in interval [0,1]", prob)]
     InvalidProb { prob: f64 },

--- a/src/stats/probs/mod.rs
+++ b/src/stats/probs/mod.rs
@@ -67,14 +67,14 @@ custom_derive! {
         NewtypeSub(*),
         NewtypeMul(*),
         NewtypeDiv(*),
-        PartialEq,
-        PartialOrd,
+        Default,
         Copy,
         Clone,
+        PartialEq,
+        PartialOrd,
         Debug,
-        Default
     )]
-    #[derive(Serialize, Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     pub struct Prob(pub f64);
 }
 
@@ -119,13 +119,13 @@ custom_derive! {
         NewtypeDeref,
         NewtypeAdd(*),
         NewtypeSub(*),
-        PartialEq,
-        PartialOrd,
         Copy,
         Clone,
-        Debug
+        PartialEq,
+        PartialOrd,
+        Debug,
     )]
-    #[derive(Serialize, Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     pub struct LogProb(pub f64);
 }
 
@@ -151,13 +151,13 @@ custom_derive! {
         NewtypeDeref,
         NewtypeAdd(*),
         NewtypeSub(*),
-        PartialEq,
-        PartialOrd,
         Copy,
         Clone,
-        Debug
+        PartialEq,
+        PartialOrd,
+        Debug,
     )]
-    #[derive(Serialize, Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     pub struct PHREDProb(pub f64);
 }
 

--- a/src/utils/interval/errors.rs
+++ b/src/utils/interval/errors.rs
@@ -6,7 +6,9 @@
 //! Error definitions for the `interval` module.
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(
+    Error, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 pub enum Error {
     #[error("an Interval must have a Range with a positive width")]
     InvalidRange,

--- a/src/utils/interval/mod.rs
+++ b/src/utils/interval/mod.rs
@@ -30,7 +30,7 @@ pub use self::errors::{Error, Result};
 
 /// An `Interval` wraps the `std::ops::Range` from the stdlib and is defined by a start and end field
 /// where end should be >= start.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
 pub struct Interval<N: Ord + Clone>(Range<N>);
 
 impl<N: Ord + Clone> Interval<N> {


### PR DESCRIPTION
## Implement Rust API Guidelines `C-COMMON-TRAITS` and `C-SERDE`

In working with Rust bio, I needed to fork the project in order to serialize some public types like `Orf`. Missing derive implementations is a common problem I seem to encounter when working with many crates, so I took the afternoon to add every recommended trait (`#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]`) to every `pub struct` and `pub enum` in the crate using a script, then I sat down to sort out the compiler issues.

If derives failed because a private `rust-bio` type didn't implement a certain trait, then derives for those traits were added to private types until they compiled. For derives failing because types outside of `rust-bio` don't implement a trait, those derives were removed until the code compiled.

After adding all of those derives, I also cleaned up a few clippy lints in the second commit. Adding some of those `Copy` derives meant a lot of calls to `Clone` could be removed!

Sorry this looks like a massive change! Should be relatively trivial to review though, since it should only be adding derives and not touching anything more complex.