### PR TITLE
perf: mark dna::complement as inline

### DIFF
--- a/src/alphabets/dna.rs
+++ b/src/alphabets/dna.rs
@@ -62,6 +62,7 @@ lazy_static! {
 /// assert_eq!(dna::complement(89), 82); // Y → R
 /// assert_eq!(dna::complement(115), 115); // s → s
 /// ```
+#[inline]
 pub fn complement(a: u8) -> u8 {
     COMPLEMENT[a as usize]
 }

--- a/src/alphabets/rna.rs
+++ b/src/alphabets/rna.rs
@@ -77,6 +77,7 @@ pub fn complement(a: u8) -> u8 {
 /// assert_eq!(rna::revcomp(b"ACGUN"), b"NACGU");
 /// assert_eq!(rna::revcomp(b"GaUuaCA"), b"UGuaAuC");
 /// assert_eq!(rna::revcomp(b"AGCUYRWSKMDVHBNZ"), b"ZNVDBHKMSWYRAGCU");
+#[inline]
 pub fn revcomp<C, T>(text: T) -> Vec<u8>
 where
     C: Borrow<u8>,

--- a/src/alphabets/rna.rs
+++ b/src/alphabets/rna.rs
@@ -77,7 +77,6 @@ pub fn complement(a: u8) -> u8 {
 /// assert_eq!(rna::revcomp(b"ACGUN"), b"NACGU");
 /// assert_eq!(rna::revcomp(b"GaUuaCA"), b"UGuaAuC");
 /// assert_eq!(rna::revcomp(b"AGCUYRWSKMDVHBNZ"), b"ZNVDBHKMSWYRAGCU");
-#[inline]
 pub fn revcomp<C, T>(text: T) -> Vec<u8>
 where
     C: Borrow<u8>,

--- a/src/alphabets/rna.rs
+++ b/src/alphabets/rna.rs
@@ -62,6 +62,7 @@ lazy_static! {
 /// assert_eq!(rna::complement(115), 115); // s → s
 /// assert_eq!(rna::complement(78), 78); // N → N
 /// ```
+#[inline]
 pub fn complement(a: u8) -> u8 {
     COMPLEMENT[a as usize]
 }


### PR DESCRIPTION
This speeds up computing the complement on a long string by ~2.3x. Not sure why rust doesn't inline such a trivial function on its own.

I didn't manage to compile your benchmarks, hence I can only point to the results from my [own project](https://github.com/kloetzl/libdna/blob/master/rust/benches/Brevcomp.rs).

> dna4_revcomp            time:   [688.18 µs 690.09 µs 692.27 µs]                         
> dnax_revcomp            time:   [3.0615 ms 3.0705 ms 3.0815 ms]                          
> 
> rust-bio                time:   [12.029 ms 12.105 ms 12.212 ms]                     
> rust-bio inlined        time:   [5.0742 ms 5.0901 ms 5.1087 ms]                              

There is still a small overhead of Rust over C. I think Rust repeatedly checks that `a as usize` is a valid index in `COMPLEMENT`. While that is usually not a problem, it is here, because the loop is so small and the extra instructions clog the pipeline.
