### PR TITLE
feat: add `pub use bio_types` to lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,3 +261,4 @@ pub mod scores;
 pub mod seq_analysis;
 pub mod stats;
 pub mod utils;
+pub use bio_types;


### PR DESCRIPTION
I'm not sure this is the right way, but it should ensure users of rust-bio
can drop the direct dependency of bio_types and import via
`use bio::bio_types` instead

Fixes #516
