### PR TITLE
feat: Reverse qgrams iterator

### DIFF
--- a/benches/fmindex.rs
+++ b/benches/fmindex.rs
@@ -26,7 +26,7 @@ fn search_index_seeds(b: &mut Bencher) {
 
         let mut loc_temp = Vec::new();
         for (offset, seed) in seeds {
-            let interval = match fmindex.backward_search(seed.iter()) {
+            match fmindex.backward_search(seed.iter()) {
                 BackwardSearchResult::Complete(interval)
                 | BackwardSearchResult::Partial(interval, _) => {
                     loc_temp.extend((interval.lower..interval.upper).map(|i| (sa[i], offset)))

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -338,6 +338,53 @@ impl RankTransform {
         qgrams
     }
 
+    /// Iterate over q-grams (substrings of length q) of given `text` in reverse. The q-grams are encoded
+    /// as `usize` by storing the symbol ranks in log2(|A|) bits (with |A| being the alphabet size).
+    ///
+    /// If q is larger than usize::BITS / log2(|A|), this method fails with an assertion.
+    ///
+    /// Complexity: O(n), where n is the length of the text.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bio::alphabets;
+    ///
+    /// let dna_alphabet = alphabets::Alphabet::new(b"ACGTacgt");
+    /// let dna_ranks = alphabets::RankTransform::new(&dna_alphabet);
+    ///
+    /// let q_grams: Vec<usize> = dna_ranks.qgrams(2, b"ACGT").collect();
+    /// assert_eq!(q_grams, vec![1, 10, 19]);
+    /// ```
+    pub fn rev_qgrams<C, IT, T>(&self, q: u32, text: IT) -> RevQGrams<'_, C, T>
+    where
+        C: Borrow<u8>,
+        T: DoubleEndedIterator<Item = C>,
+        IT: IntoIterator<IntoIter = T>,
+    {
+        assert!(q > 0, "Expecting q-gram length q to be larger than 0.");
+        let bits = (self.ranks.len() as f32).log2().ceil() as u32;
+        assert!(
+            bits * q <= usize::BITS,
+            "Expecting q to be smaller than usize / log2(|A|)"
+        );
+
+        let mut rev_qgrams = RevQGrams {
+            text: text.into_iter(),
+            ranks: self,
+            q,
+            bits,
+            left_shift: (q - 1) * bits,
+            qgram: 0,
+        };
+
+        for _ in 0..q - 1 {
+            rev_qgrams.next();
+        }
+
+        rev_qgrams
+    }
+
     /// Restore alphabet from transform.
     ///
     /// Complexity: O(n), where n is the number of symbols in the alphabet.
@@ -442,6 +489,63 @@ where
 {
 }
 
+/// Iterator over q-grams.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
+pub struct RevQGrams<'a, C, T>
+where
+    C: Borrow<u8>,
+    T: DoubleEndedIterator<Item = C>,
+{
+    text: T,
+    ranks: &'a RankTransform,
+    q: u32,
+    bits: u32,
+    left_shift: u32,
+    qgram: usize,
+}
+
+impl<'a, C, T> RevQGrams<'a, C, T>
+where
+    C: Borrow<u8>,
+    T: DoubleEndedIterator<Item = C>,
+{
+    /// Push a new character into the current qgram in the reverse direction.
+    fn qgram_push_rev(&mut self, a: u8) {
+        self.qgram >>= self.bits;
+        self.qgram |= (a as usize) << self.left_shift;
+    }
+}
+
+impl<'a, C, T> Iterator for RevQGrams<'a, C, T>
+where
+    C: Borrow<u8>,
+    T: DoubleEndedIterator<Item = C>,
+{
+    type Item = usize;
+
+    fn next(&mut self) -> Option<usize> {
+        match self.text.next_back() {
+            Some(a) => {
+                let b = self.ranks.get(*a.borrow());
+                self.qgram_push_rev(b);
+                Some(self.qgram)
+            }
+            None => None,
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.text.size_hint()
+    }
+}
+
+impl<'a, C, T> ExactSizeIterator for RevQGrams<'a, C, T>
+where
+    C: Borrow<u8>,
+    T: DoubleEndedIterator<Item = C> + ExactSizeIterator<Item = C>,
+{
+}
+
 /// Returns the english ascii lower case alphabet.
 pub fn english_ascii_lower_alphabet() -> Alphabet {
     Alphabet::new(&b"abcdefghijklmnopqrstuvwxyz"[..])
@@ -473,6 +577,28 @@ mod tests {
     }
 
     #[test]
+    fn test_qgrams() {
+        let alphabet = Alphabet::new(b"ACTG");
+        let transform = RankTransform::new(&alphabet);
+        let text = b"ACTGA";
+        let mut qgrams = transform.qgrams(4, text);
+        assert_eq!(qgrams.next(), transform.qgrams(4, b"ACTG").next());
+        assert_eq!(qgrams.next(), transform.qgrams(4, b"CTGA").next());
+        assert_eq!(qgrams.next(), None);
+    }
+
+    #[test]
+    fn test_rev_qgrams() {
+        let alphabet = Alphabet::new(b"ACTG");
+        let transform = RankTransform::new(&alphabet);
+        let text = b"ACTGA";
+        let mut rev_qgrams = transform.rev_qgrams(4, text);
+        assert_eq!(rev_qgrams.next(), transform.qgrams(4, b"CTGA").next());
+        assert_eq!(rev_qgrams.next(), transform.qgrams(4, b"ACTG").next());
+        assert_eq!(rev_qgrams.next(), None);
+    }
+
+    #[test]
     fn test_exactsize_iterator() {
         let alphabet = Alphabet::new(b"ACTG");
         let transform = RankTransform::new(&alphabet);
@@ -483,7 +609,14 @@ mod tests {
         qgrams.next();
         assert_eq!(qgrams.len(), 4);
 
+        let mut rev_qgrams = transform.rev_qgrams(4, text);
+        assert_eq!(rev_qgrams.len(), 5);
+        rev_qgrams.next();
+        assert_eq!(rev_qgrams.len(), 4);
+
         let qgrams = transform.qgrams(4, b"AC");
         assert_eq!(qgrams.len(), 0);
+        let rev_qgrams = transform.rev_qgrams(4, b"AC");
+        assert_eq!(rev_qgrams.len(), 0);
     }
 }

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -354,8 +354,8 @@ impl RankTransform {
     /// let dna_alphabet = alphabets::Alphabet::new(b"ACGTacgt");
     /// let dna_ranks = alphabets::RankTransform::new(&dna_alphabet);
     ///
-    /// let q_grams: Vec<usize> = dna_ranks.qgrams(2, b"ACGT").collect();
-    /// assert_eq!(q_grams, vec![1, 10, 19]);
+    /// let q_grams: Vec<usize> = dna_ranks.rev_qgrams(2, b"ACGT").collect();
+    /// assert_eq!(q_grams, vec![19, 10, 1]);
     /// ```
     pub fn rev_qgrams<C, IT, T>(&self, q: u32, text: IT) -> RevQGrams<'_, C, T>
     where

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -15,7 +15,6 @@
 //! ```
 
 use std::borrow::Borrow;
-use std::mem;
 
 use bit_set::BitSet;
 use vec_map::VecMap;
@@ -316,9 +315,10 @@ impl RankTransform {
         C: Borrow<u8>,
         T: IntoIterator<Item = C>,
     {
+        assert!(q > 0, "Expecting q-gram length q to be larger than 0.");
         let bits = (self.ranks.len() as f32).log2().ceil() as u32;
         assert!(
-            (bits * q) as usize <= mem::size_of::<usize>() * 8,
+            bits * q <= usize::BITS,
             "Expecting q to be smaller than usize / log2(|A|)"
         );
 
@@ -450,7 +450,7 @@ mod tests {
         assert_ne!(Alphabet::new(b"ATCG"), Alphabet::new(b"ATC"));
     }
 
-    /// When `q * bits == usize::BITS`, make sure that `1<<(1*bits)` does not overflow.
+    /// When `q * bits == usize::BITS`, make sure that `1<<(q*bits)` does not overflow.
     #[test]
     fn test_qgram_shiftleft_overflow() {
         let alphabet = Alphabet::new(b"ACTG");

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -259,6 +259,7 @@ impl RankTransform {
     /// assert_eq!(dna_ranks.get(65), 0); // "A"
     /// assert_eq!(dna_ranks.get(116), 7); // "t"
     /// ```
+    #[inline]
     pub fn get(&self, a: u8) -> u8 {
         *self.ranks.get(a as usize).expect("Unexpected character.")
     }
@@ -452,6 +453,7 @@ where
     T: Iterator<Item = C>,
 {
     /// Push a new character into the current qgram.
+    #[inline]
     fn qgram_push(&mut self, a: u8) {
         self.qgram <<= self.bits;
         self.qgram |= a as usize;
@@ -466,6 +468,7 @@ where
 {
     type Item = usize;
 
+    #[inline]
     fn next(&mut self) -> Option<usize> {
         match self.text.next() {
             Some(a) => {
@@ -510,6 +513,7 @@ where
     T: DoubleEndedIterator<Item = C>,
 {
     /// Push a new character into the current qgram in the reverse direction.
+    #[inline]
     fn qgram_push_rev(&mut self, a: u8) {
         self.qgram >>= self.bits;
         self.qgram |= (a as usize) << self.left_shift;
@@ -523,6 +527,7 @@ where
 {
     type Item = usize;
 
+    #[inline]
     fn next(&mut self) -> Option<usize> {
         match self.text.next_back() {
             Some(a) => {


### PR DESCRIPTION
This adds a new `RevQGrams` iterator created from `RankTransform::rev_qgrams` that iterates over the qgrams of a `DoubleEndedIterator` in reverse.
It also implements `size_hint` and `ExactSizeIterator` for both `QGrams` and `RevQGrams`, and does some minor cleanup along the way.

Note that I did not implement `DoubleEndedIterator` for `QGrams`, since they need to guarantee that mixing iteration from the left and right produces the same sequence of elements, which would not be the case without extra work.

I've added tests for the new features.