### PR TITLE
perf: improve alignment::distance::levenshtein and alignment::distance::bounded_levenshtein on strrings where distance is small

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,7 +86,7 @@ jobs:
     needs: Formatting
     runs-on: ubuntu-latest
     env:
-      MSRV_VERSION: 1.60.0
+      MSRV_VERSION: 1.62.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ triple_accel = ">=0.3, <0.5"
 thiserror = "1"
 anyhow = "1"
 rand = ">=0.7.3, < 0.9"
-editdistancek = "1"
+editdistancek = ">=1.0.1, <2"
 
 [dependencies.vec_map]
 version = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ triple_accel = ">=0.3, <0.5"
 thiserror = "1"
 anyhow = "1"
 rand = ">=0.7.3, < 0.9"
+editdistancek = "1"
 
 [dependencies.vec_map]
 version = "0.8"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For extra credit, feel free to familiarize yourself with:
 
 ## Minimum supported Rust version
 
-Currently the minimum supported Rust version is 1.60.0.
+Currently the minimum supported Rust version is 1.62.0.
 
 ## License
 

--- a/src/alignment/distance.rs
+++ b/src/alignment/distance.rs
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-    expected = "hamming distance cannot be calculated for texts of different length (11!=8)"
+        expected = "hamming distance cannot be calculated for texts of different length (11!=8)"
     )]
     fn test_hamming_dist_bad() {
         let x = b"GACTATATCGA";
@@ -211,7 +211,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-    expected = "simd hamming distance cannot be calculated for texts of different length (11!=8)"
+        expected = "simd hamming distance cannot be calculated for texts of different length (11!=8)"
     )]
     fn test_simd_hamming_dist_bad() {
         let x = b"GACTATATCGA";

--- a/src/alignment/distance.rs
+++ b/src/alignment/distance.rs
@@ -164,7 +164,6 @@ pub mod simd {
     /// assert_eq!(ldist, None);
     /// ```
     pub fn bounded_levenshtein(alpha: TextSlice<'_>, beta: TextSlice<'_>, k: u32) -> Option<u32> {
-        // triple_accel::levenshtein::levenshtein_simd_k(alpha, beta, k)
         if let Some(x) = editdistancek::edit_distance_bounded(alpha, beta, min(k as usize, max(alpha.len(), beta.len()))) {
             Some(x as u32)
         } else {

--- a/src/alignment/distance.rs
+++ b/src/alignment/distance.rs
@@ -6,7 +6,6 @@
 //! Various subroutines for computing a distance between sequences. Features
 //! both scalar and efficient vectorized distance functions with SIMD.
 
-
 use crate::utils::TextSlice;
 
 /// Compute the Hamming distance between two strings. Complexity: O(n).
@@ -81,8 +80,8 @@ pub mod simd {
     //! If AVX2 support is not available, there is a speed penalty for using SSE4.1 with
     //! smaller vectors.
 
-    use std::cmp::{max, min};
     use crate::utils::TextSlice;
+    use std::cmp::{max, min};
 
     /// SIMD-accelerated Hamming distance between two strings. Complexity: O(n / w), for
     /// SIMD vectors of length w (usually w = 16 or w = 32).
@@ -164,7 +163,11 @@ pub mod simd {
     /// assert_eq!(ldist, None);
     /// ```
     pub fn bounded_levenshtein(alpha: TextSlice<'_>, beta: TextSlice<'_>, k: u32) -> Option<u32> {
-        if let Some(x) = editdistancek::edit_distance_bounded(alpha, beta, min(k as usize, max(alpha.len(), beta.len()))) {
+        if let Some(x) = editdistancek::edit_distance_bounded(
+            alpha,
+            beta,
+            min(k as usize, max(alpha.len(), beta.len())),
+        ) {
             Some(x as u32)
         } else {
             None


### PR DESCRIPTION
Probably, it is better to use the implementation of the Ukkonen algorithm from ```editdistancek```.
Before:
```
test bench_levenshtein_dist_diverse_str              ... bench: 113,214,418 ns/iter (+/- 781,509)
test bench_levenshtein_dist_equal_str                ... bench:  91,783,885 ns/iter (+/- 183,007)
test bench_levenshtein_dist_worst_str                ... bench:  91,866,787 ns/iter (+/- 1,736,995)
test bench_simd_bounded_levenshtein_dist_diverse_str ... bench:  41,695,427 ns/iter (+/- 1,917,682)
test bench_simd_bounded_levenshtein_dist_equal_str   ... bench:  41,640,232 ns/iter (+/- 2,047,975)
test bench_simd_bounded_levenshtein_dist_worst_str   ... bench:  41,474,403 ns/iter (+/- 3,183,653)
test bench_simd_levenshtein_dist_diverse_str         ... bench:  54,980,802 ns/iter (+/- 2,732,004)
test bench_simd_levenshtein_dist_equal_str           ... bench:      75,170 ns/iter (+/- 1,705)
test bench_simd_levenshtein_dist_worst_str           ... bench: 100,214,002 ns/iter (+/- 21,694,930)
```
After:
```
test bench_levenshtein_dist_diverse_str              ... bench:  39,735,136 ns/iter (+/- 194,398)
test bench_levenshtein_dist_equal_str                ... bench:       6,711 ns/iter (+/- 324)
test bench_levenshtein_dist_worst_str                ... bench: 137,810,484 ns/iter (+/- 340,456)
test bench_simd_bounded_levenshtein_dist_diverse_str ... bench:  39,740,574 ns/iter (+/- 159,197)
test bench_simd_bounded_levenshtein_dist_equal_str   ... bench:       6,572 ns/iter (+/- 511)
test bench_simd_bounded_levenshtein_dist_worst_str   ... bench: 137,862,613 ns/iter (+/- 724,980)
test bench_simd_levenshtein_dist_diverse_str         ... bench:  54,768,509 ns/iter (+/- 2,092,364)
test bench_simd_levenshtein_dist_equal_str           ... bench:      75,626 ns/iter (+/- 3,295)
test bench_simd_levenshtein_dist_worst_str           ... bench:  96,541,484 ns/iter (+/- 2,901,857)
```

The implementation works in time O(nd) where d is the edit distance between strings (+simd optimization). The implementation outperforms the previous version except when the edit distance is close to the maximum possible value. You can check more benchmarks at https://github.com/nkkarpov/editdistancek .  On long random strings (1k) with random edits the version from ```editdistancek``` can achieve a 24x speedup compared to ```triple_accell``` when the percent of edits is less than 1. When the percent of edits is at most 20, and the upper bound is equal to 2 times the real distance, the new implementation has at least a 2.5x speedup. The algorithm is threshold oblivious, and the upper bound on the distance is used only for memory allocation (the algorithm requires O(k) auxiliary memory where k is the upper bound on the distance).