### PR TITLE
feat: Consensus sequence from partial order alignment graph

### DIFF
--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -296,8 +296,8 @@ impl<F: MatchFunc> Aligner<F> {
                     weight += edge.weight().clone();
                 }
                 let current_node_score = weight + neighbour_score;
-                // save the neighbour node with the highest score as best
-                if current_node_score > best_weight_score_next.1 {
+                // save the neighbour node with the highest weight and score as best
+                if (weight, current_node_score, neighbour_index) > best_weight_score_next {
                     best_weight_score_next = (weight, current_node_score, neighbour_index);
                 }
             }

--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -294,13 +294,22 @@ impl<F: MatchFunc> Aligner<F> {
                 }
                 // save the neighbour node with the highest score as best
                 if (weight + weight_score_next_vec[neighbour_node.index()].1) > best_weight_score_next.1 {
-                    best_weight_score_next = (weight, weight + weight_score_next_vec[neighbour_node.index()].1, neighbour_node.index());
+                    best_weight_score_next = (
+                        weight,
+                        weight + weight_score_next_vec[neighbour_node.index()].1,
+                        neighbour_node.index(),
+                    );
                 }
             }
             weight_score_next_vec[node.index()] = best_weight_score_next;
         }
         // get the index of the max scored node (end of consensus)
-        let mut pos = weight_score_next_vec.iter().enumerate().max_by_key(|(_, &value)| value.1).map(|(idx, _)| idx).unwrap();
+        let mut pos = weight_score_next_vec
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, &value)| value.1)
+            .map(|(idx, _)| idx)
+            .unwrap();
         // go through weight_score_next_vec appending to the consensus
         while pos != usize::MAX {
             consensus.push(self.poa.graph.raw_nodes()[pos].weight);

--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -279,7 +279,8 @@ impl<F: MatchFunc> Aligner<F> {
     /// Return the consensus sequence generated from the POA graph.
     pub fn consensus(&self) -> Vec<u8> {
         let mut consensus: Vec<u8> = vec![];
-        let mut weight_score_next_vec: Vec<(i32, i32, usize)> = vec![(0, 0, 0); self.poa.graph.node_count() + 1];
+        let mut weight_score_next_vec: Vec<(i32, i32, usize)> =
+            vec![(0, 0, 0); self.poa.graph.node_count() + 1];
         let mut topo = Topo::new(&self.poa.graph);
         // go through the nodes topologically
         while let Some(node) = topo.next(&self.poa.graph) {
@@ -293,7 +294,9 @@ impl<F: MatchFunc> Aligner<F> {
                     weight += edge.weight().clone();
                 }
                 // save the neighbour node with the highest score as best
-                if (weight + weight_score_next_vec[neighbour_node.index()].1) > best_weight_score_next.1 {
+                if (weight + weight_score_next_vec[neighbour_node.index()].1)
+                    > best_weight_score_next.1
+                {
                     best_weight_score_next = (
                         weight,
                         weight + weight_score_next_vec[neighbour_node.index()].1,


### PR DESCRIPTION
There was no function available in code to obtain a consensus sequence from the poa graph.
I added this functionality by writing a simple function which returns the sequence with the highest weighted edges.
Fixes #246.
