### PR TITLE
docs: don't use wildcard version, replace 'extern crate' with 'use'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,13 +82,13 @@
 //!
 //! ```toml
 //! [dependencies]
-//! bio = "*"
+//! bio = "1"
 //! ```
 //!
 //! and import the crate from your source code:
 //!
 //! ```rust
-//! extern crate bio;
+//! use bio;
 //! ```
 //!
 //! ## Example: FM-index and FASTQ

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,10 +85,10 @@
 //! bio = "1"
 //! ```
 //!
-//! and import the crate from your source code:
+//! Now Rust-Bio modules can be used directly in your source code, for example:
 //!
 //! ```rust
-//! use bio;
+//! use bio::io::fastq;
 //! ```
 //!
 //! ## Example: FM-index and FASTQ


### PR DESCRIPTION
Wildcard version specifications are considered bad practice.
`use` can be used to import crate items since Rust edition 2018.