### PR TITLE
Expand path variables when reading `fasta` files

### DIFF
--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -138,7 +138,7 @@ use std::io;
 use std::io::prelude::*;
 use std::path::Path;
 
-use crate::utils::{Text, TextSlice};
+use crate::utils::{Text, TextSlice, expand_path};
 use anyhow::Context;
 use std::fmt;
 
@@ -160,6 +160,7 @@ pub struct Reader<B> {
 impl Reader<io::BufReader<fs::File>> {
     /// Read FASTA from given file path.
     pub fn from_file<P: AsRef<Path> + std::fmt::Debug>(path: P) -> anyhow::Result<Self> {
+        let path = expand_path(path.as_ref());
         fs::File::open(&path)
             .map(Reader::new)
             .with_context(|| format!("Failed to read fasta from {:#?}", path))
@@ -170,6 +171,7 @@ impl Reader<io::BufReader<fs::File>> {
         capacity: usize,
         path: P,
     ) -> anyhow::Result<Self> {
+        let path = expand_path(path.as_ref());
         fs::File::open(&path)
             .map(|file| Reader::with_capacity(capacity, file))
             .with_context(|| format!("Failed to read fasta from {:#?}", path))

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -1,0 +1,31 @@
+use std::env;
+use std::path::PathBuf;
+use std::path::Path;
+use regex::Regex;
+
+pub fn expand_path(path: &Path) -> PathBuf {
+    let path_str = path.to_string_lossy();
+
+    // This regex matches occurrences of $VAR or ${VAR}
+    let re = Regex::new(r"\$(\w+|\{\w+\})").unwrap();
+
+    let expanded_path = re.replace_all(&path_str, |caps: &regex::Captures| {
+        let var = caps[1].trim_matches(|c| c == '{' || c == '}');
+        env::var(var).unwrap_or_else(|_| caps[0].to_owned())
+    });
+
+    PathBuf::from(expanded_path.into_owned())
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_expand_vars() {
+        let path = Path::new("$HOME/test.txt");
+        let expanded_path = expand_path(path);
+        assert_eq!(expanded_path, PathBuf::from(format!("{}/test.txt", env::var("HOME").unwrap())));
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -14,6 +14,9 @@ pub use self::text::{trim_newline, Text, TextSlice};
 mod interval;
 pub use self::interval::Interval;
 
+mod io;
+pub use self::io::{expand_path};
+
 /// In place implementation of scan over a slice.
 pub fn scan<T: Copy, F: Fn(T, T) -> T>(a: &mut [T], op: F) {
     let mut s = a[0];


### PR DESCRIPTION
I noticed recently that the `fasta::Reader::from_file` interface, my tests were failing if I used path variables (e.g. `$HOME/path/to/file.fasta`). Switching to the full expanded path resolved my issue.

#### I added two small changes to the crate:
1) A new `utils::io` module that includes the `expand_path` function, and
2) the `fasta::Reader` interface should now leverage this to expand out env variables if passed by users.

Let me know what the protocol is for contributing. Thanks!