### PR TITLE
chore: temporarily disable coverage estimation until simd support has arrived in the stable rust stdlib

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -106,30 +106,33 @@ jobs:
           command: test
           args: --all --no-fail-fast
 
-  Coverage:
-    needs: Formatting
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
+  # TODO re-enable coverage estimation once we have removed the simd-dependency which is incompatible
+  # with nightly. We need to wait for the stdlib simd implementation to stabilize, see
+  # https://github.com/rust-lang/rust/issues/86656
+  # Coverage:
+  #   needs: Formatting
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #         submodules: recursive
 
-      - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
+  #     - name: Install nightly toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: nightly
+  #         override: true
 
-      - name: Install and run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          # TODO: update to latest tarpaulin once artefact download is fixed: https://github.com/actions-rs/tarpaulin/pull/23
-          version: "0.22.0"
-          args: "--workspace --all-features --run-types Tests,Doctests --out Lcov --timeout 300"
+  #     - name: Install and run cargo-tarpaulin
+  #       uses: actions-rs/tarpaulin@v0.1
+  #       with:
+  #         # TODO: update to latest tarpaulin once artefact download is fixed: https://github.com/actions-rs/tarpaulin/pull/23
+  #         version: "0.22.0"
+  #         args: "--workspace --all-features --run-types Tests,Doctests --out Lcov --timeout 300"
 
-      - name: Upload coverage
-        uses: coverallsapp/github-action@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./lcov.info
+  #     - name: Upload coverage
+  #       uses: coverallsapp/github-action@v1
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+  #         path-to-lcov: ./lcov.info

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,7 +86,7 @@ jobs:
     needs: Formatting
     runs-on: ubuntu-latest
     env:
-      MSRV_VERSION: 1.64.0
+      MSRV_VERSION: 1.65.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For extra credit, feel free to familiarize yourself with:
 
 ## Minimum supported Rust version
 
-Currently the minimum supported Rust version is 1.64.0.
+Currently the minimum supported Rust version is 1.65.0.
 
 ## License
 


### PR DESCRIPTION
This is because our current simd dependency has become incompatible with nightly rust.