### PR TITLE
fix: minimum ndarray version is 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ itertools = ">=0.8, <0.12"
 itertools-num = "0.1"
 bv = { version = "0.11", features = ["serde"] }
 bit-set = "0.5"
-ndarray= ">=0.13, <0.16"
+ndarray= ">=0.15, <0.16"
 lazy_static = "1.4"
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
Closes #556 as I was able to reproduce the build error with `0.14` reported by @jakobnissen 