### PR TITLE
fix(ci): Fix Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,6 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      # Prefix all commit messages with "deps: ", which should be
-      # accepted as a conventional commit and trigger release-please
-      prefix: "deps"
+      # Prefix all commit messages with "build(deps): ", which is
+      # a conventional commit prefix and triggers release-please
+      prefix: "build(deps)"


### PR DESCRIPTION
Change the Dependabot prefix from `deps` to `build(deps)`, because
`deps` is not a conventional commit prefix.

See for example the `PR / title-format (pull_request_target)` CI failures in
- https://github.com/rust-bio/rust-bio/pull/562
- https://github.com/rust-bio/rust-bio/pull/565