### PR TITLE
refactor: remove getset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ pest = { version = "2", optional = true }
 pest_derive = { version = "2", optional = true }
 strum = ">= 0.16, < 0.26"
 strum_macros = ">= 0.16, < 0.26"
-getset = ">=0.0.9, <0.2"
 enum-map = ">=0.6.4, <3"
 triple_accel = ">=0.3, <0.5"
 thiserror = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,9 +245,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate strum_macros;
 
-#[macro_use]
-extern crate getset;
-
 #[cfg(feature = "phylogeny")]
 #[macro_use]
 extern crate pest_derive;

--- a/src/stats/bayesian/model.rs
+++ b/src/stats/bayesian/model.rs
@@ -54,19 +54,7 @@ pub trait Posterior {
 /// [here](https://github.com/varlociraptor/varlociraptor/blob/694e994547e8f523e5b0013fdf951b694f3870fa/src/model/modes/generic.rs#L200)
 /// for an example.
 #[derive(
-    Default,
-    Getters,
-    MutGetters,
-    Copy,
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Debug,
-    Serialize,
-    Deserialize,
+    Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
 )]
 pub struct Model<L, Pr, Po, Payload = ()>
 where
@@ -75,14 +63,8 @@ where
     Po: Posterior,
     Payload: Default,
 {
-    #[get = "pub"]
-    #[get_mut = "pub"]
     likelihood: L,
-    #[get = "pub"]
-    #[get_mut = "pub"]
     prior: Pr,
-    #[get = "pub"]
-    #[get_mut = "pub"]
     posterior: Po,
     payload: PhantomData<Payload>,
 }
@@ -104,6 +86,30 @@ where
             posterior,
             payload: PhantomData,
         }
+    }
+
+    pub fn likelihood(&self) -> &L {
+        &self.likelihood
+    }
+
+    pub fn likelihood_mut(&mut self) -> &mut L {
+        &mut self.likelihood
+    }
+
+    pub fn prior(&self) -> &Pr {
+        &self.prior
+    }
+
+    pub fn prior_mut(&mut self) -> &mut Pr {
+        &mut self.prior
+    }
+
+    pub fn posterior(&self) -> &Po {
+        &self.posterior
+    }
+
+    pub fn posterior_mut(&mut self) -> &mut Po {
+        &mut self.posterior
     }
 
     /// Calculate joint probability, i.e. `Pr(event) * Pr(data | event)`.


### PR DESCRIPTION
getset is no longer recommended by its maintainer: https://github.com/jbaublitz/getset/pull/87#issuecomment-1167658416

& is thus unlikely to update to `syn 2`