### PR TITLE
fix: POA reverse edge fix

### DIFF
--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -349,7 +349,7 @@ impl Traceback {
                     j -= 1;
                 }
                 AlignmentOperation::Match(None) => {
-                    i -= 1;
+                    i = 0;
                     j -= 1;
                 }
                 AlignmentOperation::Del(None) => {
@@ -887,7 +887,7 @@ impl<F: MatchFunc> Poa<F> {
                                 *self.graph.edge_weight_mut(edge).unwrap() += 1;
                             }
                             None => {
-                                if prev.index() != head.index() {
+                                if prev.index() != head.index() && prev.index() != node.index() {
                                     self.graph.add_edge(prev, node, 1);
                                 }
                             }

--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -862,9 +862,13 @@ impl<F: MatchFunc> Poa<F> {
         for op in aln.operations.iter() {
             match op {
                 AlignmentOperation::Match(None) => {
-                    let node: NodeIndex<usize> = NodeIndex::new(0);
+                    let node: NodeIndex<usize> = NodeIndex::new(head.index());
                     if (seq[i] != self.graph.raw_nodes()[head.index()].weight) && (seq[i] != b'X') {
                         let node = self.graph.add_node(seq[i]);
+                        if edge_not_connected {
+                            self.graph.add_edge(prev, node, 1);
+                        }
+                        edge_not_connected = false;
                         prev = node;
                     }
                     if edge_not_connected {


### PR DESCRIPTION
The current POA implementation gives rise to reverse edges when insertions are made before the head node, this fixes it.
Fixes https://github.com/rust-bio/rust-bio/issues/549.
Fixes https://github.com/rust-bio/rust-bio/issues/572.