### PR TITLE
fix: Fix clippy warnings

### DIFF
--- a/src/alignment/distance.rs
+++ b/src/alignment/distance.rs
@@ -163,15 +163,12 @@ pub mod simd {
     /// assert_eq!(ldist, None);
     /// ```
     pub fn bounded_levenshtein(alpha: TextSlice<'_>, beta: TextSlice<'_>, k: u32) -> Option<u32> {
-        if let Some(x) = editdistancek::edit_distance_bounded(
+        editdistancek::edit_distance_bounded(
             alpha,
             beta,
             min(k as usize, max(alpha.len(), beta.len())),
-        ) {
-            Some(x as u32)
-        } else {
-            None
-        }
+        )
+        .map(|x| x as u32)
     }
 }
 

--- a/src/alignment/pairwise/banded.rs
+++ b/src/alignment/pairwise/banded.rs
@@ -1262,7 +1262,7 @@ impl Band {
                     // Band to lower right corner
                     let rows = self.rows as u32;
                     let cols = self.cols as u32;
-                    self.add_gap((r as u32, c as u32), (rows as u32, cols as u32), w);
+                    self.add_gap((r as u32, c as u32), (rows, cols), w);
                 }
             }
         }

--- a/src/alignment/pairwise/mod.rs
+++ b/src/alignment/pairwise/mod.rs
@@ -1675,7 +1675,7 @@ mod tests {
             let scoring = Scoring {
                 xclip_prefix: 0,
                 yclip_prefix: 0,
-                ..base_score.clone()
+                ..base_score
             };
             let mut al = Aligner::with_scoring(scoring);
             let alignment = al.custom(x, y);
@@ -1686,7 +1686,7 @@ mod tests {
             let scoring = Scoring {
                 xclip_prefix: 0,
                 yclip_suffix: 0,
-                ..base_score.clone()
+                ..base_score
             };
             let mut al = Aligner::with_scoring(scoring);
             let alignment = al.custom(x, y);
@@ -1697,7 +1697,7 @@ mod tests {
             let scoring = Scoring {
                 xclip_suffix: 0,
                 yclip_prefix: 0,
-                ..base_score.clone()
+                ..base_score
             };
             let mut al = Aligner::with_scoring(scoring);
             let alignment = al.custom(x, y);

--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -519,16 +519,13 @@ impl<F: MatchFunc> Aligner<F> {
         // go through the nodes topologically
         while let Some(node) = topo.next(&self.poa.graph) {
             let mut best_weight_score_next: (i32, i32, usize) = (0, 0, usize::MAX);
-            let mut neighbour_nodes = self.poa.graph.neighbors_directed(node, Incoming);
+            let neighbour_nodes = self.poa.graph.neighbors_directed(node, Incoming);
             // go through the incoming neighbour nodes
-            while let Some(neighbour_node) = neighbour_nodes.next() {
-                let mut weight = 0;
+            for neighbour_node in neighbour_nodes {
                 let neighbour_index = neighbour_node.index();
                 let neighbour_score = weight_score_next_vec[neighbour_index].1;
-                let mut edges = self.poa.graph.edges_connecting(neighbour_node, node);
-                while let Some(edge) = edges.next() {
-                    weight += edge.weight().clone();
-                }
+                let edges = self.poa.graph.edges_connecting(neighbour_node, node);
+                let weight = edges.map(|edge| edge.weight()).sum();
                 let current_node_score = weight + neighbour_score;
                 // save the neighbour node with the highest weight and score as best
                 if (weight, current_node_score, neighbour_index) > best_weight_score_next {

--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -111,7 +111,7 @@ impl Alignment {
             // go through the sequences checking if bases match with the current node base
             for current_seq in 0..sequences.len() {
                 if seq_indices[current_seq] >= sequences[current_seq].len() {
-                    seq_pretty[current_seq].push('-' as u8);
+                    seq_pretty[current_seq].push(b'-');
                 } else if sequences[current_seq][seq_indices[current_seq]] == topo_base {
                     seq_pretty[current_seq].push(topo_base);
                     seq_indices[current_seq] += 1;
@@ -131,8 +131,8 @@ impl Alignment {
                 con_pretty.push(b'-');
             }
             if all_null {
-                for current_seq in 0..sequences.len() {
-                    seq_pretty[current_seq].pop();
+                for current_seq in seq_pretty.iter_mut() {
+                    current_seq.pop();
                 }
                 con_pretty.pop();
             }

--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -677,23 +677,23 @@ impl<F: MatchFunc> Poa<F> {
         }
         // X suffix clipping
         let mut max_in_row = (0, 0);
-        for j in 0..n + 1 {
+        for (col_index, &(score, col_max_row)) in max_in_column.iter().enumerate() {
             // avoid pointing to itself
-            if max_in_column[j].1 == traceback.last.index() + 1 {
+            if col_max_row == traceback.last.index() + 1 {
                 continue;
             }
             let maxcell = max(
-                *traceback.get(traceback.last.index() + 1, j),
+                *traceback.get(traceback.last.index() + 1, col_index),
                 TracebackCell {
-                    score: max_in_column[j].0 + self.scoring.xclip_suffix,
-                    op: AlignmentOperation::Xclip(max_in_column[j].1),
+                    score: score + self.scoring.xclip_suffix,
+                    op: AlignmentOperation::Xclip(col_max_row),
                 },
             );
             if max_in_row.0 < maxcell.score {
                 max_in_row.0 = maxcell.score;
-                max_in_row.1 = j;
+                max_in_row.1 = col_index;
             }
-            traceback.set(traceback.last.index() + 1, j, maxcell);
+            traceback.set(traceback.last.index() + 1, col_index, maxcell);
         }
         // Y suffix clipping from the last node
         let maxcell = max(

--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -298,28 +298,28 @@ impl Traceback {
         // get the matrix cell if in band range else return the appropriate values
         if !(self.matrix[i].1 > j || self.matrix[i].2 <= j || self.matrix[i].0.is_empty()) {
             let real_position = j - self.matrix[i].1;
-            return &self.matrix[i].0[real_position];
+            &self.matrix[i].0[real_position]
         }
         // behind the band, met the edge
         else if j == 0 {
-            return &TracebackCell {
+            &TracebackCell {
                 score: MIN_SCORE,
                 op: AlignmentOperation::Del(None),
-            };
+            }
         }
         // infront of the band
         else if j >= self.matrix[i].2 {
-            return &TracebackCell {
+            &TracebackCell {
                 score: MIN_SCORE,
                 op: AlignmentOperation::Ins(None),
-            };
+            }
         }
         // behind the band
         else {
-            return &TracebackCell {
+            &TracebackCell {
                 score: MIN_SCORE,
                 op: AlignmentOperation::Match(None),
-            };
+            }
         }
     }
 

--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -334,7 +334,7 @@ impl Traceback {
         while i > 0 || j > 0 {
             // push operation and edge corresponding to (one of the) optimal
             // routes
-            ops.push(self.get(i, j).op.clone());
+            ops.push(self.get(i, j).op);
             match self.get(i, j).op {
                 AlignmentOperation::Match(Some((p, _))) => {
                     i = p + 1;

--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -683,7 +683,7 @@ impl<F: MatchFunc> Poa<F> {
                 continue;
             }
             let maxcell = max(
-                traceback.get(traceback.last.index() + 1, j).clone(),
+                *traceback.get(traceback.last.index() + 1, j),
                 TracebackCell {
                     score: max_in_column[j].0 + self.scoring.xclip_suffix,
                     op: AlignmentOperation::Xclip(max_in_column[j].1),
@@ -697,7 +697,7 @@ impl<F: MatchFunc> Poa<F> {
         }
         // Y suffix clipping from the last node
         let maxcell = max(
-            traceback.get(traceback.last.index() + 1, n).clone(),
+            *traceback.get(traceback.last.index() + 1, n),
             TracebackCell {
                 score: max_in_row.0 + self.scoring.yclip_suffix,
                 op: AlignmentOperation::Yclip(max_in_row.1, n),

--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -296,7 +296,7 @@ impl Traceback {
 
     fn get(&self, i: usize, j: usize) -> &TracebackCell {
         // get the matrix cell if in band range else return the appropriate values
-        if !(self.matrix[i].1 > j || self.matrix[i].2 <= j) && (self.matrix[i].0.len() > 0) {
+        if !(self.matrix[i].1 > j || self.matrix[i].2 <= j || self.matrix[i].0.is_empty()) {
             let real_position = j - self.matrix[i].1;
             return &self.matrix[i].0[real_position];
         }

--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -85,13 +85,12 @@ impl Alignment {
     /// we will get the following output:
     ///
     /// ```c
-    ///cons:   ACC---CCCTT-TTTCC--GG
-    ///seq1:   ACC---CCCTT-TTTCC--GG
-    ///seq2:   AC--TTCCCTT-TTTCC--GG
-    ///seq3:   ACCG--CC-TT-TTTCC--GG
-    ///seq4:   ACC---CCCT-GTTTC-AAGG
+    /// cons:   ACC---CCCTT-TTTCC--GG
+    /// seq1:   ACC---CCCTT-TTTCC--GG
+    /// seq2:   AC--TTCCCTT-TTTCC--GG
+    /// seq3:   ACCG--CC-TT-TTTCC--GG
+    /// seq4:   ACC---CCCT-GTTTC-AAGG
     /// ```
-    ///
     pub fn pretty(
         &self,
         consensus: TextSlice,
@@ -118,18 +117,18 @@ impl Alignment {
                     seq_indices[current_seq] += 1;
                     all_null = false;
                 } else {
-                    seq_pretty[current_seq].push('-' as u8);
+                    seq_pretty[current_seq].push(b'-');
                 }
             }
             // do the same for the consensus
             if con_index >= consensus.len() {
-                con_pretty.push('-' as u8);
+                con_pretty.push(b'-');
             } else if consensus[con_index] == topo_base {
                 con_pretty.push(topo_base);
                 con_index += 1;
                 all_null = false;
             } else {
-                con_pretty.push('-' as u8);
+                con_pretty.push(b'-');
             }
             if all_null {
                 for current_seq in 0..sequences.len() {

--- a/src/alignment/sparse.rs
+++ b/src/alignment/sparse.rs
@@ -713,10 +713,7 @@ CGGGAGGAGACCTGGGCAGCGGCGGACTCATTGCAGGTCGCTCTGCGGTGAGGACGCCACAGGCAC";
         let expanded_matches = super::expand_kmer_matches(x, y, 6, &matches, 1);
         assert_eq!(
             expanded_matches,
-            (0..5)
-                .into_iter()
-                .map(|x| (x, x))
-                .collect::<Vec<(u32, u32)>>()
+            (0..5).map(|x| (x, x)).collect::<Vec<(u32, u32)>>()
         );
 
         let x = b"TTTTTTGGGCAAAAAA";
@@ -727,10 +724,7 @@ CGGGAGGAGACCTGGGCAGCGGCGGACTCATTGCAGGTCGCTCTGCGGTGAGGACGCCACAGGCAC";
         let expanded_matches = super::expand_kmer_matches(x, y, 6, &matches, 1);
         assert_eq!(
             expanded_matches,
-            (0..11)
-                .into_iter()
-                .map(|x| (x, x))
-                .collect::<Vec<(u32, u32)>>()
+            (0..11).map(|x| (x, x)).collect::<Vec<(u32, u32)>>()
         );
 
         let x = b"TTTTTTCCGCAAAAAA";
@@ -771,10 +765,7 @@ CGGGAGGAGACCTGGGCAGCGGCGGACTCATTGCAGGTCGCTCTGCGGTGAGGACGCCACAGGCAC";
         let expanded_matches = super::expand_kmer_matches(x, y, 6, &matches, 1);
         assert_eq!(
             expanded_matches,
-            (0..5)
-                .into_iter()
-                .map(|x| (x, x))
-                .collect::<Vec<(u32, u32)>>()
+            (0..5).map(|x| (x, x)).collect::<Vec<(u32, u32)>>()
         );
     }
 }

--- a/src/alignment/sparse.rs
+++ b/src/alignment/sparse.rs
@@ -637,7 +637,7 @@ CGGGAGGAGACCTGGGCAGCGGCGGACTCATTGCAGGTCGCTCTGCGGTGAGGACGCCACAGGCAC";
     #[test]
     fn test_sdpkpp_tandem_repeat() {
         let k = 8;
-        let matches = super::find_kmer_matches(&QUERY_REPEAT, &TARGET_REPEAT, k);
+        let matches = super::find_kmer_matches(QUERY_REPEAT, TARGET_REPEAT, k);
         let res = super::sdpkpp(&matches, k, 1, -1, -1);
 
         // For debugging:

--- a/src/alignment/sparse.rs
+++ b/src/alignment/sparse.rs
@@ -343,9 +343,7 @@ pub fn hash_kmers(seq: &[u8], k: usize) -> HashMapFx<&[u8], Vec<u32>> {
     let slc = seq;
     let mut set: HashMapFx<&[u8], Vec<u32>> = HashMapFx::default();
     for i in 0..(slc.len() + 1).saturating_sub(k) {
-        set.entry(&slc[i..i + k])
-            .or_insert_with(Vec::new)
-            .push(i as u32);
+        set.entry(&slc[i..i + k]).or_default().push(i as u32);
     }
     set
 }

--- a/src/data_structures/annot_map.rs
+++ b/src/data_structures/annot_map.rs
@@ -109,7 +109,7 @@ where
         let itree = self
             .refid_itrees
             .entry(location.refid().clone())
-            .or_insert_with(IntervalTree::new);
+            .or_default();
         let rng = location.start()..(location.start() + (location.length() as isize));
         itree.insert(rng, data);
     }
@@ -170,10 +170,7 @@ where
     /// assert_eq!(hits, vec![&assert_copy]);
     /// ```
     pub fn insert_loc(&mut self, data: T) {
-        let itree = self
-            .refid_itrees
-            .entry(data.refid().clone())
-            .or_insert_with(IntervalTree::new);
+        let itree = self.refid_itrees.entry(data.refid().clone()).or_default();
         let rng = data.start()..(data.start() + (data.length() as isize));
         itree.insert(rng, data);
     }

--- a/src/data_structures/bwt.rs
+++ b/src/data_structures/bwt.rs
@@ -171,14 +171,14 @@ impl Occ {
                 // If r is closer to the high checkpoint, count backwards from there.
                 let hi_idx = hi_checkpoint * self.k as usize;
                 if (hi_idx - r) < (self.k as usize / 2) {
-                    return hi_occ - bytecount::count(&bwt[r + 1..=hi_idx], a) as usize;
+                    return hi_occ - bytecount::count(&bwt[r + 1..=hi_idx], a);
                 }
             }
         }
 
         // Otherwise the default case is to count from the low checkpoint.
         let lo_idx = lo_checkpoint * self.k as usize;
-        bytecount::count(&bwt[lo_idx + 1..=r], a) as usize + lo_occ
+        bytecount::count(&bwt[lo_idx + 1..=r], a) + lo_occ
     }
 }
 

--- a/src/data_structures/bwt.rs
+++ b/src/data_structures/bwt.rs
@@ -262,7 +262,7 @@ mod tests {
         let occ = Occ::new(&bwt, 3, &alphabet);
         let wm = WaveletMatrix::new(&bwt);
 
-        for c in vec![b'A', b'C', b'G', b'T', b'$'] {
+        for c in [b'A', b'C', b'G', b'T', b'$'] {
             for p in 0..text.len() {
                 assert_eq!(occ.get(&bwt, p, c) as u64, wm.rank(c, p as u64));
             }

--- a/src/data_structures/bwt.rs
+++ b/src/data_structures/bwt.rs
@@ -242,7 +242,7 @@ mod tests {
     #[test]
     fn test_occ() {
         let bwt = vec![1u8, 3u8, 3u8, 1u8, 2u8, 0u8];
-        let alphabet = Alphabet::new(&[0u8, 1u8, 2u8, 3u8]);
+        let alphabet = Alphabet::new([0u8, 1u8, 2u8, 3u8]);
         let occ = Occ::new(&bwt, 3, &alphabet);
         assert_eq!(occ.occ, [[0, 0], [1, 2], [0, 0], [0, 2]]);
         assert_eq!(occ.get(&bwt, 4, 2u8), 1);

--- a/src/data_structures/fmindex.rs
+++ b/src/data_structures/fmindex.rs
@@ -726,8 +726,8 @@ mod tests {
             let pattern = b"ATTGGGG";
             let intervals = fmdindex.all_smems(pattern, 0);
             assert_eq!(intervals.len(), 2);
-            let solutions = vec![[0, 14, 0, 3], [4, 9, 3, 4]];
-            for (i, interval) in intervals.iter().enumerate() {
+            let solutions = [[0, 14, 0, 3], [4, 9, 3, 4]];
+            for (interval, &solution) in intervals.iter().zip(solutions.iter()) {
                 let forward_positions = interval.0.forward().occ(&sa);
                 let revcomp_positions = interval.0.revcomp().occ(&sa);
                 let pattern_position = interval.1;
@@ -739,7 +739,7 @@ mod tests {
                         pattern_position,
                         smem_len
                     ],
-                    solutions[i]
+                    solution
                 );
             }
         }

--- a/src/data_structures/fmindex.rs
+++ b/src/data_structures/fmindex.rs
@@ -557,6 +557,9 @@ impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> FMDIndex<DBWT, D
     /// I.e., let T be the original text and R be its reverse complement.
     /// Then, the expected text is T$R$. Further, multiple concatenated texts are allowed, e.g.
     /// T1$R1$T2$R2$T3$R3$.
+    ///
+    /// # Safety
+    ///
     /// It is unsafe to construct an FMD index from an FM index that is not built on the DNA alphabet.
     pub unsafe fn from_fmindex_unchecked(
         fmindex: FMIndex<DBWT, DLess, DOcc>,

--- a/src/data_structures/interval_tree/array_backed_interval_tree.rs
+++ b/src/data_structures/interval_tree/array_backed_interval_tree.rs
@@ -199,7 +199,7 @@ impl<N: Ord + Clone + Copy, D: Clone> ArrayBackedIntervalTree<N, D> {
 
         let interval = interval.into();
         let (start, end) = (interval.start, interval.end);
-        let n = self.entries.len() as usize;
+        let n = self.entries.len();
         let a = &self.entries;
         results.clear();
         let mut stack = [StackCell::empty(); 64];

--- a/src/data_structures/interval_tree/avl_interval_tree.rs
+++ b/src/data_structures/interval_tree/avl_interval_tree.rs
@@ -498,7 +498,10 @@ mod tests {
         assert_intersections(tree, target, vec![]);
     }
 
+    // Clippy has a warning against `vec!` macros with a single range as argument.
+    // Since we do actually want that here, we disable the warning.
     #[test]
+    #[allow(clippy::single_range_in_vec_init)]
     fn test_insertion_and_intersection() {
         let mut tree: IntervalTree<i64, String> = IntervalTree::new();
         assert_eq!(tree.find(1..2).count(), 0);

--- a/src/data_structures/interval_tree/avl_interval_tree.rs
+++ b/src/data_structures/interval_tree/avl_interval_tree.rs
@@ -485,7 +485,7 @@ mod tests {
     ) {
         let mut actual_entries: Vec<Entry<'_, i64, String>> = tree.find(&target).collect();
         println!("{:?}", actual_entries);
-        actual_entries.sort_by(|x1, x2| x1.data.cmp(&x2.data));
+        actual_entries.sort_by(|x1, x2| x1.data.cmp(x2.data));
         let expected_entries = make_entry_tuples(expected_results);
         assert_eq!(actual_entries.len(), expected_entries.len());
         for (actual, expected) in actual_entries.iter().zip(expected_entries.iter()) {

--- a/src/data_structures/qgram_index.rs
+++ b/src/data_structures/qgram_index.rs
@@ -71,7 +71,7 @@ impl QGramIndex {
         let text = text.into_iter();
         let ranks = RankTransform::new(alphabet);
 
-        let qgram_count = alphabet.len().pow(q as u32);
+        let qgram_count = alphabet.len().pow(q);
         let mut address = vec![0; qgram_count + 1];
 
         for qgram in ranks.qgrams(q, text.clone()) {
@@ -93,11 +93,11 @@ impl QGramIndex {
         {
             let mut offset = vec![0; qgram_count];
             for (i, qgram) in ranks.qgrams(q, text).enumerate() {
-                let a = address[qgram as usize];
-                if address[qgram as usize + 1] - a != 0 {
+                let a = address[qgram];
+                if address[qgram + 1] - a != 0 {
                     // if not masked, insert positions
-                    pos[a + offset[qgram as usize]] = i;
-                    offset[qgram as usize] += 1;
+                    pos[a + offset[qgram]] = i;
+                    offset[qgram] += 1;
                 }
             }
         }

--- a/src/data_structures/qgram_index.rs
+++ b/src/data_structures/qgram_index.rs
@@ -404,7 +404,7 @@ mod tests {
         let qgram_index = QGramIndex::new(q, text.iter(), &alphabet);
 
         let exact_matches = qgram_index.exact_matches(text);
-        assert!(exact_matches.len() >= 1);
+        assert!(!exact_matches.is_empty());
     }
 
     #[test]

--- a/src/data_structures/rank_select.rs
+++ b/src/data_structures/rank_select.rs
@@ -171,9 +171,7 @@ impl RankSelect {
         let mut superblock = match superblocks.binary_search(&SuperblockRank::First(j)) {
             Ok(i) | Err(i) => i, // superblock with same rank exists
         };
-        if superblock > 0 {
-            superblock -= 1;
-        }
+        superblock = superblock.saturating_sub(1);
         let mut rank = *superblocks[superblock];
 
         let first_block = superblock * self.s / 8;

--- a/src/data_structures/rank_select.rs
+++ b/src/data_structures/rank_select.rs
@@ -315,9 +315,9 @@ mod tests {
         assert_eq!(rs.rank_0(5).unwrap(), 5);
         assert_eq!(rs.select_0(0), None);
         assert_eq!(rs.select_0(1).unwrap(), 0);
-        assert_eq!(rs.get(5), true);
-        assert_eq!(rs.get(1), false);
-        assert_eq!(rs.get(32), true);
+        assert!(rs.get(5));
+        assert!(!rs.get(1));
+        assert!(rs.get(32));
     }
 
     #[test]

--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -824,11 +824,9 @@ mod tests {
         let mut rng = rand::thread_rng();
         let alpha = [b'A', b'T', b'C', b'G', b'N'];
         let seqs = (0..num_seqs)
-            .into_iter()
             .map(|_| {
                 let len = rng.gen_range((seq_len / 2)..=seq_len);
                 (0..len)
-                    .into_iter()
                     .map(|_| *alpha.choose(&mut rng).unwrap())
                     .collect::<Vec<u8>>()
             })
@@ -857,7 +855,6 @@ mod tests {
              ];
         let num_rand = 100;
         let rand_cases = (0..num_rand)
-            .into_iter()
             .map(|i| rand_seqs(10, i * 10))
             .collect::<Vec<_>>();
         for i in 0..num_rand {
@@ -907,7 +904,6 @@ mod tests {
              ];
         let num_rand = 100;
         let rand_cases = (0..num_rand)
-            .into_iter()
             .map(|i| rand_seqs(10, i * 10))
             .collect::<Vec<_>>();
         for i in 0..num_rand {

--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -865,8 +865,8 @@ mod tests {
             let pos = suffix_array(text);
             for i in 0..(pos.len() - 2) {
                 // Check that every element in the suffix array is lexically <= the next elem
-                let cur = str_from_pos(&pos, &text, i);
-                let next = str_from_pos(&pos, &text, i + 1);
+                let cur = str_from_pos(&pos, text, i);
+                let next = str_from_pos(&pos, text, i + 1);
 
                 assert!(
                     cur <= next,

--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -854,12 +854,12 @@ mod tests {
                 "complex with revcomps"),
              ];
         let num_rand = 100;
-        let rand_cases = (0..num_rand)
-            .map(|i| rand_seqs(10, i * 10))
-            .collect::<Vec<_>>();
-        for rand_case in rand_cases.iter() {
-            test_cases.push((rand_case, "rand test case"));
-        }
+        let rand_cases: Vec<_> = (0..num_rand).map(|i| rand_seqs(10, i * 10)).collect();
+        test_cases.extend(
+            rand_cases
+                .iter()
+                .map(|case| (case.as_ref(), "rand test case")),
+        );
 
         for &(text, test_name) in test_cases.iter() {
             let pos = suffix_array(text);
@@ -903,12 +903,12 @@ mod tests {
              (&b"TACTCCGCTAGGGACACCTAAATAGATACTCGCAAAGGCGACTGATATATCCTTAGGTCGAAGAGATACCAGAGAAATAGTAGGTCTTAGGCTAGTCCTT$AAGGACTAGCCTAAGACCTACTATTTCTCTGGTATCTCTTCGACCTAAGGATATATCAGTCGCCTTTGCGAGTATCTATTTAGGTGTCCCTAGCGGAGTA$TAGGGACACCTAAATAGATACTCGCAAAGGCGACTGATATATCCTTAGGTCGAAGAGATACCAGAGAAATAGTAGGTCTTAGGCTAGTCCTTGTCCAGTA$TACTGGACAAGGACTAGCCTAAGACCTACTATTTCTCTGGTATCTCTTCGACCTAAGGATATATCAGTCGCCTTTGCGAGTATCTATTTAGGTGTCCCTA$ACGCACCCCGGCATTCGTCGACTCTACACTTAGTGGAACATACAAATTCGCTCGCAGGAGCGCCTCATACATTCTAACGCAGTGATCTTCGGCTGAGACT$AGTCTCAGCCGAAGATCACTGCGTTAGAATGTATGAGGCGCTCCTGCGAGCGAATTTGTATGTTCCACTAAGTGTAGAGTCGACGAATGCCGGGGTGCGT$"[..], "complex sentinels"),
              ];
         let num_rand = 100;
-        let rand_cases = (0..num_rand)
-            .map(|i| rand_seqs(10, i * 10))
-            .collect::<Vec<_>>();
-        for rand_case in rand_cases.iter() {
-            test_cases.push((rand_case, "rand test case"));
-        }
+        let rand_cases: Vec<_> = (0..num_rand).map(|i| rand_seqs(10, i * 10)).collect();
+        test_cases.extend(
+            rand_cases
+                .iter()
+                .map(|case| (case.as_ref(), "rand test case")),
+        );
 
         for &(text, test_name) in test_cases.iter() {
             for &sample_rate in &[2, 3, 5, 16] {

--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -857,8 +857,8 @@ mod tests {
         let rand_cases = (0..num_rand)
             .map(|i| rand_seqs(10, i * 10))
             .collect::<Vec<_>>();
-        for i in 0..num_rand {
-            test_cases.push((&rand_cases[i], "rand test case"));
+        for rand_case in rand_cases.iter() {
+            test_cases.push((rand_case, "rand test case"));
         }
 
         for &(text, test_name) in test_cases.iter() {
@@ -906,8 +906,8 @@ mod tests {
         let rand_cases = (0..num_rand)
             .map(|i| rand_seqs(10, i * 10))
             .collect::<Vec<_>>();
-        for i in 0..num_rand {
-            test_cases.push((&rand_cases[i], "rand test case"));
+        for rand_case in rand_cases.iter() {
+            test_cases.push((rand_case, "rand test case"));
         }
 
         for &(text, test_name) in test_cases.iter() {

--- a/src/data_structures/wavelet_matrix.rs
+++ b/src/data_structures/wavelet_matrix.rs
@@ -171,7 +171,7 @@ mod tests {
                 true, false, true, true, false, true, false, true, false, true, false, true,
             ],
         ];
-        let zeros = vec![6, 7, 5];
+        let zeros = [6, 7, 5];
 
         assert_eq!(wm.height, zeros.len());
         assert_eq!(wm.width, levels[0].len());
@@ -198,7 +198,7 @@ mod tests {
                 false, true, false, true, false, true, false, true, false, true, false, true,
             ],
         ];
-        let zeros = vec![8, 8, 6];
+        let zeros = [8, 8, 6];
 
         assert_eq!(wm.height, zeros.len());
         assert_eq!(wm.width, levels[0].len());
@@ -266,7 +266,7 @@ mod tests {
             vec![0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2],
         ];
 
-        let alphabet = vec![b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7'];
+        let alphabet = [b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7'];
         for (i, c) in alphabet.iter().enumerate() {
             for p in 0..text.len() {
                 assert_eq!(wm.rank(*c, p as u64), ranks[i][p]);
@@ -288,7 +288,7 @@ mod tests {
             vec![0, 0, 0, 0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 2, 2],
         ];
 
-        let alphabet = vec![b'A', b'C', b'G', b'T', b'N', b'$'];
+        let alphabet = [b'A', b'C', b'G', b'T', b'N', b'$'];
         for (i, c) in alphabet.iter().enumerate() {
             for p in 0..text.len() {
                 assert_eq!(wm.rank(*c, p as u64), ranks[i][p]);

--- a/src/data_structures/wavelet_matrix.rs
+++ b/src/data_structures/wavelet_matrix.rs
@@ -134,7 +134,7 @@ impl WaveletMatrix {
             !self.check_overflow(p),
             "Invalid p (it must be in range 0..wm_size-1"
         );
-        let height = self.height as usize;
+        let height = self.height;
         let mut spos = 0;
         let mut epos = p + 1;
         for level in 0..height {

--- a/src/io/bed.rs
+++ b/src/io/bed.rs
@@ -109,10 +109,10 @@ impl<W: io::Write> Writer<W> {
     pub fn write(&mut self, record: &Record) -> csv::Result<()> {
         if record.aux.is_empty() {
             self.inner
-                .serialize(&(&record.chrom, record.start, record.end))
+                .serialize((&record.chrom, record.start, record.end))
         } else {
             self.inner
-                .serialize(&(&record.chrom, record.start, record.end, &record.aux))
+                .serialize((&record.chrom, record.start, record.end, &record.aux))
         }
     }
 }

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -371,7 +371,7 @@ impl Index {
 
     /// Open a FASTA index from a given file path.
     pub fn from_file<P: AsRef<Path> + std::fmt::Debug>(path: &P) -> anyhow::Result<Self> {
-        fs::File::open(&path)
+        fs::File::open(path)
             .map_err(csv::Error::from)
             .and_then(Self::new)
             .with_context(|| format!("Failed to read fasta index from {:#?}", path))
@@ -414,7 +414,7 @@ impl IndexedReader<fs::File> {
     /// present for FASTA ref.fasta.
     pub fn from_file<P: AsRef<Path> + std::fmt::Debug>(path: &P) -> anyhow::Result<Self> {
         let index = Index::with_fasta_file(path)?;
-        fs::File::open(&path)
+        fs::File::open(path)
             .map(|f| Self::with_index(f, index))
             .map_err(csv::Error::from)
             .with_context(|| format!("Failed to read fasta from {:#?}", path))
@@ -1296,26 +1296,26 @@ ATTGTTGTTTTA
 
     #[test]
     fn test_indexed_reader() {
-        _test_indexed_reader(&FASTA_FILE, &FAI_FILE, _read_buffer);
+        _test_indexed_reader(FASTA_FILE, FAI_FILE, _read_buffer);
         _test_indexed_reader_truncated(_read_buffer);
         _test_indexed_reader_extreme_whitespace(_read_buffer);
     }
 
     #[test]
     fn test_indexed_reader_crlf() {
-        _test_indexed_reader(&FASTA_FILE_CRLF, &FAI_FILE_CRLF, _read_buffer);
+        _test_indexed_reader(FASTA_FILE_CRLF, FAI_FILE_CRLF, _read_buffer);
     }
 
     #[test]
     fn test_indexed_reader_iter() {
-        _test_indexed_reader(&FASTA_FILE, &FAI_FILE, _read_iter);
+        _test_indexed_reader(FASTA_FILE, FAI_FILE, _read_iter);
         _test_indexed_reader_truncated(_read_iter);
         _test_indexed_reader_extreme_whitespace(_read_iter);
     }
 
     #[test]
     fn test_indexed_reader_iter_crlf() {
-        _test_indexed_reader(&FASTA_FILE_CRLF, &FAI_FILE_CRLF, _read_iter);
+        _test_indexed_reader(FASTA_FILE_CRLF, FAI_FILE_CRLF, _read_iter);
     }
 
     fn _test_indexed_reader<'a, F>(fasta: &'a [u8], fai: &'a [u8], read: F)
@@ -1416,22 +1416,22 @@ ATTGTTGTTTTA
 
     #[test]
     fn test_indexed_reader_all() {
-        _test_indexed_reader_all(&FASTA_FILE, &FAI_FILE, _read_buffer_all);
+        _test_indexed_reader_all(FASTA_FILE, FAI_FILE, _read_buffer_all);
     }
 
     #[test]
     fn test_indexed_reader_crlf_all() {
-        _test_indexed_reader_all(&FASTA_FILE_CRLF, &FAI_FILE_CRLF, _read_buffer_all);
+        _test_indexed_reader_all(FASTA_FILE_CRLF, FAI_FILE_CRLF, _read_buffer_all);
     }
 
     #[test]
     fn test_indexed_reader_iter_all() {
-        _test_indexed_reader_all(&FASTA_FILE, &FAI_FILE, _read_iter_all);
+        _test_indexed_reader_all(FASTA_FILE, FAI_FILE, _read_iter_all);
     }
 
     #[test]
     fn test_indexed_reader_iter_crlf_all() {
-        _test_indexed_reader_all(&FASTA_FILE_CRLF, &FAI_FILE_CRLF, _read_iter_all);
+        _test_indexed_reader_all(FASTA_FILE_CRLF, FAI_FILE_CRLF, _read_iter_all);
     }
 
     fn _test_indexed_reader_all<'a, F>(fasta: &'a [u8], fai: &'a [u8], read: F)
@@ -1476,22 +1476,22 @@ ATTGTTGTTTTA
 
     #[test]
     fn test_indexed_reader_by_rid_all() {
-        _test_indexed_reader_by_rid_all(&FASTA_FILE, &FAI_FILE, _read_buffer_by_rid_all);
+        _test_indexed_reader_by_rid_all(FASTA_FILE, FAI_FILE, _read_buffer_by_rid_all);
     }
 
     #[test]
     fn test_indexed_reader_crlf_by_rid_all() {
-        _test_indexed_reader_by_rid_all(&FASTA_FILE_CRLF, &FAI_FILE_CRLF, _read_buffer_by_rid_all);
+        _test_indexed_reader_by_rid_all(FASTA_FILE_CRLF, FAI_FILE_CRLF, _read_buffer_by_rid_all);
     }
 
     #[test]
     fn test_indexed_reader_iter_by_rid_all() {
-        _test_indexed_reader_by_rid_all(&FASTA_FILE, &FAI_FILE, _read_iter_by_rid_all);
+        _test_indexed_reader_by_rid_all(FASTA_FILE, FAI_FILE, _read_iter_by_rid_all);
     }
 
     #[test]
     fn test_indexed_reader_iter_crlf_by_rid_all() {
-        _test_indexed_reader_by_rid_all(&FASTA_FILE_CRLF, &FAI_FILE_CRLF, _read_iter_by_rid_all);
+        _test_indexed_reader_by_rid_all(FASTA_FILE_CRLF, FAI_FILE_CRLF, _read_iter_by_rid_all);
     }
 
     fn _test_indexed_reader_by_rid_all<'a, F>(fasta: &'a [u8], fai: &'a [u8], read: F)

--- a/src/pattern_matching/myers/long.rs
+++ b/src/pattern_matching/myers/long.rs
@@ -228,7 +228,7 @@ where
             && (peq[last_block + 1].peq[a as usize] & T::one() == T::one() || carry < 0)
         {
             last_block += 1;
-            self.add_state(-carry as i8);
+            self.add_state(-carry);
             advance_block(&mut self.states[last_block], &peq[last_block], a, carry);
         } else {
             while last_block > 0 && self.states[last_block].dist >= max_dist + w {

--- a/src/pattern_matching/myers/mod.rs
+++ b/src/pattern_matching/myers/mod.rs
@@ -255,13 +255,13 @@ mod tests {
     #[should_panic(expected = "Pattern too long")]
     fn test_pattern_too_long() {
         let pattern: Vec<_> = repeat(b'T').take(65).collect();
-        super::Myers::<u8>::new(&pattern);
+        super::Myers::<u8>::new(pattern);
     }
 
     #[test]
     #[should_panic(expected = "Pattern too long")]
     fn test_pattern_too_long_builder() {
         let pattern: Vec<_> = repeat(b'T').take(65).collect();
-        super::MyersBuilder::new().build_64(&pattern);
+        super::MyersBuilder::new().build_64(pattern);
     }
 }

--- a/src/pattern_matching/pssm/dnamotif.rs
+++ b/src/pattern_matching/pssm/dnamotif.rs
@@ -211,7 +211,7 @@ mod tests {
             assert_eq!(*loc, 4);
             assert_relative_eq!(*sum, 1.0, epsilon = f32::EPSILON);
         } else {
-            assert!(false);
+            panic!();
         }
     }
 

--- a/src/seq_analysis/orf.rs
+++ b/src/seq_analysis/orf.rs
@@ -58,11 +58,11 @@ impl Finder {
         Finder {
             start_codons: start_codons
                 .iter()
-                .map(|x| x.iter().map(|&x| x as u8).collect::<VecDeque<u8>>())
+                .map(|x| x.iter().copied().collect::<VecDeque<u8>>())
                 .collect(),
             stop_codons: stop_codons
                 .iter()
-                .map(|x| x.iter().map(|&x| x as u8).collect::<VecDeque<u8>>())
+                .map(|x| x.iter().copied().collect::<VecDeque<u8>>())
                 .collect(),
             min_len,
         }

--- a/src/stats/hmm/mod.rs
+++ b/src/stats/hmm/mod.rs
@@ -1393,8 +1393,8 @@ mod tests {
 
         let seqs = vec![vec![0.1, 0.5, 1.0, 1.5, 1.8, 2.1]];
         for seq in &seqs {
-            let prob_fwd = *Prob::from(forward(&hmm, &seq).1);
-            let prob_bck = *Prob::from(backward(&hmm, &seq).1);
+            let prob_fwd = *Prob::from(forward(&hmm, seq).1);
+            let prob_bck = *Prob::from(backward(&hmm, seq).1);
             assert_relative_eq!(prob_fwd, prob_bck, epsilon = 0.00001);
         }
     }

--- a/src/stats/hmm/mod.rs
+++ b/src/stats/hmm/mod.rs
@@ -1309,12 +1309,12 @@ mod tests {
         for len in 1..10 {
             let mut seq: Vec<usize> = vec![0; len];
             while seq.iter().sum::<usize>() != len {
-                for i in 0..len {
-                    if seq[i] == 0 {
-                        seq[i] = 1;
+                for elem in seq.iter_mut() {
+                    if *elem == 0 {
+                        *elem = 1;
                         break;
                     } else {
-                        seq[i] = 0;
+                        *elem = 0;
                     }
                 }
                 let prob_fwd = *Prob::from(forward(&hmm, &seq).1);

--- a/src/stats/hmm/mod.rs
+++ b/src/stats/hmm/mod.rs
@@ -1259,7 +1259,7 @@ mod tests {
         let (path, log_prob) = viterbi(&hmm, &[2, 2, 1, 0, 1, 3, 2, 0, 0]);
         let prob = Prob::from(log_prob);
 
-        let expected = vec![0, 0, 0, 1, 1, 1, 1, 1, 1]
+        let expected = [0, 0, 0, 1, 1, 1, 1, 1, 1]
             .iter()
             .map(|i| State(*i))
             .collect::<Vec<State>>();
@@ -1338,7 +1338,7 @@ mod tests {
         let (path, log_prob) = viterbi(&hmm, &[-0.1, 0.1, -0.2, 0.5, 0.8, 1.1, 1.2, 1.5, 0.5, 0.2]);
         let prob = Prob::from(log_prob);
 
-        let expected = vec![0, 0, 0, 0, 0, 1, 1, 1, 0, 0]
+        let expected = [0, 0, 0, 0, 0, 1, 1, 1, 0, 0]
             .iter()
             .map(|i| State(*i))
             .collect::<Vec<State>>();
@@ -1482,19 +1482,19 @@ mod tests {
             .collect::<Vec<Prob>>();
 
         // Compare with the example given in Jason Eisner's spreadsheet (http://www.cs.jhu.edu/~jason/papers/#eisner-2002-tnlp)
-        let pi_hat_vec_ori = vec![0.0597, 0.9403]
+        let pi_hat_vec_ori = [0.0597, 0.9403]
             .iter()
             .map(|x| Prob::from(*x))
             .collect::<Vec<Prob>>();
-        let transitions_hat_vec_ori = vec![0.8797, 0.1049, 0.0921, 0.8658]
+        let transitions_hat_vec_ori = [0.8797, 0.1049, 0.0921, 0.8658]
             .iter()
             .map(|x| Prob::from(*x))
             .collect::<Vec<Prob>>();
-        let observations_hat_vec_ori = vec![0.6765, 0.2188, 0.1047, 0.0584, 0.4251, 0.5165]
+        let observations_hat_vec_ori = [0.6765, 0.2188, 0.1047, 0.0584, 0.4251, 0.5165]
             .iter()
             .map(|x| Prob::from(*x))
             .collect::<Vec<Prob>>();
-        let end_hat_vec_ori = vec![0.0153, 0.0423]
+        let end_hat_vec_ori = [0.0153, 0.0423]
             .iter()
             .map(|x| Prob::from(*x))
             .collect::<Vec<Prob>>();
@@ -1559,19 +1559,19 @@ mod tests {
             .collect::<Vec<Prob>>();
 
         // Example based on Jason Eisner spreadsheet (http://www.cs.jhu.edu/~jason/papers/#eisner-2002-tnlp)
-        let pi_hat_vec_ori = vec![0.0, 1.0]
+        let pi_hat_vec_ori = [0.0, 1.0]
             .iter()
             .map(|x| Prob::from(*x))
             .collect::<Vec<Prob>>();
-        let transitions_hat_vec_ori = vec![0.9337, 0.0663, 0.0718, 0.865]
+        let transitions_hat_vec_ori = [0.9337, 0.0663, 0.0718, 0.865]
             .iter()
             .map(|x| Prob::from(*x))
             .collect::<Vec<Prob>>();
-        let observations_hat_vec_ori = vec![0.6407, 0.1481, 0.2112, 1.5e-4, 0.5341, 0.4657]
+        let observations_hat_vec_ori = [0.6407, 0.1481, 0.2112, 1.5e-4, 0.5341, 0.4657]
             .iter()
             .map(|x| Prob::from(*x))
             .collect::<Vec<Prob>>();
-        let end_hat_vec_ori = vec![0.0, 0.0632]
+        let end_hat_vec_ori = [0.0, 0.0632]
             .iter()
             .map(|x| Prob::from(*x))
             .collect::<Vec<Prob>>();

--- a/src/stats/pairhmm/pairhmm.rs
+++ b/src/stats/pairhmm/pairhmm.rs
@@ -16,9 +16,7 @@ use std::cmp;
 use std::mem;
 use std::usize;
 
-pub use crate::stats::pairhmm::{
-    EmissionParameters, GapParameters, StartEndGapParameters, XYEmission,
-};
+pub use crate::stats::pairhmm::{EmissionParameters, GapParameters, StartEndGapParameters};
 use crate::stats::LogProb;
 
 /// Fast approximation of sum over the three given proabilities. If the largest is sufficiently
@@ -284,7 +282,7 @@ impl PairHMM {
 
 #[cfg(test)]
 mod tests {
-    use crate::stats::{LogProb, Prob};
+    use crate::stats::{pairhmm::XYEmission, LogProb, Prob};
 
     use super::*;
 

--- a/tests/data_structures/rank_select.rs
+++ b/tests/data_structures/rank_select.rs
@@ -27,10 +27,7 @@ struct Select<T: Hash + Eq + Clone> {
 
 impl<T: Hash + Eq + Clone> Select<T> {
     fn push(&mut self, val: T) {
-        self.select
-            .entry(val)
-            .or_insert_with(Vec::new)
-            .push(self.len);
+        self.select.entry(val).or_default().push(self.len);
         self.len += 1;
     }
 


### PR DESCRIPTION
Fixes all but one clippy warning throughout the repo.
Unfortunately, this means changing a lot of files, though luckily all changes are confined to only a few lines.

The only clippy warning left is the one complaining that the `pairhmm` module has a child called `pairhmm`. I didn't want to `allow` the warning, and changing the module name is not something I wanted to make a decision about.

I considered splitting this PR up on a per module basis in order to potentially make it easier to merge, but I thought I'd start off like this. Each commit only changes a single file and only fixes a single clippy warning, so it should be pretty simple to cherry pick.