### PR TITLE
refactor!: Refactor misleadingly named method io::gff::Record::frame to phase and improve typing

### DIFF
--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -35,6 +35,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 use bio_types::strand::Strand;
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// `GffType`
 ///
@@ -148,9 +149,48 @@ type GffRecordInner = (
     u64,
     String,
     String,
-    String,
+    Phase,
     String,
 );
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct Phase(Option<u8>);
+
+impl<'de> Deserialize<'de> for Phase {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "." => Ok(Phase(None)),
+            _ => {
+                let p = u8::from_str(&s);
+                if let Ok(p) = p {
+                    if p < 3 {
+                        Ok(Phase(Some(p)))
+                    } else {
+                        Err(serde::de::Error::custom("Phase must be \".\", 0, 1, or 2"))
+                    }
+                } else {
+                    Err(serde::de::Error::custom("Phase must be \".\", 0, 1, or 2"))
+                }
+            }
+        }
+    }
+}
+
+impl Serialize for Phase {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            Some(p) => serializer.serialize_u8(p),
+            None => serializer.serialize_str("."),
+        }
+    }
+}
 
 /// An iterator over the records of a GFF file.
 pub struct Records<'a, R: io::Read> {
@@ -173,7 +213,7 @@ impl<'a, R: io::Read> Iterator for Records<'a, R> {
                     end,
                     score,
                     strand,
-                    frame,
+                    phase,
                     raw_attributes,
                 )| {
                     let trim_quotes = |s: &str| s.trim_matches('\'').trim_matches('"').to_owned();
@@ -191,7 +231,7 @@ impl<'a, R: io::Read> Iterator for Records<'a, R> {
                         end,
                         score,
                         strand,
-                        frame,
+                        phase,
                         attributes,
                     }
                 },
@@ -251,7 +291,7 @@ impl<W: io::Write> Writer<W> {
             record.end,
             &record.score,
             &record.strand,
-            &record.frame,
+            &record.phase,
             attributes,
         ))
     }
@@ -267,7 +307,7 @@ pub struct Record {
     end: u64,
     score: String,
     strand: String,
-    frame: String,
+    phase: Phase,
     attributes: MultiMap<String, String>,
 }
 
@@ -282,7 +322,7 @@ impl Record {
             end: 0,
             score: ".".to_owned(),
             strand: ".".to_owned(),
-            frame: "".to_owned(),
+            phase: Phase(None),
             attributes: MultiMap::<String, String>::new(),
         }
     }
@@ -329,9 +369,9 @@ impl Record {
         }
     }
 
-    /// Frame of the feature.
-    pub fn frame(&self) -> &str {
-        &self.frame
+    /// Phase of the feature. The phase is one of the integers 0, 1, or 2, indicating the number of bases that should be removed from the beginning of this feature to reach the first base of the next codon. `"."` if not applicable.
+    pub fn phase(&self) -> &Phase {
+        &self.phase
     }
 
     /// Attribute of feature
@@ -374,9 +414,9 @@ impl Record {
         &mut self.strand
     }
 
-    /// Get mutable reference on frame of feature.
-    pub fn frame_mut(&mut self) -> &mut String {
-        &mut self.frame
+    /// Get mutable reference on phase of feature.
+    pub fn phase_mut(&mut self) -> &mut Phase {
+        &mut self.phase
     }
 
     /// Get mutable reference on attributes of feature.
@@ -441,7 +481,7 @@ P0A7B8\tUniProtKB\tChain\t2\t176\t50\t+\t.\tID PRO_0000148105
         let ends = [1, 176];
         let scores = [None, Some(50)];
         let strand = [None, Some(Strand::Forward)];
-        let frame = [".", "."];
+        let phase = [Phase(None), Phase(None)];
         let mut attributes = [MultiMap::new(), MultiMap::new()];
         attributes[0].insert("ID".to_owned(), "test".to_owned());
         attributes[0].insert("Note".to_owned(), "Removed".to_owned());
@@ -462,7 +502,7 @@ P0A7B8\tUniProtKB\tChain\t2\t176\t50\t+\t.\tID PRO_0000148105
             assert_eq!(*record.end(), ends[i]);
             assert_eq!(record.score(), scores[i]);
             assert_eq!(record.strand(), strand[i]);
-            assert_eq!(record.frame(), frame[i]);
+            assert_eq!(*record.phase(), phase[i]);
             assert_eq!(record.attributes(), &attributes[i]);
         }
 
@@ -476,7 +516,7 @@ P0A7B8\tUniProtKB\tChain\t2\t176\t50\t+\t.\tID PRO_0000148105
             assert_eq!(*record.end(), ends[i]);
             assert_eq!(record.score(), scores[i]);
             assert_eq!(record.strand(), strand[i]);
-            assert_eq!(record.frame(), frame[i]);
+            assert_eq!(*record.phase(), phase[i]);
             assert_eq!(record.attributes(), &attributes[i]);
         }
     }
@@ -519,7 +559,7 @@ P0A7B8\tUniProtKB\tChain\t2\t176\t50\t+\t.\tID PRO_0000148105
         let ends = [1, 176];
         let scores = [None, Some(50)];
         let strand = [None, Some(Strand::Forward)];
-        let frame = [".", "."];
+        let phase = [Phase(None), Phase(None)];
         let mut attributes = [MultiMap::new(), MultiMap::new()];
         attributes[0].insert("ID".to_owned(), "test".to_owned());
         attributes[0].insert("Note".to_owned(), "Removed".to_owned());
@@ -536,7 +576,7 @@ P0A7B8\tUniProtKB\tChain\t2\t176\t50\t+\t.\tID PRO_0000148105
             assert_eq!(*record.end(), ends[i]);
             assert_eq!(record.score(), scores[i]);
             assert_eq!(record.strand(), strand[i]);
-            assert_eq!(record.frame(), frame[i]);
+            assert_eq!(*record.phase(), phase[i]);
             assert_eq!(record.attributes(), &attributes[i]);
         }
     }
@@ -550,7 +590,7 @@ P0A7B8\tUniProtKB\tChain\t2\t176\t50\t+\t.\tID PRO_0000148105
         let ends = [14409, 14409];
         let scores = [None, None];
         let strand = [Some(Strand::Forward), Some(Strand::Forward)];
-        let frame = [".", "."];
+        let phase = [Phase(None), Phase(None)];
         let mut attributes = [MultiMap::new(), MultiMap::new()];
         attributes[0].insert("gene_id".to_owned(), "ENSG00000223972.5".to_owned());
         attributes[0].insert(
@@ -574,7 +614,7 @@ P0A7B8\tUniProtKB\tChain\t2\t176\t50\t+\t.\tID PRO_0000148105
             assert_eq!(*record.end(), ends[i]);
             assert_eq!(record.score(), scores[i]);
             assert_eq!(record.strand(), strand[i]);
-            assert_eq!(record.frame(), frame[i]);
+            assert_eq!(*record.phase(), phase[i]);
             assert_eq!(record.attributes(), &attributes[i]);
         }
     }

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -369,7 +369,7 @@ impl Record {
         }
     }
 
-    /// Phase of the feature. The phase is one of the integers 0, 1, or 2, indicating the number of bases that should be removed from the beginning of this feature to reach the first base of the next codon. `"."` if not applicable.
+    /// Phase of the feature. The phase is one of the integers 0, 1, or 2, indicating the number of bases that should be removed from the beginning of this feature to reach the first base of the next codon. `None` if not applicable (`"."` in GFF file).
     pub fn phase(&self) -> &Phase {
         &self.phase
     }


### PR DESCRIPTION
This PR does some refactoring for `io::gff::Record::frame`. The [docs on gmod](http://gmod.org/wiki/GFF3#GFF3_Format) specifically mention the column `phase` not to be confused with `frame` which is currently the case in the bio crate. I also used the chance to add a better typing to the field as an `Option<u8>` as `Phase` is much nicer to work with than a plain String.

Beware that this is potentially a breaking change although I am not sure this change really qualifies for a new major release of rust-bio.