### PR TITLE
fix: Add missing method to access phase of gff record

### DIFF
--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -692,4 +692,24 @@ P0A7B8\tUniProtKB\tChain\t2\t176\t50\t+\t.\tID PRO_0000148105
             Err("String 'xtf9' is not a valid GFFType (GFF/GTF format version).".to_string())
         )
     }
+
+    #[test]
+    fn test_from_u8_creates_phase_with_value() {
+        let phase = Phase::from(1);
+        assert_eq!(phase, Phase(Some(1)));
+    }
+
+    #[test]
+    fn test_try_into_u8_returns_value_for_phase_with_value() {
+        let phase = Phase(Some(2));
+        let result: Result<u8, ()> = phase.try_into();
+        assert_eq!(result, Ok(2));
+    }
+
+    #[test]
+    fn test_try_into_u8_returns_error_for_phase_with_none() {
+        let phase = Phase(None);
+        let result: Result<u8, ()> = phase.try_into();
+        assert_eq!(result, Err(()));
+    }
 }

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -164,14 +164,27 @@ impl Phase {
     /// ```
     /// use bio::io::gff::Phase;
     ///
-    /// let phase = Phase(Some(1));
+    /// let phase = Phase::new(Some(1));
     /// assert_eq!(phase.as_u8(), Some(1));
     ///
-    /// let phase = Phase(None);
+    /// let phase = Phase::new(None);
     /// assert_eq!(phase.as_u8(), None);
     /// ```
     pub fn as_u8(&self) -> Option<u8> {
         self.0
+    }
+
+    /// Create a new `Phase` from an `Option<u8>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bio::io::gff::Phase;
+    ///
+    /// let phase = Phase::new(Some(1));
+    /// ```
+    pub fn new(phase: Option<u8>) -> Self {
+        Phase(phase)
     }
 }
 

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -157,22 +157,22 @@ type GffRecordInner = (
 pub struct Phase(Option<u8>);
 
 impl Phase {
-/// Returns the phase of the feature as an `Option<u8>`.
-///
-/// # Examples
-///
-/// ```
-/// use bio::io::gff::Phase;
-///
-/// let phase = Phase(Some(1));
-/// assert_eq!(phase.as_u8(), Some(1));
-///
-/// let phase = Phase(None);
-/// assert_eq!(phase.as_u8(), None);
-/// ```
-pub fn as_u8(&self) -> Option<u8> {
-    self.0
-}
+    /// Returns the phase of the feature as an `Option<u8>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bio::io::gff::Phase;
+    ///
+    /// let phase = Phase(Some(1));
+    /// assert_eq!(phase.as_u8(), Some(1));
+    ///
+    /// let phase = Phase(None);
+    /// assert_eq!(phase.as_u8(), None);
+    /// ```
+    pub fn as_u8(&self) -> Option<u8> {
+        self.0
+    }
 }
 
 impl<'de> Deserialize<'de> for Phase {

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -156,6 +156,25 @@ type GffRecordInner = (
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct Phase(Option<u8>);
 
+impl Phase {
+/// Returns the phase of the feature as an `Option<u8>`.
+///
+/// # Examples
+///
+/// ```
+/// use bio::io::gff::Phase;
+///
+/// let phase = Phase(Some(1));
+/// assert_eq!(phase.as_u8(), Some(1));
+///
+/// let phase = Phase(None);
+/// assert_eq!(phase.as_u8(), None);
+/// ```
+pub fn as_u8(&self) -> Option<u8> {
+    self.0
+}
+}
+
 impl<'de> Deserialize<'de> for Phase {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -28,7 +28,7 @@ use anyhow::Context;
 use itertools::Itertools;
 use multimap::MultiMap;
 use regex::Regex;
-use std::convert::AsRef;
+use std::convert::{AsRef, TryInto};
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -156,35 +156,20 @@ type GffRecordInner = (
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct Phase(Option<u8>);
 
-impl Phase {
-    /// Returns the phase of the feature as an `Option<u8>`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bio::io::gff::Phase;
-    ///
-    /// let phase = Phase::new(Some(1));
-    /// assert_eq!(phase.as_u8(), Some(1));
-    ///
-    /// let phase = Phase::new(None);
-    /// assert_eq!(phase.as_u8(), None);
-    /// ```
-    pub fn as_u8(&self) -> Option<u8> {
-        self.0
+impl From<u8> for Phase {
+    fn from(p: u8) -> Self {
+        Phase(Some(p))
     }
+}
 
-    /// Create a new `Phase` from an `Option<u8>`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bio::io::gff::Phase;
-    ///
-    /// let phase = Phase::new(Some(1));
-    /// ```
-    pub fn new(phase: Option<u8>) -> Self {
-        Phase(phase)
+impl TryInto<u8> for Phase {
+    type Error = ();
+
+    fn try_into(self) -> Result<u8, Self::Error> {
+        match self.0 {
+            Some(p) => Ok(p),
+            None => Err(()),
+        }
     }
 }
 

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -157,6 +157,13 @@ type GffRecordInner = (
 pub struct Phase(Option<u8>);
 
 impl From<u8> for Phase {
+    /// Create a new Phase from a u8.
+    ///
+    /// # Example
+    /// ```
+    /// use bio::io::gff::Phase;
+    /// let p = Phase::from(0);
+    /// ```
     fn from(p: u8) -> Self {
         Phase(Some(p))
     }
@@ -165,6 +172,17 @@ impl From<u8> for Phase {
 impl TryInto<u8> for Phase {
     type Error = ();
 
+    /// Try to convert a Phase into a u8.
+    ///
+    /// # Example
+    /// ```
+    /// use std::convert::TryInto;
+    /// use bio::io::gff::Phase;
+    ///
+    /// let p = Phase::from(0);
+    /// let u: u8 = p.try_into().unwrap();
+    /// assert_eq!(u, 0);
+    /// ```
     fn try_into(self) -> Result<u8, Self::Error> {
         match self.0 {
             Some(p) => Ok(p),


### PR DESCRIPTION
This PR adds a missing method to access the phase of a gff record.