### PR TITLE
feat: position-specific scoring matrix: support inputs with ambiguous monomers in from_seqs

### DIFF
--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -298,10 +298,7 @@ pub fn suffix_array(text: &[u8]) -> RawSuffixArray {
 /// use bio::data_structures::suffix_array::suffix_array_int;
 /// let text: Vec<usize> = vec![3, 2, 2, 4, 4, 1, 2, 1, 0];
 /// let sa = suffix_array_int(&text);
-/// assert_eq!(
-///     sa,
-///     vec![8, 7, 5, 6, 1, 2, 0, 4, 3]
-/// );
+/// assert_eq!(sa, vec![8, 7, 5, 6, 1, 2, 0, 4, 3]);
 /// ```
 pub fn suffix_array_int<T>(text: &[T]) -> RawSuffixArray
 where

--- a/src/io/gff.rs
+++ b/src/io/gff.rs
@@ -176,8 +176,8 @@ impl TryInto<u8> for Phase {
     ///
     /// # Example
     /// ```
-    /// use std::convert::TryInto;
     /// use bio::io::gff::Phase;
+    /// use std::convert::TryInto;
     ///
     /// let p = Phase::from(0);
     /// let u: u8 = p.try_into().unwrap();

--- a/src/pattern_matching/pssm/dnamotif.rs
+++ b/src/pattern_matching/pssm/dnamotif.rs
@@ -118,6 +118,7 @@ impl Motif for DNAMotif {
             b'D' => Ok(array![0.333, 0.333, 0.333, 0.0]),
             b'B' => Ok(array![0.0, 0.333, 0.333, 0.333]),
             b'N' => Ok(array![0.25, 0.25, 0.25, 0.25]),
+            b'0' => Ok(array![0.0, 0.0, 0.0, 0.0]),
             _ => Err(Error::InvalidMonomer { mono }),
         }
     }

--- a/src/pattern_matching/pssm/dnamotif.rs
+++ b/src/pattern_matching/pssm/dnamotif.rs
@@ -101,6 +101,27 @@ impl Motif for DNAMotif {
         }
     }
 
+    fn incr(mono: u8) -> Result<Array1<f32>> {
+        match mono {
+            b'A' => Ok(array![1.0, 0.0, 0.0, 0.0]),
+            b'T' => Ok(array![0.0, 1.0, 0.0, 0.0]),
+            b'G' => Ok(array![0.0, 0.0, 1.0, 0.0]),
+            b'C' => Ok(array![0.0, 0.0, 0.0, 1.0]),
+            b'M' => Ok(array![0.5, 0.0, 0.0, 0.5]),
+            b'R' => Ok(array![0.5, 0.0, 0.5, 0.0]),
+            b'W' => Ok(array![0.5, 0.5, 0.0, 0.0]),
+            b'S' => Ok(array![0.0, 0.0, 0.5, 0.5]),
+            b'Y' => Ok(array![0.0, 0.5, 0.0, 0.5]),
+            b'K' => Ok(array![0.0, 0.5, 0.5, 0.0]),
+            b'V' => Ok(array![0.333, 0.0, 0.333, 0.333]),
+            b'H' => Ok(array![0.333, 0.333, 0.0, 0.333]),
+            b'D' => Ok(array![0.333, 0.333, 0.333, 0.0]),
+            b'B' => Ok(array![0.0, 0.333, 0.333, 0.333]),
+            b'N' => Ok(array![0.25, 0.25, 0.25, 0.25]),
+            _ => Err(Error::InvalidMonomer { mono }),
+        }
+    }
+
     fn len(&self) -> usize {
         self.scores.dim().0
     }
@@ -143,10 +164,14 @@ impl Motif for DNAMotif {
             fracs.sort_by(|a, b| b.partial_cmp(a).unwrap());
 
             res.push(if fracs[0].0 > 0.5 && fracs[0].0 > 2.0 * fracs[1].0 {
+                // use the dominant nucleotide if it's above 50% and more than
+                // 2x the second-highest nucleotide
                 Self::MONOS[fracs[0].1]
             } else if 4.0 * (fracs[0].0 + fracs[1].0) > 3.0 {
+                // the top two nucleotides represent > 75%
                 two(Self::MONOS[fracs[0].1], Self::MONOS[fracs[1].1])
             } else if fracs[3].0 < EPSILON {
+                // the least common nucleotide is ~0
                 let base = Self::MONOS[fracs[3].1];
                 match base {
                     b'T' => b'V',
@@ -188,13 +213,12 @@ mod tests {
     #[test]
     fn simple_pssm() {
         let pssm: DNAMotif = DNAMotif::from_seqs(
-            vec![
+            &[
                 b"AAAA".to_vec(),
                 b"TTTT".to_vec(),
                 b"GGGG".to_vec(),
                 b"CCCC".to_vec(),
-            ]
-            .as_ref(),
+            ],
             None,
         )
         .unwrap();
@@ -202,7 +226,7 @@ mod tests {
     }
     #[test]
     fn find_motif() {
-        let pssm = DNAMotif::from_seqs(vec![b"ATGC".to_vec()].as_ref(), None).unwrap();
+        let pssm = DNAMotif::from_seqs(&[b"ATGC".to_vec()], None).unwrap();
         let seq = b"GGGGATGCGGGG";
         if let Ok(ScoredPos {
             ref loc, ref sum, ..
@@ -218,16 +242,14 @@ mod tests {
     #[test]
     fn test_info_content() {
         // matrix w/ 100% match to A at each position
-        let pssm =
-            DNAMotif::from_seqs(vec![b"AAAA".to_vec()].as_ref(), Some(&[0.0, 0.0, 0.0, 0.0]))
-                .unwrap();
+        let pssm = DNAMotif::from_seqs(&[b"AAAA".to_vec()], Some(&[0.0; 4])).unwrap();
         // 4 bases * 2 bits per base = 8
         assert_relative_eq!(pssm.info_content(), 8.0, epsilon = f32::EPSILON);
     }
 
     #[test]
     fn test_mono_err() {
-        let pssm = DNAMotif::from_seqs(vec![b"ATGC".to_vec()].as_ref(), None).unwrap();
+        let pssm = DNAMotif::from_seqs(&[b"ATGC".to_vec()], None).unwrap();
         assert_eq!(
             pssm.score(b"AAAAXAAAAAAAAA"),
             Err(Error::InvalidMonomer { mono: b'X' })
@@ -238,7 +260,7 @@ mod tests {
     fn test_inconsist_err() {
         assert_eq!(
             DNAMotif::from_seqs(
-                vec![b"AAAA".to_vec(), b"TTTT".to_vec(), b"C".to_vec()].as_ref(),
+                &[b"AAAA".to_vec(), b"TTTT".to_vec(), b"C".to_vec()],
                 Some(&[0.0; 4])
             ),
             Err(Error::InconsistentLen)
@@ -247,29 +269,24 @@ mod tests {
 
     #[test]
     fn test_degenerate_consensus_same_bases() {
-        let pssm: DNAMotif = DNAMotif::from_seqs(
-            vec![b"ATGC".to_vec(), b"ATGC".to_vec()].as_ref(),
-            Some(&[0., 0., 0., 0.]),
-        )
-        .unwrap();
+        let pssm: DNAMotif =
+            DNAMotif::from_seqs(&[b"ATGC".to_vec(), b"ATGC".to_vec()], Some(&[0.0; 4])).unwrap();
         assert_eq!(pssm.degenerate_consensus(), b"ATGC".to_vec());
     }
 
     #[test]
     fn test_degenerate_consensus_two_bases() {
-        let pssm: DNAMotif = DNAMotif::from_seqs(
-            vec![b"AAACCG".to_vec(), b"CGTGTT".to_vec()].as_ref(),
-            Some(&[0., 0., 0., 0.]),
-        )
-        .unwrap();
+        let pssm: DNAMotif =
+            DNAMotif::from_seqs(&[b"AAACCG".to_vec(), b"CGTGTT".to_vec()], Some(&[0.0; 4]))
+                .unwrap();
         assert_eq!(pssm.degenerate_consensus(), b"MRWSYK".to_vec());
     }
 
     #[test]
     fn test_degenerate_consensus_three_bases() {
         let pssm: DNAMotif = DNAMotif::from_seqs(
-            vec![b"AAAC".to_vec(), b"CCGG".to_vec(), b"GTTT".to_vec()].as_ref(),
-            Some(&[0., 0., 0., 0.]),
+            &[b"AAAC".to_vec(), b"CCGG".to_vec(), b"GTTT".to_vec()],
+            Some(&[0.0; 4]),
         )
         .unwrap();
         assert_eq!(pssm.degenerate_consensus(), b"VHDB".to_vec());
@@ -278,16 +295,20 @@ mod tests {
     #[test]
     fn test_degenerate_consensus_n() {
         let pssm: DNAMotif = DNAMotif::from_seqs(
-            vec![
+            &[
                 b"AAAA".to_vec(),
                 b"GGGG".to_vec(),
                 b"CCCC".to_vec(),
                 b"TTTT".to_vec(),
-            ]
-            .as_ref(),
+            ],
             None,
         )
         .unwrap();
         assert_eq!(pssm.degenerate_consensus(), b"NNNN".to_vec());
+    }
+    #[test]
+    fn test_degenerate_input() {
+        let pssm: DNAMotif = DNAMotif::from_seqs(&[b"ATMC".to_vec()], Some(&[0.0; 4])).unwrap();
+        assert_eq!(pssm.degenerate_consensus(), b"ATMC".to_vec());
     }
 }

--- a/src/pattern_matching/pssm/mod.rs
+++ b/src/pattern_matching/pssm/mod.rs
@@ -36,7 +36,7 @@ use std::borrow::Borrow;
 use std::f32::NEG_INFINITY;
 
 use itertools::Itertools;
-use ndarray::prelude::Array2;
+use ndarray::prelude::*;
 
 mod dnamotif;
 pub mod errors;
@@ -89,20 +89,20 @@ pub trait Motif {
     ///    defaults to DEF_PSEUDO for all if None is supplied
     ///
     /// FIXME: pseudos should be an array of size MONO_CT, but that
-    /// is currently unsupported
+    /// is currently unsupported in stable rust
     fn seqs_to_weights(seqs: &[Vec<u8>], _pseudos: Option<&[f32]>) -> Result<Array2<f32>> {
-        let p1 = vec![DEF_PSEUDO; Self::MONO_CT];
-        let pseudos = match _pseudos {
-            Some(p2) => p2,
-            None => p1.as_slice(),
-        };
-
-        if pseudos.len() != Self::MONO_CT {
-            return Err(Error::InvalidPseudos {
-                expected: Self::MONO_CT as u8,
-                received: pseudos.len() as u8,
-            });
+        if _pseudos.is_some() {
+            if _pseudos.unwrap().len() != Self::MONO_CT {
+                return Err(Error::InvalidPseudos {
+                    expected: Self::MONO_CT as u8,
+                    received: _pseudos.unwrap().len() as u8,
+                });
+            }
         }
+        let pseudos: Array1<f32> = match _pseudos {
+            Some(p) => Array::from_vec(p.iter().cloned().collect()),
+            None => Array::from_vec(vec![DEF_PSEUDO; Self::MONO_CT]),
+        };
 
         if seqs.is_empty() {
             return Err(Error::EmptyMotif);
@@ -110,10 +110,8 @@ pub trait Motif {
 
         let seqlen = seqs[0].len();
         let mut counts = Array2::zeros((seqlen, Self::MONO_CT));
-        for i in 0..seqlen {
-            for base in 0..Self::MONO_CT {
-                counts[[i, base]] = pseudos[base];
-            }
+        for mut row in counts.axis_iter_mut(Axis(0)) {
+            row += &pseudos;
         }
 
         for seq in seqs.iter() {
@@ -121,11 +119,8 @@ pub trait Motif {
                 return Err(Error::InconsistentLen);
             }
 
-            for (idx, base) in seq.iter().enumerate() {
-                match Self::lookup(*base) {
-                    Err(e) => return Err(e),
-                    Ok(pos) => counts[[idx, pos]] += 1.0,
-                }
+            for (mut ctr, base) in counts.axis_iter_mut(Axis(0)).zip(seq.iter()) {
+                ctr += &Self::incr(*base)?;
             }
         }
         Ok(counts)
@@ -148,6 +143,14 @@ pub trait Motif {
             }
         }
     }
+
+    /// Returns an array of length MONO_CT summing to 1.  used to build a PSSM
+    /// from sequences, potentially including ambiguous monomers (eg, M is either A or C)
+    /// # Arguments
+    /// * `mono` - monomer, eg, b'A' for DNA or b'R' for protein
+    /// # Errors
+    /// * `Error::InvalidMonomer(mono)` - `mono` wasn't found in the lookup table
+    fn incr(mono: u8) -> Result<Array1<f32>>;
 
     /// Returns the monomer associated with the given index; the reverse of `lookup`.
     /// Returns INVALID_MONO if the index isn't associated with a monomer.


### PR DESCRIPTION
This PR enables the creation of a position-specific scoring matrix from inputs with ambiguous monomers, eg, DNA sequences containing N bases.

There are two use cases for this:
- some sequencing technologies emit N bases, which would produce an error if used as an input in the current code
- this serves as a [lossy] deserialization technique for the PSSM representation produced by `degenerate_consensus` 