### PR TITLE
build(deps): Remove unused dependency `rand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ enum-map = ">=0.6.4, <3"
 triple_accel = ">=0.3, <0.5"
 thiserror = "2"
 anyhow = "1"
-rand = ">=0.7.3, < 0.10"
 editdistancek = ">=1.0.1, <2"
 
 [dependencies.vec_map]

--- a/benches/fasta_buffer_size.rs
+++ b/benches/fasta_buffer_size.rs
@@ -17,7 +17,7 @@ fn random_seq<RNG>(length: usize, rng: &mut RNG) -> Vec<u8>
 where
     RNG: rand::Rng,
 {
-    (0..length).map(|_| NUCS[rng.gen_range(0..=3)]).collect()
+    (0..length).map(|_| NUCS[rng.random_range(0..=3)]).collect()
 }
 
 fn write_sequence(file: &mut std::fs::File, seed: u64) {

--- a/benches/fastx.rs
+++ b/benches/fastx.rs
@@ -3,7 +3,7 @@
 extern crate test;
 
 use bio::io::{fasta, fastx};
-use rand::distributions::Alphanumeric;
+use rand::distr::Alphanumeric;
 use rand::rngs::StdRng;
 use rand::Rng;
 use rand::SeedableRng;
@@ -32,7 +32,7 @@ fn gen_random_fasta() -> io::Result<Vec<u8>> {
 
             let seq: Vec<u8> = (0..SEQ_LEN)
                 .map(|_| {
-                    let idx = rng.gen_range(0..BASES.len());
+                    let idx = rng.random_range(0..BASES.len());
                     BASES[idx]
                 })
                 .collect();

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 bio = {path = ".."}
-itertools = ">=0.8, <0.12"
 
 [dependencies.libfuzzer-sys]
 git = "https://github.com/rust-fuzz/libfuzzer-sys.git"

--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -848,11 +848,11 @@ mod tests {
     }
 
     fn rand_seqs(num_seqs: usize, seq_len: usize) -> Vec<u8> {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let alpha = [b'A', b'T', b'C', b'G', b'N'];
         let seqs = (0..num_seqs)
             .map(|_| {
-                let len = rng.gen_range((seq_len / 2)..=seq_len);
+                let len = rng.random_range((seq_len / 2)..=seq_len);
                 (0..len)
                     .map(|_| *alpha.choose(&mut rng).unwrap())
                     .collect::<Vec<u8>>()


### PR DESCRIPTION
- Remove the unused dependency `rand`, keep the dev dependency
- Remove the unused dependency `itertools` from `fuzz`
- Change `rand::distributions` to `rand::distr`
- Change `rand::thread_rng()` to `rand::rng()`
- Change `gen_range` to `random_range`
