### PR TITLE
Refactor pattern_matching::myers and add LazyMatches::dist_at()

### DIFF
--- a/benches/approximate_matching.rs
+++ b/benches/approximate_matching.rs
@@ -300,7 +300,6 @@ fn myers_end_long_8(b: &mut Bencher) {
     });
 }
 
-#[cfg(has_u128)]
 #[bench]
 fn myers_end_128(b: &mut Bencher) {
     let myers = Myers::<u128>::new(PATTERN);
@@ -313,7 +312,6 @@ fn myers_end_128(b: &mut Bencher) {
     });
 }
 
-#[cfg(has_u128)]
 #[bench]
 fn myers_end_long_128(b: &mut Bencher) {
     let myers = long::Myers::<u128>::new(PATTERN);
@@ -339,7 +337,6 @@ fn myers_pos_64(b: &mut Bencher) {
     });
 }
 
-#[cfg(has_u128)]
 #[bench]
 fn myers_pos_128(b: &mut Bencher) {
     let mut myers = Myers::<u128>::new(PATTERN);
@@ -409,7 +406,6 @@ fn myers_path_long_8(b: &mut Bencher) {
     });
 }
 
-#[cfg(has_u128)]
 #[bench]
 fn myers_path_long_128(b: &mut Bencher) {
     let mut myers = long::Myers::<u128>::new(PATTERN);

--- a/benches/approximate_matching.rs
+++ b/benches/approximate_matching.rs
@@ -5,7 +5,7 @@ extern crate test;
 use test::Bencher;
 
 use bio::alignment::Alignment;
-use bio::pattern_matching::myers::{long, Myers};
+use bio::pattern_matching::myers::{self, long};
 use bio::pattern_matching::ukkonen::*;
 
 static TEXT: &[u8] = b"GATCACAGGTCTATCACCCTATTAACCACTCACGGGAGCTCTCCATGC\
@@ -222,11 +222,13 @@ CATCACGATG";
 
 // Pattern has same length as in pattern_matching.rs, but 2 differences to best match.
 // With k = 5 there are 14 hits, with k = 6, there are 78 hits (most are overlapping)
-static PATTERN: &[u8] = b"GCGCGTCCACACCGCTCG";
+const PATTERN: &[u8] = b"GCGCGTCCACACCGCTCG";
 
-static K: u8 = 6;
+const DISTANCE: u8 = 2;
+
+const K: u8 = 6;
 // used with assertions to ensure correct code and to prevent over-optimization
-static N_HITS: usize = 78; // at given K
+const N_HITS: usize = 78; // at given K
 
 #[bench]
 fn ukkonen(b: &mut Bencher) {
@@ -252,107 +254,87 @@ fn pairwise_align(b: &mut Bencher) {
     });
 }
 
-#[bench]
-fn myers_end_32(b: &mut Bencher) {
-    let myers: Myers<u32> = Myers::new(PATTERN);
-    b.iter(|| {
-        let mut n = 0;
-        for _ in myers.find_all_end(TEXT, K) {
-            n += 1;
-        }
-        assert_eq!(n, N_HITS);
-    });
+macro_rules! impl_bench_myers_end {
+    ($(($mod:ident) $size:ty, $dist_size:ty : $func_name:ident),*) => {
+        $(
+            #[bench]
+            fn $func_name(b: &mut Bencher) {
+                let myers: $mod::Myers<$size> = $mod::Myers::new(PATTERN);
+                b.iter(|| {
+                    let mut n = 0;
+                    for _ in myers.find_all_end(TEXT, K as $dist_size) {
+                        n += 1;
+                    }
+                    assert_eq!(n, N_HITS);
+                });
+            }
+        )*
+    }
 }
 
-#[bench]
-fn myers_end_64(b: &mut Bencher) {
-    let myers = Myers::<u64>::new(PATTERN);
-    b.iter(|| {
-        let mut n = 0;
-        for _ in myers.find_all_end(TEXT, K) {
-            n += 1;
-        }
-        assert_eq!(n, N_HITS);
-    });
+impl_bench_myers_end!(
+    (myers) u32, u8: myers_end_32,
+    (myers) u64, u8: myers_end_64,
+    (myers) u128, u8: myers_end_128,
+    (long) u8, usize: myers_end_long_8,
+    (long) u64, usize: myers_end_long_64,
+    (long) u128, usize: myers_end_long_128
+);
+
+macro_rules! impl_bench_myers_dist {
+    ($(($mod:ident) $size:ty, $dist_size:ty : $func_name:ident),*) => {
+        $(
+            #[bench]
+            fn $func_name(b: &mut Bencher) {
+                let myers: $mod::Myers<$size> = $mod::Myers::new(PATTERN);
+                b.iter(|| {
+                    let dist = myers.distance(TEXT);
+                    assert_eq!(dist as u8, DISTANCE);
+                });
+            }
+        )*
+    }
 }
 
-#[bench]
-fn myers_end_long_64(b: &mut Bencher) {
-    let myers = long::Myers::<u64>::new(PATTERN);
-    b.iter(|| {
-        let mut n = 0;
-        for _ in myers.find_all_end(TEXT, K as usize) {
-            n += 1;
-        }
-        assert_eq!(n, N_HITS);
-    });
+impl_bench_myers_dist!(
+    (myers) u32, u8: myers_dist_32,
+    (myers) u64, u8: myers_dist_64,
+    (myers) u128, u8: myers_dist_128,
+    (long) u8, usize: myers_dist_long_8,
+    (long) u64, usize: myers_dist_long_64,
+    (long) u128, usize: myers_dist_long_128
+);
+
+macro_rules! impl_bench_myers_pos {
+    ($(($mod:ident) $size:ty, $dist_type:ty : $func_name:ident),*) => {
+        $(
+            #[bench]
+            fn $func_name(b: &mut Bencher) {
+                let mut myers = $mod::Myers::<$size>::new(PATTERN);
+                b.iter(|| {
+                    let mut n = 0;
+                    let matches = myers.find_all(TEXT, K as $dist_type);
+                    for _ in matches {
+                        n += 1;
+                    }
+                    assert_eq!(n, N_HITS);
+                });
+            }
+        )*
+    }
 }
 
-#[bench]
-fn myers_end_long_8(b: &mut Bencher) {
-    let myers = long::Myers::<u8>::new(PATTERN);
-    b.iter(|| {
-        let mut n = 0;
-        for _ in myers.find_all_end(TEXT, K as usize) {
-            n += 1;
-        }
-        assert_eq!(n, N_HITS);
-    });
-}
-
-#[bench]
-fn myers_end_128(b: &mut Bencher) {
-    let myers = Myers::<u128>::new(PATTERN);
-    b.iter(|| {
-        let mut n = 0;
-        for _ in myers.find_all_end(TEXT, K) {
-            n += 1;
-        }
-        assert_eq!(n, N_HITS);
-    });
-}
-
-#[bench]
-fn myers_end_long_128(b: &mut Bencher) {
-    let myers = long::Myers::<u128>::new(PATTERN);
-    b.iter(|| {
-        let mut n = 0;
-        for _ in myers.find_all_end(TEXT, K as usize) {
-            n += 1;
-        }
-        assert_eq!(n, N_HITS);
-    });
-}
-
-#[bench]
-fn myers_pos_64(b: &mut Bencher) {
-    let mut myers = Myers::<u64>::new(PATTERN);
-    b.iter(|| {
-        let mut n = 0;
-        let matches = myers.find_all(TEXT, K);
-        for _ in matches {
-            n += 1;
-        }
-        assert_eq!(n, N_HITS);
-    });
-}
-
-#[bench]
-fn myers_pos_128(b: &mut Bencher) {
-    let mut myers = Myers::<u128>::new(PATTERN);
-    b.iter(|| {
-        let mut n = 0;
-        let matches = myers.find_all(TEXT, K);
-        for _ in matches {
-            n += 1;
-        }
-        assert_eq!(n, N_HITS);
-    });
-}
+impl_bench_myers_pos!(
+    (myers) u64, u8: myers_pos_64,
+    (myers) u128, u8: myers_pos_128,
+    (long) u8, usize: myers_pos_long_8,
+    (long) u64, usize: myers_pos_long_64,
+    (long) u128, usize: myers_pos_long_128
+);
 
 #[bench]
 fn myers_path_reverse_64(b: &mut Bencher) {
-    let mut myers = Myers::<u64>::new(PATTERN);
+    let mut myers = myers::Myers::<u64>::new(PATTERN);
     let mut ops = vec![];
     b.iter(|| {
         let mut n = 0;
@@ -364,65 +346,37 @@ fn myers_path_reverse_64(b: &mut Bencher) {
     });
 }
 
-#[bench]
-fn myers_path_64(b: &mut Bencher) {
-    let mut myers = Myers::<u64>::new(PATTERN);
-    let mut ops = vec![];
-    b.iter(|| {
-        let mut n = 0;
-        let mut matches = myers.find_all(TEXT, K);
-        while matches.next_path(&mut ops).is_some() {
-            n += 1;
-        }
-        assert_eq!(n, N_HITS);
-    });
+macro_rules! impl_bench_myers_path {
+    ($(($mod:ident) $size:ty, $dist_type:ty : $func_name:ident),*) => {
+        $(
+            #[bench]
+            fn $func_name(b: &mut Bencher) {
+                let mut myers = $mod::Myers::<$size>::new(PATTERN);
+                let mut ops = vec![];
+                b.iter(|| {
+                    let mut n = 0;
+                    let mut matches = myers.find_all(TEXT, K as $dist_type);
+                    while matches.next_path(&mut ops).is_some() {
+                        n += 1;
+                    }
+                    assert_eq!(n, N_HITS);
+                });
+            }
+        )*
+    }
 }
 
-#[bench]
-fn myers_path_long_64(b: &mut Bencher) {
-    let mut myers = long::Myers::<u64>::new(PATTERN);
-    let mut ops = vec![];
-    b.iter(|| {
-        let mut n = 0;
-        let mut matches = myers.find_all(TEXT, K as usize);
-        while matches.next_path(&mut ops).is_some() {
-            n += 1;
-        }
-        assert_eq!(n, N_HITS);
-    });
-}
-
-#[bench]
-fn myers_path_long_8(b: &mut Bencher) {
-    let mut myers = long::Myers::<u8>::new(PATTERN);
-    let mut ops = vec![];
-    b.iter(|| {
-        let mut n = 0;
-        let mut matches = myers.find_all(TEXT, K as usize);
-        while matches.next_path(&mut ops).is_some() {
-            n += 1;
-        }
-        assert_eq!(n, N_HITS);
-    });
-}
-
-#[bench]
-fn myers_path_long_128(b: &mut Bencher) {
-    let mut myers = long::Myers::<u128>::new(PATTERN);
-    let mut ops = vec![];
-    b.iter(|| {
-        let mut n = 0;
-        let mut matches = myers.find_all(TEXT, K as usize);
-        while matches.next_path(&mut ops).is_some() {
-            n += 1;
-        }
-        assert_eq!(n, N_HITS);
-    });
-}
+impl_bench_myers_path!(
+    (myers) u64, u8: myers_path_64,
+    (myers) u128, u8: myers_path_128,
+    (long) u8, usize: myers_path_long_8,
+    (long) u64, usize: myers_path_long_64,
+    (long) u128, usize: myers_path_long_128
+);
 
 #[bench]
 fn myers_alignment_64(b: &mut Bencher) {
-    let mut myers = Myers::<u64>::new(PATTERN);
+    let mut myers = myers::Myers::<u64>::new(PATTERN);
     let mut aln = Alignment::default();
     b.iter(|| {
         let mut n = 0;
@@ -437,7 +391,7 @@ fn myers_alignment_64(b: &mut Bencher) {
 // Allocates a new Alignment instance in each loop
 #[bench]
 fn myers_alignment_alloc_64(b: &mut Bencher) {
-    let mut myers = Myers::<u64>::new(PATTERN);
+    let mut myers = myers::Myers::<u64>::new(PATTERN);
     b.iter(|| {
         let mut n = 0;
         let mut matches = myers.find_all(TEXT, K);
@@ -455,7 +409,7 @@ fn myers_alignment_alloc_64(b: &mut Bencher) {
 // test impact of storing traceback information
 #[bench]
 fn myers_no_alignment_64(b: &mut Bencher) {
-    let mut myers = Myers::<u64>::new(PATTERN);
+    let mut myers = myers::Myers::<u64>::new(PATTERN);
     b.iter(|| {
         let mut n = 0;
         let mut matches = myers.find_all(TEXT, K);
@@ -469,7 +423,7 @@ fn myers_no_alignment_64(b: &mut Bencher) {
 // test impact of storing traceback information
 #[bench]
 fn myers_no_alignment_lazy_64(b: &mut Bencher) {
-    let mut myers = Myers::<u64>::new(PATTERN);
+    let mut myers = myers::Myers::<u64>::new(PATTERN);
     b.iter(|| {
         let n = myers.find_all_lazy(TEXT, K).count();
         assert_eq!(n, N_HITS);
@@ -478,12 +432,12 @@ fn myers_no_alignment_lazy_64(b: &mut Bencher) {
 
 #[bench]
 fn myers_lazy_best_alignment_64(b: &mut Bencher) {
-    let mut myers = Myers::<u64>::new(PATTERN);
+    let mut myers = myers::Myers::<u64>::new(PATTERN);
     let mut aln = Alignment::default();
     b.iter(|| {
         let mut n = 0;
         let mut matches = myers.find_all_lazy(TEXT, K);
-        let mut best_dist = u8::max_value();
+        let mut best_dist = u8::MAX;
         let mut best_end = 0;
         for (end, dist) in matches.by_ref() {
             if dist < best_dist {
@@ -499,7 +453,7 @@ fn myers_lazy_best_alignment_64(b: &mut Bencher) {
 
 #[bench]
 fn myers_lazy_best_alignment_iter_min_64(b: &mut Bencher) {
-    let mut myers = Myers::<u64>::new(PATTERN);
+    let mut myers = myers::Myers::<u64>::new(PATTERN);
     let mut aln = Alignment::default();
     b.iter(|| {
         let mut n = 0;

--- a/fuzz/fuzz_targets/myers_matching.rs
+++ b/fuzz/fuzz_targets/myers_matching.rs
@@ -1,167 +1,242 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
+#[macro_use]
+extern crate libfuzzer_sys;
 
-use std::cmp::{min, max};
-use bio::pattern_matching::myers::{MyersBuilder, Myers, long};
 use bio::alignment::Alignment;
 use bio::alignment::AlignmentOperation::*;
+use bio::pattern_matching::myers::{long, Myers, MyersBuilder};
 
+const HEADER_LEN: usize = 11;
 
 fuzz_target!(|data: &[u8]| {
-    if data.len() < 3 {
+    if data.len() < HEADER_LEN + 1 {
+        return;
+    }
+    let header = &data[..HEADER_LEN];
+    let data = &data[HEADER_LEN..];
+    if data.iter().any(|b| !b.is_ascii_graphic()) {
         return;
     }
 
-    let (max_dist, data) = data.split_first().unwrap();
-    let (pattern_len, data) = data.split_first().unwrap();
-    let max_dist = min(64, *max_dist);
-    let pattern_len = max(1, min(64, min(data.len(), *pattern_len as usize)));
+    let mut builder = MyersBuilder::new();
 
-    if data.iter().any(|&b| b < 65 || b > 122 || b > 90 && b < 97) {
-        return;
-    }
-
+    // 1: max. distance
+    let max_dist = header[0] / 32;
+    // 2: pattern length (limited to 128 symbols)
+    let pattern_len = header[1].rotate_left(max_dist as u32) as usize;
+    let pattern_len = pattern_len.max(1).min(128).min(data.len());
     let (pattern, text) = data.split_at(pattern_len);
+    let mut text = text.to_vec();
 
-    // Test whether builders succeed
-    // TODO: Builder testing could be expanded
-    let max_dist = max_dist as u8;
-    // Test whether builders succeed
-    // TODO: Builder testing could be expanded
-    let _ = MyersBuilder::new().build_64(pattern);
-    let _ = MyersBuilder::new().build_long_64(pattern);
-
-    // Myers objects
-    let mut myers = Myers::<u64>::new(pattern);
-    let mut myers_long = long::Myers::<u8>::new(pattern);
-
-    // No traceback, just searching
-    let end_dist: Vec<_> = myers.find_all_end(text, max_dist).collect();
-    let end_dist_long: Vec<_> = myers_long.find_all_end(text, max_dist as usize)
-        .map(|(end, dist)| (end, dist as u8))
-        .collect();
-    assert_eq!(end_dist, end_dist_long);
-
-    // Test traceback algorithm:
-    // The following code compares the distance from the myers algorithm with the
-    // number of substitutions / InDels found in the alignment path. If the distances
-    // are equal, then the traceback found a valid alignment path.
-    // Additionally, the actual pattern and text are inspected; matches / substitutions
-    // that are unexpectedly (un)equal will cause a panic.
-
-    // 'Default' API
-    let mut aln = Alignment::default();
-    let mut aln_long = Alignment::default();
-    {
-        let mut matches = myers.find_all(text, max_dist);
-        let mut matches_long = myers_long.find_all(text, max_dist as usize);
-
-        matches.alignment(&mut aln); // all insertions to text
-        matches_long.alignment(&mut aln_long);
-
-        let mut end_dist_iter = end_dist.iter();
-        while matches.next_alignment(&mut aln) {
-            assert!(matches_long.next_alignment(&mut aln_long));
-            assert_eq!(aln, aln_long);
-
-            // verify alignment
-            validate_alignment(&aln, pattern, text);
-            assert!(aln.score as u8 <= max_dist);
-
-            // compare to find_all_end() results
-            let (end, dist) = end_dist_iter.next().unwrap();
-            assert_eq!(*end + 1, aln.yend);
-            assert_eq!(*dist, aln.score as u8);
+    // 3: wildcard yes/no
+    // 4-5: range of wildcard positions in the text
+    let mut wildcard = None;
+    let w = header[2];
+    if w > b'z' && w.is_ascii() {
+        let (i0, i1) = (header[3] as usize, header[4] as usize);
+        if i1 >= i0 && i1 < text.len() {
+            for i in i0..=i1 {
+                text[i] = w;
+            }
+            builder.text_wildcard(w);
+            wildcard = Some(w);
         }
-        assert!(end_dist_iter.next().is_none());
-        assert!(!matches_long.next_alignment(&mut aln_long));
     }
 
-    {
-        // Lazy API
-
-        let mut matches = myers.find_all_lazy(text, max_dist);
-        let mut matches_long = myers_long.find_all_lazy(text, max_dist as usize);
-        let mut end_dist_iter = end_dist.iter();
-
-        while let Some((end, dist)) = matches.next() {
-            // compare distances
-            let (end_long, dist_long) = matches_long.next().unwrap();
-            assert_eq!((end, dist), (end_long, dist_long as u8));
-
-            // compare alignments
-            assert!(matches.alignment_at(end, &mut aln));
-            assert!(matches_long.alignment_at(end, &mut aln_long));
-            assert_eq!(aln, aln_long);
-
-            // verify alignment
-            validate_alignment(&aln, pattern, text);
-            assert_eq!(dist, aln.score as u8);
-            assert!(aln.score as u8 <= max_dist);
-
-            // compare to find_all_end() results
-            let (end, dist) = end_dist_iter.next().unwrap();
-            assert_eq!(*end + 1, aln.yend);
-            assert_eq!(*dist, aln.score as u8);
-
-            // larger positions were not yet searched
-            assert!(!matches.alignment_at(end + 1, &mut aln));
+    // 6: ambiguous symbol
+    // 7-11: equivalent symbols
+    let mut ambigs = None;
+    let ambig = header[5];
+    if ambig.is_ascii_graphic() && ambig > b'z' {
+        let equivalents: Vec<u8> = header[6..]
+            .iter()
+            .cloned()
+            .filter(|&b| b.is_ascii_graphic())
+            .collect();
+        if !equivalents.is_empty() {
+            builder.ambig(ambig, &equivalents);
+            ambigs = Some((ambig, equivalents));
         }
-        assert!(end_dist_iter.next().is_none());
+    }
+    let ambigs = ambigs.as_ref().map(|(a, eq)| (*a, eq.as_slice()));
+
+    let text = &text;
+    // dbg!(std::str::from_utf8(pattern), std::str::from_utf8(text), max_dist, wildcard.map(|w| w as char), ambigs);
+
+    macro_rules! run_fuzz {
+        ($myers:ident, $myers_long:ident) => {
+            // No traceback, just searching
+            let end_dist: Vec<_> = $myers.find_all_end(text, max_dist).collect();
+            let end_dist_long: Vec<_> = $myers_long
+                .find_all_end(text, max_dist as usize)
+                .map(|(end, dist)| (end, dist as u8))
+                .collect();
+            assert_eq!(end_dist, end_dist_long);
+
+            // Test traceback algorithm:
+            // The following code compares the distance from the myers algorithm with the
+            // number of substitutions / InDels found in the alignment path. If the distances
+            // are equal, then the traceback found a valid alignment path.
+            // Additionally, the actual pattern and text are inspected; matches / substitutions
+            // that are unexpectedly (un)equal will cause a panic.
+
+            // 'Default' API
+            let mut aln = Alignment::default();
+            let mut aln_long = Alignment::default();
+            {
+                let mut matches = $myers.find_all(text, max_dist);
+                let mut matches_long = $myers_long.find_all(text, max_dist as usize);
+
+                matches.alignment(&mut aln); // all insertions to text
+                matches_long.alignment(&mut aln_long);
+
+                let mut end_dist_iter = end_dist.iter();
+                while matches.next_alignment(&mut aln) {
+                    assert!(matches_long.next_alignment(&mut aln_long));
+                    assert_eq!(aln, aln_long);
+
+                    // verify alignment
+                    validate_alignment(&aln, pattern, text, wildcard, ambigs);
+                    assert!(aln.score as u8 <= max_dist);
+
+                    // compare to find_all_end() results
+                    let (end, dist) = end_dist_iter.next().unwrap();
+                    assert_eq!(*end + 1, aln.yend);
+                    assert_eq!(*dist, aln.score as u8);
+                }
+                assert!(end_dist_iter.next().is_none());
+                assert!(!matches_long.next_alignment(&mut aln_long));
+            }
+
+            {
+                // Lazy API
+
+                let mut matches = $myers.find_all_lazy(text, max_dist);
+                let mut matches_long = $myers_long.find_all_lazy(text, max_dist as usize);
+                let mut end_dist_iter = end_dist.iter();
+
+                while let Some((end, dist)) = matches.next() {
+                    // compare distances
+                    let (end_long, dist_long) = matches_long.next().unwrap();
+                    assert_eq!((end, dist), (end_long, dist_long as u8));
+
+                    // compare alignments
+                    assert!(matches.alignment_at(end, &mut aln));
+                    assert!(matches_long.alignment_at(end, &mut aln_long));
+                    assert_eq!(aln, aln_long);
+
+                    // verify alignment
+                    validate_alignment(&aln, pattern, text, wildcard, ambigs);
+                    assert_eq!(dist, aln.score as u8);
+                    assert!(aln.score as u8 <= max_dist);
+
+                    // compare to find_all_end() results
+                    let (end, dist) = end_dist_iter.next().unwrap();
+                    assert_eq!(*end + 1, aln.yend);
+                    assert_eq!(*dist, aln.score as u8);
+
+                    // larger positions were not yet searched
+                    assert!(!matches.alignment_at(end + 1, &mut aln));
+                }
+                assert!(end_dist_iter.next().is_none());
+            }
+
+            // Lazy API with unlimited distance: all positions should be found
+
+            let mut matches = $myers.find_all_lazy(text, u8::max_value());
+            let mut matches_long = $myers_long.find_all_lazy(text, u8::max_value() as usize);
+
+            let mut i = 0;
+            while let Some((end, dist)) = matches.next() {
+                assert_eq!(end, i);
+
+                // compare distances
+                let (end_long, dist_long) = matches_long.next().unwrap();
+                assert_eq!((end, dist), (end_long, dist_long as u8));
+
+                // compare alignments
+                assert!(matches.alignment_at(end, &mut aln));
+                assert!(matches_long.alignment_at(end, &mut aln_long));
+                assert_eq!(aln, aln_long);
+
+                // verify alignment
+                validate_alignment(&aln, pattern, text, wildcard, ambigs);
+                assert_eq!(dist, aln.score as u8);
+                assert!(aln.score as u8 <= u8::max_value());
+
+                // larger positions were not yet searched
+                assert!(!matches.alignment_at(end + 1, &mut aln));
+                assert!(!matches_long.alignment_at(end + 1, &mut aln_long));
+                i += 1;
+            }
+        };
     }
 
-    // Lazy API with unlimited distance: each position should be found
-
-    let mut matches = myers.find_all_lazy(text, u8::max_value());
-    let mut matches_long = myers_long.find_all_lazy(text, u8::max_value() as usize);
-
-    let mut i = 0;
-    while let Some((end, dist)) = matches.next() {
-        assert_eq!(end, i);
-
-        // compare distances
-        let (end_long, dist_long) = matches_long.next().unwrap();
-        assert_eq!((end, dist), (end_long, dist_long as u8));
-
-        // compare alignments
-        assert!(matches.alignment_at(end, &mut aln));
-        assert!(matches_long.alignment_at(end, &mut aln_long));
-        assert_eq!(aln, aln_long);
-
-        // verify alignment
-        validate_alignment(&aln, pattern, text);
-        assert_eq!(dist, aln.score as u8);
-        assert!(aln.score as u8 <= u8::max_value());
-
-        // larger positions were not yet searched
-        assert!(!matches.alignment_at(end + 1, &mut aln));
-        assert!(!matches_long.alignment_at(end + 1, &mut aln_long));
-        i += 1;
+    let mut myers_long: long::Myers<u8> = builder.build_long(pattern);
+    if pattern.len() <= 64 {
+        let mut myers: Myers<u64> = builder.build(pattern);
+        run_fuzz!(myers, myers_long);
+    } else {
+        let mut myers: Myers<u128> = builder.build(pattern);
+        run_fuzz!(myers, myers_long);
     }
+
+    // compare to edlib (if no wildcard/ambiguities)
+    // if pattern.len() <= 64 && wildcard.is_none() && ambigs.is_none() {
+    //     use edlib_rs::edlibrs::*;
+    //     let mut config = EdlibAlignConfigRs::default();
+    //     config.k = max_dist as i32;
+    //     config.mode = EdlibAlignModeRs::EDLIB_MODE_HW;
+    //     config.task = EdlibAlignTaskRs::EDLIB_TASK_PATH;
+
+    //     let mut myers: Myers<u64> = builder.build(pattern);
+    //     let mut matches = myers.find_all_lazy(text, max_dist);
+    //     let mut aln = Alignment::default();
+
+    //     let hits: Vec<_> = matches.by_ref().collect();
+    //     let best_hit = hits.iter().min_by_key(|(_, dist)| dist);
+    //     if let Some((best_end, best_dist)) = best_hit {
+    //         let res = edlibAlignRs(pattern, text, &config);
+    //         assert_eq!(res.status, EDLIB_STATUS_OK);
+    //         assert_eq!(res.editDistance, *best_dist as i32);
+    //     // TODO: due to differences in traceback implementation,
+    //     //       so we cannot compare the alignment paths directly 
+    // }
 });
-
 
 // Validates an Alignment based on the sequences that were used to construct it.
 // - calculates the score using edit distance (mismatches / gap penalties = 1) and
 //   then compares it to the stored score
 // - checks if matches and substitutions are really correct given the actual sequences
-fn validate_alignment(aln: &Alignment, x: &[u8], y: &[u8]) {
-
+fn validate_alignment(
+    aln: &Alignment,
+    x: &[u8],
+    y: &[u8],
+    wildcard: Option<u8>,
+    ambigs: Option<(u8, &[u8])>,
+) {
+    // dbg!(aln, std::str::from_utf8(x), std::str::from_utf8(y), wildcard, ambigs);
     let y = &y[aln.ystart..aln.yend];
-
     let mut ix = 0;
     let mut iy = 0;
     let mut calc_dist = 0;
     for op in &aln.operations {
         match *op {
-            Match => {
-                assert!(x[ix] == y[iy], "Match operation, but characters are not equal");
-                ix += 1;
-                iy += 1;
-            }
-            Subst => {
-                assert!(x[ix] != y[iy], "Subst operation, but characters are equal");
-                calc_dist += 1;
+            Match | Subst => {
+                let matches = x[ix] == y[iy]
+                    || wildcard.map(|w| w == y[iy]).unwrap_or(false)
+                    || ambigs
+                        .map(|(a, equiv)| x[ix] == a && equiv.contains(&y[iy]))
+                        .unwrap_or(false);
+                assert!(
+                    (*op == Subst) ^ matches,
+                    "{:?} operation invalid: {} {} {}",
+                    op,
+                    x[ix] as char,
+                    if *op == Match { "!=" } else { "==" },
+                    y[iy] as char
+                );
+                calc_dist += !matches as usize;
                 ix += 1;
                 iy += 1;
             }
@@ -173,9 +248,9 @@ fn validate_alignment(aln: &Alignment, x: &[u8], y: &[u8]) {
                 calc_dist += 1;
                 ix += 1;
             }
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 
-    assert_eq!(calc_dist, aln.score as usize);
+    assert_eq!(calc_dist, aln.score as usize, "Score mismatch");
 }

--- a/src/pattern_matching/bndm.rs
+++ b/src/pattern_matching/bndm.rs
@@ -49,7 +49,7 @@ impl BNDM {
     }
 
     /// Find all matches of pattern with a given text. Matches are returned as iterator over start positions.
-    pub fn find_all<'a>(&'a self, text: TextSlice<'a>) -> Matches<'_> {
+    pub fn find_all<'a>(&'a self, text: TextSlice<'a>) -> Matches<'a> {
         Matches {
             bndm: self,
             window: self.m,

--- a/src/pattern_matching/bom.rs
+++ b/src/pattern_matching/bom.rs
@@ -94,7 +94,7 @@ impl BOM {
     }
 
     /// Find all matches of the pattern in the given text. Matches are returned as an iterator over start positions.
-    pub fn find_all<'a>(&'a self, text: TextSlice<'a>) -> Matches<'_> {
+    pub fn find_all<'a>(&'a self, text: TextSlice<'a>) -> Matches<'a> {
         Matches {
             bom: self,
             text,

--- a/src/pattern_matching/horspool.rs
+++ b/src/pattern_matching/horspool.rs
@@ -64,7 +64,7 @@ impl<'a> Horspool<'a> {
 
     /// Find all matches with a given text. Matches are returned as an iterator over start
     /// positions.
-    pub fn find_all<'b>(&'b self, text: TextSlice<'b>) -> Matches<'_> {
+    pub fn find_all<'b>(&'b self, text: TextSlice<'b>) -> Matches<'b> {
         Matches {
             horspool: self,
             text,

--- a/src/pattern_matching/mod.rs
+++ b/src/pattern_matching/mod.rs
@@ -13,7 +13,7 @@
 //! * BOM algorithm: fast for long patterns and small alphabet.
 //! * KMP algorithm: the classical ancestor.
 //! * Ukkonens algorithm: approximate pattern matching with dynamic programming.
-//! * Myers algorithm: linear-time approximate pattern matching with edit distance for small patterns
+//! * Myers algorithm: linear-time approximate pattern matching with edit distance.
 //!
 //! Another library that provides heavily optimized routines for string search primitives is memchr: https://crates.io/crates/memchr
 

--- a/src/pattern_matching/myers/builder.rs
+++ b/src/pattern_matching/myers/builder.rs
@@ -131,7 +131,6 @@ impl MyersBuilder {
 
     /// Creates a Myers instance given a pattern, using `u128` as bit vector type.
     /// Pattern length is restricted to at most 128 symbols.
-    #[cfg(has_u128)]
     pub fn build_128<C, P>(&self, pattern: P) -> Myers<u128>
     where
         C: Borrow<u8>,
@@ -179,7 +178,6 @@ impl MyersBuilder {
 
     /// Creates a `long::Myers` instance given a pattern, using `u128` as bit vector type.
     /// Pattern length is not restricted regardless of the type of the bit vector.
-    #[cfg(has_u128)]
     pub fn build_long_128<C, P>(&self, pattern: P) -> MyersLong<u128>
     where
         C: Borrow<u8>,

--- a/src/pattern_matching/myers/common_tests.rs
+++ b/src/pattern_matching/myers/common_tests.rs
@@ -28,6 +28,17 @@ macro_rules! impl_common_tests {
         }
 
         #[test]
+        fn test_distance_long() {
+            // the pattern of length 17 spans three u8 blocks in tests of `myers::long`
+            let text = "ACCGTGGATGAGCGCCATAG".to_string();
+            let patt = "--CGTGGACCAGCGCCATA-".replace('-', "");
+
+            let myers = Myers::<$bitvec>::new(patt.as_bytes());
+            assert_eq!(myers.distance(text.as_bytes()), 2);
+            assert_eq!(myers.find_best_end(text.as_bytes()), (18, 2));
+        }
+
+        #[test]
         fn test_full_position() {
             let text = "CAGACATCTT".to_string();
             let patt = "-AGA------".replace('-', "");
@@ -205,9 +216,7 @@ macro_rules! impl_common_tests {
 
             // search another text first to test proper initialization of
             // `State`s in the second search
-            let _ = myers
-                .find_all_end(b"GTGGACCAGCGCCATAGTGGACCAGCGCCATAGTGGACCAGCGCCATA", 10)
-                .count();
+            let _ = myers.distance(b"GTGGACCAGCGCCATAGTGGACCAGCGCCATAGTGGACCAGCGCCATA");
 
             // second search
             let mut matches = myers.find_all_lazy(text.as_bytes(), 2);

--- a/src/pattern_matching/myers/helpers.rs
+++ b/src/pattern_matching/myers/helpers.rs
@@ -3,16 +3,17 @@ use std::ops::*;
 
 use num_traits::{AsPrimitive, FromPrimitive, PrimInt, ToPrimitive, WrappingAdd};
 
-/// Trait for types that should be used to store the distance score when using the simple
+/// Trait for types used to store the edit distance when using the simple
 /// Myers algorithm (not the block-based one, which always uses `usize`).
 ///
 /// For all currently implemented BitVec types, the maximum possible distance
 /// can be stored in `u8`. Custom implementations using bigger integers can
-/// adjust `DistType` to hold bigger numbers. Note that due to how the traceback
-/// algorithm currently works, `DistType` should be able to represent numbers larger
-/// than the bit-width of the `BitVec` type. For instance, a hypothetical `BitVec` type
-/// of `u256` should use `u16` as distance, since `u8` cannot store numbers larger
-/// than 255.
+/// adjust `DistType` to hold bigger numbers.
+///
+/// *Note*: For the traceback algorithm to work, the maximum possible edit distance
+/// (which is the number of bits of the `BitVec` type) should be *smaller* than
+/// `<DistType>::MAX`. A hypothetical `BitVec` type of `u256` should have
+/// `DistType = u16`, since `u8` cannot represent numbers > 255.
 pub trait DistType: Copy
         + Debug
         + Default

--- a/src/pattern_matching/myers/helpers.rs
+++ b/src/pattern_matching/myers/helpers.rs
@@ -48,8 +48,8 @@ pub trait BitVec: Copy
     + Shl<usize>
     + ShlAssign<usize>
     + ShrAssign<usize>
-    // These num_traits traits are required; in addition there are Bounded, Zero and One,
-    // which are all required by PrimInt and thus included
+    // These num_traits traits are required; `Bounded`, `Zero` and `One` are
+    // implicitly included with `PrimInt`
     + PrimInt
     + WrappingAdd
     + ToPrimitive

--- a/src/pattern_matching/myers/helpers.rs
+++ b/src/pattern_matching/myers/helpers.rs
@@ -72,7 +72,6 @@ impl_bitvec!(u8, u8);
 impl_bitvec!(u16, u8);
 impl_bitvec!(u32, u8);
 impl_bitvec!(u64, u8);
-#[cfg(has_u128)]
 impl_bitvec!(u128, u8);
 
 use crate::alignment::{Alignment, AlignmentMode};

--- a/src/pattern_matching/myers/long.rs
+++ b/src/pattern_matching/myers/long.rs
@@ -1,12 +1,15 @@
-//! Block-based version of the algorithm, which does not restrict pattern length.
+//! Myers bit-parallel approximate pattern matching with unlimited pattern length.
 //!
-//! This module implements the block-based version of the Myers pattern matching algorithm.
-//! It can be used for searching patterns of any length and obtaining semiglobal alignments
-//! of the hits. Apart from that, the `Myers` object in this module provides exactly the same
-//! API as the 'simple' version `bio::pattern_matching::myers::Myers`.
-//! For short patterns, the 'simple' version is still to be preferred, as the block-based
-//! algorithm is slower.
-
+//! This module implements the block-based version of the Myers algorithm
+//! and offers methods for computing the semi-global alignment.
+//! The API is exactly the same as for the 'simple' algorithm in
+//! [`bio::pattern_matching::myers`](crate::pattern_matching::myers).
+//! For patterns of up to 64 symbols, the 'simple' version is to be preferred,
+//! as it is faster.
+//! Whether the 'simple' algorithm with `u128` bit vectors outperforms the block-based
+//! implementation with `u64` bit vectors may depend on the use case.
+//!
+//! Time complexity: O(n * k)
 use std::borrow::Borrow;
 use std::cmp::{max, min};
 use std::collections::HashMap;
@@ -198,6 +201,7 @@ where
             last_m: m % w,
         };
         // y = ceil(k/w) in Myers' paper, Fig. 9 where k = max_dist
+        // (but distances cannot exceed m)
         let min_blocks = max(1, ceil_div(min(max_dist, m), w));
         for _ in 0..min_blocks {
             s.add_block(0);

--- a/src/pattern_matching/myers/long.rs
+++ b/src/pattern_matching/myers/long.rs
@@ -27,7 +27,8 @@ use super::BitVec;
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 struct Peq<T: BitVec> {
     peq: [T; 256],
-    bound: T,
+    // a bit mask with bits set for all positions covered by the pattern
+    bit_mask: T,
 }
 
 /// Myers algorithm.
@@ -71,13 +72,13 @@ impl<T: BitVec> Myers<T> {
         assert!(m <= usize::MAX / 2, "Pattern too long");
 
         // build peq
-        let mut peq = vec![];
+        let mut peq = Vec::with_capacity(ceil_div(m, w));
         for chunk in pattern.chunks(w).into_iter() {
             let mut peq_block = [T::zero(); 256];
-            let mut i = 0;
+            let mut chunk_len = 0;
             for symbol in chunk {
                 let symbol = *symbol.borrow();
-                let mask = T::one() << i;
+                let mask = T::one() << chunk_len;
                 // equivalent
                 peq_block[symbol as usize] |= mask;
                 // ambiguities
@@ -86,7 +87,7 @@ impl<T: BitVec> Myers<T> {
                         peq_block[eq as usize] |= mask;
                     }
                 }
-                i += 1;
+                chunk_len += 1;
             }
             // wildcards
             if let Some(wildcards) = opt_wildcards {
@@ -97,14 +98,14 @@ impl<T: BitVec> Myers<T> {
 
             peq.push(Peq {
                 peq: peq_block,
-                bound: T::one() << (i - 1),
+                bit_mask: T::one() << (chunk_len - 1),
             });
         }
 
         Myers {
             peq,
             m,
-            states_store: vec![],
+            states_store: Vec::new(),
         }
     }
 
@@ -141,9 +142,9 @@ fn advance_block<T: BitVec>(state: &mut State<T, usize>, p: &Peq<T>, a: u8, hin:
     //     0
     // };
 
-    // apparently faster than uncommented code above
-    let mut hout = ((ph & p.bound) != T::zero()) as i8;
-    hout -= ((mh & p.bound) != T::zero()) as i8;
+    // apparently faster than commented code above
+    let mut hout = ((ph & p.bit_mask) != T::zero()) as i8;
+    hout -= ((mh & p.bit_mask) != T::zero()) as i8;
     state.dist = state.dist.wrapping_add(hout as usize);
 
     ph <<= 1;
@@ -165,10 +166,14 @@ fn advance_block<T: BitVec>(state: &mut State<T, usize>, p: &Peq<T>, a: u8, hin:
     hout
 }
 
+/// Multi-block state
 #[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub(super) struct States<T: BitVec> {
     states: Vec<State<T, usize>>,
-    max_block: usize,
+    // index of the last block (max_block_i + 1 blocks are needed to cover the full pattern)
+    max_block_i: usize,
+    // length of the remaining pattern chunk in the last block
+    // (see `add_block()`)
     last_m: usize,
 }
 
@@ -178,34 +183,40 @@ where
 {
     fn new(m: usize, max_dist: usize) -> Self {
         let w = word_size::<T>();
+        let nblock = ceil_div(m, w);
         let mut s = States {
-            states: vec![],
-            max_block: ceil_div(m, w) - 1,
+            states: Vec::with_capacity(nblock),
+            max_block_i: nblock - 1,
             last_m: m % w,
         };
+        // y = ceil(k/w) in Myers' paper, Fig. 9 where k = max_dist
         let min_blocks = max(1, ceil_div(min(max_dist, m), w));
         for _ in 0..min_blocks {
-            s.add_state(0);
+            s.add_block(0);
         }
         s
     }
 
+    /// Adds a new block to the Ukkonen band
+    /// `carry` (`vin` in Myers' paper) can be -1, 0, or 1
     #[inline]
-    fn add_state(&mut self, offset: i8) {
+    fn add_block(&mut self, carry: i8) {
         let prev_dist = self.states.last().map(|s| s.dist).unwrap_or(0);
-        // delta: number of bits of the new state covered by the pattern
-        // For the last block, we add m % w, not all bits are necessarily used.
-        // This strategy differs from the solution by Myers (p. 407, note 4).
-        // We wanted to avoid having to pad pattern and sequence.
-        let delta = if self.states.len() == self.max_block && self.last_m > 0 {
+        // delta: number of bits in pv/mv covered by the pattern
+        let delta = if self.states.len() == self.max_block_i && self.last_m > 0 {
+            // For the last ('bottom') block, we add the length of the remaining pattern
+            // chunk = m % w (stored in self.last_m) and ignore the remaining bits.
+            // This strategy differs from the solution by Myers (p. 407, note 4 / p. 410, Fig. 9),
+            // where the computation starts with distance score = w * b [where b = N blocks],
+            // and both the pattern and sequence need to be padded with wild-card symbols.
             self.last_m
         } else {
             word_size::<T>()
         };
         self.states.push(State::init(
-            (prev_dist)
+            prev_dist
                 .wrapping_add(delta)
-                .wrapping_add(offset as usize)
+                .wrapping_add(carry as usize)
                 .to_usize()
                 .unwrap(),
         ));
@@ -214,36 +225,39 @@ where
     #[inline]
     fn step(&mut self, a: u8, peq: &[Peq<T>], max_dist: usize) {
         let mut carry = 0;
-        let mut last_block = self.states.len() - 1;
+        let mut y = self.states.len() - 1;
 
+        // compute blocks
         for (state, block_peq) in self.states.iter_mut().zip(peq) {
             carry = advance_block(state, block_peq, a, carry);
         }
 
+        // adjust Ukkonen band if necessary
         let w = word_size::<T>();
-        let last_dist = self.states[last_block].dist;
+        let last_dist = self.states[y].dist;
         // note: this will fail if edit distances are > isize::MAX,
         // but in practice such long patterns will never occur
         if (last_dist as isize - carry as isize) as usize <= max_dist
-            && last_block < self.max_block
-            && (peq[last_block + 1].peq[a as usize] & T::one() == T::one() || carry < 0)
+            && y < self.max_block_i
+            && (peq[y + 1].peq[a as usize] & T::one() == T::one() || carry < 0)
         {
-            last_block += 1;
-            self.add_state(-carry);
-            advance_block(&mut self.states[last_block], &peq[last_block], a, carry);
+            y += 1;
+            self.add_block(-carry);
+            // compute the new block as well
+            advance_block(&mut self.states[y], &peq[y], a, carry);
         } else {
             // note: max_dist should be <= usize::MAX - w; this is ensured beforehand
-            while last_block > 0 && self.states[last_block].dist >= max_dist + w {
-                last_block -= 1;
+            while y > 0 && self.states[y].dist >= max_dist + w {
+                y -= 1;
             }
-            self.states.truncate(last_block + 1);
+            self.states.truncate(y + 1);
         }
     }
 
     /// Returns the edit distance if known (i.e., all blocks were computed),
     #[inline]
     fn known_dist(&self) -> Option<usize> {
-        self.states.get(self.max_block).map(|s| s.dist)
+        self.states.get(self.max_block_i).map(|s| s.dist)
     }
 }
 
@@ -280,6 +294,11 @@ where
     }
 
     #[inline]
+    fn n_blocks(&self) -> usize {
+        self.n_blocks
+    }
+
+    #[inline]
     fn set_max_state(&self, pos: usize, states: &mut [State<T, usize>]) {
         let pos = pos * self.n_blocks;
         for s in states.iter_mut().skip(pos).take(self.n_blocks) {
@@ -299,11 +318,11 @@ where
         states[pos..pos + source.len()].clone_from_slice(source);
 
         if source.len() < self.n_blocks {
-            // When following the traceback path, it can happen that the block to the
+            // While following the traceback path, it can happen that the block to the
             // left was not computed because it is outside of the band.
-            // In order to prevent the algorithm from going left in this case,
-            // we initialize the block below the last computed block with meaningful
-            // defaults.
+            // Here we initialize the block below the last computed block with meaningful
+            // defaults that act as a "barrier" preventing the algorithm from moving
+            // left to this block.
             states[pos + source.len()] = State {
                 dist: usize::MAX,
                 pv: T::zero(),
@@ -342,28 +361,44 @@ where
 type RevColIter<'a, T> = iter::Rev<slice::Chunks<'a, State<T, usize>>>;
 
 pub(super) struct LongTracebackHandler<'a, T: BitVec> {
+    // reverse iterator used to set `col` and `left_col`
     states_iter: iter::Chain<RevColIter<'a, T>, iter::Cycle<RevColIter<'a, T>>>,
-    block_pos: usize,
-    left_block_pos: usize,
+    // slice of blocks representing the current DP matrix column
     col: &'a [State<T, usize>],
+    // slice of blocks representing the DP matrix column to the left
     left_col: &'a [State<T, usize>],
+    // current block
     block: State<T, usize>,
+    // current left block
     left_block: State<T, usize>,
-    left_max_mask: T,
-    pos_bitvec: T,
-    left_mask: T,
+    // index of `block` in `col`
+    block_idx: usize,
+    // index of `left_block` in `left_col`
+    left_block_idx: usize,
+    // mask with one active bit indicating the position of the last letter
+    max_mask: T,
+    // mask with one active bit indicating the current position (row) in the current block
+    pos_mask: T,
+    // Bit mask that "covers" the range of rows *below* the left cell
+    // in the current block. This is used used to initialize blocks
+    // (adjust the distance score) with `State::adjust_up_by(left_adj_mask)`.
+    left_adj_mask: T,
     _a: PhantomData<&'a ()>,
 }
 
 impl<'a, T: BitVec> LongTracebackHandler<'a, T> {
     #[inline]
     fn new(n_blocks: usize, m: usize, pos: usize, states: &'a [State<T, usize>]) -> Option<Self> {
+        // length of the pattern chunk in the lowermost block
         let mut last_m = m.to_usize().unwrap() % word_size::<T>();
         if last_m == 0 {
             last_m = word_size::<T>();
         }
+        // mask with single bit indicating index of last letter in the block
         let mask0 = T::one() << (last_m - 1);
 
+        // reverse iterator over DP matrix columns
+        // chain + cycle is needed in `FullMatches` (see comment in simple.rs)
         let pos = n_blocks * (pos + 1);
         let mut states_iter = states[..pos]
             .chunks(n_blocks)
@@ -378,106 +413,121 @@ impl<'a, T: BitVec> LongTracebackHandler<'a, T> {
             return None;
         }
 
-        // This bit mask is supplied to State::adjust_by_mask() in order to adjust the distance
-        // of the left block. It is adjusted with every `move_up_left`
-        let left_mask = if last_m != 1 {
-            T::zero()
+        // initial data for left block
+        let (left_block_idx, left_adj_mask, max_mask) = if last_m == 1 && n_blocks > 1 {
+            (n_blocks - 2, T::zero(), T::one() << (word_size::<T>() - 1))
         } else {
-            T::from_usize(0b10).unwrap()
+            (n_blocks - 1, mask0, mask0)
         };
 
+        // the left cell has to be  in diagonal position (move one up)
+        let mut left_block = left_col[left_block_idx];
+        left_block.adjust_up_by(left_adj_mask);
+
         Some(LongTracebackHandler {
-            block_pos: n_blocks - 1,
-            left_block_pos: n_blocks - 1,
-            block: *col.last().unwrap(),
-            left_block: *left_col.last().unwrap(),
+            block: col[n_blocks - 1],
+            left_block,
             col,
             left_col,
+            block_idx: n_blocks - 1,
+            left_block_idx,
             states_iter,
-            pos_bitvec: mask0,
-            left_mask,
-            left_max_mask: mask0,
+            pos_mask: mask0,
+            left_adj_mask,
+            max_mask,
             _a: PhantomData,
         })
+    }
+
+    /// Adjust 'left_adj_mask' to cover one more cell above.
+    /// This may involve switching to the block on top
+    /// *before* the mask would cover the whole block.
+    /// Actually, only the masks and block index are adjusted,
+    /// not the `State` itself.
+    #[inline]
+    fn adjust_left_up(&mut self) -> bool {
+        let at_boundary = self.left_adj_mask & T::from_usize(0b10).unwrap() != T::zero()
+            && self.left_block_idx > 0;
+        if !at_boundary {
+            self.left_adj_mask = (self.left_adj_mask >> 1) | self.max_mask;
+        } else {
+            self.max_mask = T::one() << (word_size::<T>() - 1);
+            self.left_adj_mask = T::zero();
+            self.left_block_idx -= 1;
+        }
+        // println!("left {:064b}\nmax  {:064b}", self.left_adj_mask, self.left_max_mask);
+        at_boundary
     }
 }
 
 impl<'a, T: BitVec + 'a> TracebackHandler<'a, T, usize> for LongTracebackHandler<'a, T> {
     #[inline]
-    fn block(&self) -> &State<T, usize> {
-        &self.block
+    fn dist(&self) -> usize {
+        self.block.dist
     }
 
     #[inline]
-    fn left_block(&self) -> &State<T, usize> {
-        &self.left_block
+    fn left_dist(&self) -> usize {
+        self.left_block.dist
     }
 
     #[inline]
-    fn pos_bitvec(&self) -> T {
-        self.pos_bitvec
+    fn try_move_up(&mut self) -> bool {
+        if self.block.pv & self.pos_mask != T::zero() {
+            self.move_up();
+            return true;
+        }
+        false
     }
 
     #[inline]
-    fn move_up(&mut self, adjust_dist: bool) {
+    fn move_up(&mut self) {
+        // (1) move up in current column
         // If the block boundary has not been reached yet, we can shift to the
         // upper position. Otherwise, we move to a new block (if there is one!)
-        if self.pos_bitvec != T::one() || self.block_pos == 0 {
-            if adjust_dist {
-                self.block.adjust_dist(self.pos_bitvec);
-            }
-            self.pos_bitvec >>= 1;
+        if self.pos_mask != T::one() || self.block_idx == 0 {
+            self.block.adjust_one_up(self.pos_mask);
+            self.pos_mask >>= 1;
         } else {
             // move to upper block
-            self.pos_bitvec = T::one() << (word_size::<T>() - 1);
-            self.block_pos -= 1;
-            if adjust_dist {
-                self.block = self.col[self.block_pos];
-            }
+            self.pos_mask = T::one() << (word_size::<T>() - 1);
+            self.block_idx -= 1;
+            self.block = self.col[self.block_idx];
         }
-    }
-
-    #[inline]
-    fn move_up_left(&mut self, adjust_dist: bool) {
-        // If the block boundary has not been reached yet, we can extend the range mask by
-        // activating a new bit.
-        // However, we switch to a new block (if there is one!) before the mask would cover
-        // the whole block.
-        if self.left_mask & T::from_usize(0b10).unwrap() == T::zero() || self.left_block_pos == 0 {
-            self.left_mask = (self.left_mask >> 1) | self.left_max_mask;
-            if adjust_dist {
-                self.left_block.adjust_dist(self.pos_bitvec);
-            }
+        // (2) move up in left column
+        let at_boundary = self.adjust_left_up();
+        if !at_boundary {
+            self.left_block.adjust_one_up(self.pos_mask);
         } else {
-            self.left_max_mask = T::one() << (word_size::<T>() - 1);
-            self.left_mask = T::zero();
-            self.left_block_pos -= 1;
-            if adjust_dist {
-                self.left_block = self.left_col[self.left_block_pos];
-            }
+            self.left_block = self.left_col[self.left_block_idx];
         }
     }
 
     #[inline]
-    fn move_to_left(&mut self) {
-        self.col = self.left_col;
-        self.left_col = self.states_iter.next().unwrap();
-        self.block = replace(&mut self.left_block, self.left_col[self.left_block_pos]);
-        self.left_block.adjust_by_mask(self.left_mask);
+    fn prepare_diagonal(&mut self) {
+        self.adjust_left_up();
+        if self.pos_mask != T::one() || self.block_idx == 0 {
+            // not at block boundary
+            self.pos_mask >>= 1;
+        } else {
+            // at boundary: move to upper block
+            self.pos_mask = T::one() << (word_size::<T>() - 1);
+            self.block_idx -= 1;
+        }
     }
 
-    #[inline]
-    fn move_left_down_if_better(&mut self) -> bool {
-        if self.left_mask != T::zero() {
+    fn try_prepare_left(&mut self) -> bool {
+        if self.left_adj_mask != T::zero() {
             // simple case: not at block boundary
-            if self.left_block.mv & self.pos_bitvec != T::zero() {
+            if self.left_block.mv & self.pos_mask != T::zero() {
                 self.left_block.dist -= 1;
                 return true;
             }
-        } else if let Some(b) = self.left_col.get(self.left_block_pos + 1) {
-            // more complicated: at lower block boundary, and there is a lower block
+        } else if let Some(b) = self.left_col.get(self.left_block_idx + 1) {
+            // more complicated: at lower block boundary, and there is another block below in the band;
             if b.mv & T::one() == T::one() {
-                let d = self.left_block().dist - 1;
+                // move one block down again
+                let d = self.left_block.dist - 1;
                 self.left_block = *b;
                 self.left_block.dist = d;
                 return true;
@@ -487,13 +537,33 @@ impl<'a, T: BitVec + 'a> TracebackHandler<'a, T, usize> for LongTracebackHandler
     }
 
     #[inline]
-    fn column_slice(&self) -> &[State<T, usize>] {
-        self.col
+    fn finish_move_left(&mut self) {
+        self.col = self.left_col;
+        self.left_col = self.states_iter.next().unwrap();
+        self.block = replace(&mut self.left_block, self.left_col[self.left_block_idx]);
+        self.left_block.adjust_up_by(self.left_adj_mask);
     }
 
     #[inline]
-    fn finished(&self) -> bool {
-        self.pos_bitvec == T::zero() && self.block_pos == 0
+    fn done(&self) -> bool {
+        self.pos_mask == T::zero() && self.block_idx == 0
+    }
+
+    fn print_state(&self) {
+        eprintln!(
+            "--- TB dist ({:?} <-> {:?})",
+            self.left_block.dist, self.block.dist
+        );
+        eprintln!(
+            " lm {:0width$b}\nleft block={} {}\n  m {:0width$b}\ncurrent block={} {}\n",
+            self.left_adj_mask,
+            self.left_block_idx,
+            self.left_block,
+            self.pos_mask,
+            self.block_idx,
+            self.block,
+            width = word_size::<T>()
+        );
     }
 }
 

--- a/src/pattern_matching/myers/long.rs
+++ b/src/pattern_matching/myers/long.rs
@@ -14,7 +14,6 @@ use std::iter;
 use std::marker::PhantomData;
 use std::mem::replace;
 use std::slice;
-use std::u64;
 
 use itertools::Itertools;
 use num_traits::ToPrimitive;
@@ -69,7 +68,7 @@ impl<T: BitVec> Myers<T> {
         let pattern = pattern.into_iter();
         let m = pattern.len();
         assert!(m > 0, "Pattern is empty");
-        assert!(m <= usize::max_value() / 2, "Pattern too long");
+        assert!(m <= usize::MAX / 2, "Pattern too long");
 
         // build peq
         let mut peq = vec![];
@@ -304,7 +303,7 @@ where
             // we initialize the block below the last computed block with meaningful
             // defaults.
             states[pos + source.len()] = State {
-                dist: usize::max_value(),
+                dist: usize::MAX,
                 pv: T::zero(),
                 mv: T::zero(),
             };
@@ -387,18 +386,8 @@ impl<'a, T: BitVec + 'a> TracebackHandler<'a, T, usize> for LongTracebackHandler
     }
 
     #[inline]
-    fn block_mut(&mut self) -> &mut State<T, usize> {
-        &mut self.block
-    }
-
-    #[inline]
     fn left_block(&self) -> &State<T, usize> {
         &self.left_block
-    }
-
-    #[inline]
-    fn left_block_mut(&mut self) -> &mut State<T, usize> {
-        &mut self.left_block
     }
 
     #[inline]
@@ -494,8 +483,6 @@ impl_myers!(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     impl_tests!(super, u8, usize, build_64);
 
     #[test]
@@ -505,7 +492,7 @@ mod tests {
 
         let myers: Myers<u64> = Myers::new(pattern.iter().cloned());
 
-        let hits: Vec<_> = myers.find_all_end(text, usize::max_value() - 64).collect();
+        let hits: Vec<_> = myers.find_all_end(text, usize::MAX - 64).collect();
         dbg!(hits);
     }
 }

--- a/src/pattern_matching/myers/mod.rs
+++ b/src/pattern_matching/myers/mod.rs
@@ -45,7 +45,7 @@
 //!
 //! It is also possible to to construct `Myers::<u128>`, which handles patterns with
 //! up to 128 symbols using the standard algorithm.
-//! 
+//!
 //! Longer patterns are possible with the block-based implementation,
 //! which lives in the [`long`] submodule. An example:
 //!

--- a/src/pattern_matching/myers/mod.rs
+++ b/src/pattern_matching/myers/mod.rs
@@ -41,15 +41,13 @@
 //! # }
 //! ```
 //!
-//! Starting with stable Rust 1.26, it is also possible to use `u128` as bitvector
-//! (`Myers::<u128>`), which enables longer patterns, but is somewhat slower.
-//!
 //! # Long patterns
 //!
-//! With the default implementation, query (pattern) length is limited by the size of the
-//! bit-vector; 64 symbols for `Myers::<u64>`. Patterns longer than 128 symbols (when using
-//! `u128` as bit-vector) can only be handled by using the block-based Myers implementation,
-//! which lives in the [`long`](long/index.html) submodule. An example:
+//! It is also possible to to construct `Myers::<u128>`, which handles patterns with
+//! up to 128 symbols using the standard algorithm.
+//! 
+//! Longer patterns are possible with the block-based implementation,
+//! which lives in the [`long`] submodule. An example:
 //!
 //! ```
 //! # extern crate bio;
@@ -76,7 +74,8 @@
 //! assert_eq!(occ_64, occ_long_8);
 //! # }
 //! ```
-//! Note that `u8` just used for demonstration, using `u64` is still the best in most cases.
+//! > *Note:* `u8` is used for demonstration, but `long::Myers::<u64>` is still
+//! > the best in most cases.
 //!
 //! # Obtaining the starting position of a match
 //!

--- a/src/pattern_matching/myers/mod.rs
+++ b/src/pattern_matching/myers/mod.rs
@@ -1,30 +1,38 @@
-// Copyright 2014-2016 Johannes Köster.
+// Copyright 2014-2025 Johannes Köster and Markus Schlegel.
 // Licensed under the MIT license (http://opensource.org/licenses/MIT)
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
 //! Myers bit-parallel approximate pattern matching algorithm.
-//! Finds all matches up to a given edit distance. The pattern has to fit into a bitvector,
-//! and is thus limited to 64 or (since stable Rust version 1.26) to 128 symbols.
-//! Complexity: O(n)
+//! Finds all matches up to a given edit distance k. Also supports ambiguous matching,
+//! and methods for obtaining the alignment path are provided.
+//! The simple and fast implementation (this module) supports patterns of up to
+//! 64 or 128 symbols (depending on the bit vector type used),
+//! whereas the implementation in the [`long`] submodule works with patterns of
+//! arbitrary length.
 //!
-//! Traceback allows obtaining the starting position and the alignment path of the hit.
-//! Its implementation is somehow similar to the one by Edlib (Šošić and Šikić 2017),
-//! although there can be small differences when there is more than one possible alignment
-//! path with then same edit distance at a position: Edlib prefers to make insertions
-//! and deletions to the pattern (query) over substitutions
-//! (Insertion > Deletion > Substitution) while our implementation prefers substitutions
-//! (Substitution > Insertion > Deletion).
+//! Time complexity: O(n)
 //!
-//! *Myers, G. (1999). A fast bit-vector algorithm for approximate string matching based on dynamic
-//!  programming. Journal of the ACM (JACM) 46, 395–415.*
+//! Unlimited pattern matching (`long`): O(n * k)
 //!
-//! *Šošić, M., and Šikić, M. (2017). Edlib: a C/C ++ library for fast, exact sequence alignment
-//! using edit distance. Bioinformatics 33, 1394–1395.*
+//! While the search only yields the end position and edit distance of matches,
+//! additional methods are provided for obtaining the start and the alignment path
+//! (edit operations) of a hit, in O(m + k) worst-case time.
+//! The implementation is very  similar to Edlib's (Šošić and Šikić, 2017),
+//! although minor differences may occur when there are multiple possible
+//! alignments with the same edit distance.
+//! Edlib prioritizes InDels over substitutions (insertion > deletion > substitution),
+//! whereas our implementation prioritizes substitutions (substitution > insertion > deletion).
+//!
+//! Myers, G. (1999). *A fast bit-vector algorithm for approximate string matching based on dynamic
+//!  programming*. Journal of the ACM (JACM) 46, 395–415. <https://doi.org/10.1145/316542.316550>
+//!
+//! Šošić, M., and Šikić, M. (2017). *Edlib: a C/C ++ library for fast, exact sequence alignment
+//! using edit distance.* Bioinformatics 33, 1394–1395. <https://doi.org/10.1093/bioinformatics/btw753>
 //!
 //! # Example
 //!
-//! Iterating over matches in pairs of `(end, distance)` using `u64` as bitvector type:
+//! Iterating over matches in pairs of `(end, distance)` using `u64` as bit vector type:
 //!
 //! ```
 //! # extern crate bio;
@@ -46,8 +54,8 @@
 //! It is also possible to to construct `Myers::<u128>`, which handles patterns with
 //! up to 128 symbols using the standard algorithm.
 //!
-//! Longer patterns are possible with the block-based implementation,
-//! which lives in the [`long`] submodule. An example:
+//! In addition, the [`long`] submodule handles unlimited patterns by splitting
+//! them into separate blocks. An example:
 //!
 //! ```
 //! # extern crate bio;
@@ -60,11 +68,11 @@
 //! let myers_64 = Myers::<u64>::new(pattern);
 //! let occ_64: Vec<_> = myers_64.find_all_end(text, 2).collect();
 //!
-//! // the pattern of length 9 is too long to fit into a single `u8` bit-vector
+//! // the pattern of length 9 is too long to fit into a single `u8` bit vector
 //! // (panics!)
 //! // let myers_8 = Myers::<u8>::new(pattern);
 //!
-//! // However, we can use the block-based implementation with `u8` bit-vectors
+//! // However, we can use `long::Myers` with `u8` blocks
 //! let myers_long_8 = long::Myers::<u8>::new(pattern);
 //! let occ_long_8: Vec<_> = myers_long_8
 //!     .find_all_end(text, 2)
@@ -74,16 +82,19 @@
 //! assert_eq!(occ_64, occ_long_8);
 //! # }
 //! ```
-//! > *Note:* `u8` is used for demonstration, but `long::Myers::<u64>` is still
-//! > the best in most cases.
 //!
-//! # Obtaining the starting position of a match
+//! <div class="warning">
+//!
+//! `u8` is used for demonstration, but `long::Myers::<u64>` is still
+//! the best in most cases.
+//!
+//! </div>
+//!
+//! # Obtaining the start position of a match
 //!
 //! The `Myers::find_all` method provides an iterator over tuples of `(start, end, distance)`.
-//! Calculating the starting position requires finding the alignment path, therefore this is
-//! slower than `Myers::find_all_end`. Note that the end positions differ from above by one.
-//! This is intentional, as the iterator returns a range rather an index, and ranges in Rust
-//! do not include the end position by default.
+//! As calculating the start position requires finding the alignment path, this is
+//! slower than `Myers::find_all_end`.
 //!
 //! ```
 //! # extern crate bio;
@@ -99,6 +110,14 @@
 //! assert_eq!(occ, [(3, 12, 2), (3, 13, 2)]);
 //! # }
 //! ```
+//!
+//! <div class="warning">
+//!
+//! The end positions here are greater by one than in `Myers::find_all_end`.
+//! This is intentional, since the iterator returns a range rather than an index, and in
+//! Rust, ranges do not include the end position.
+//!
+//! </div>
 //!
 //! # Obtaining alignments
 //!
@@ -120,30 +139,33 @@
 //!
 //! let mut matches = myers.find_all(text, 3);
 //! while matches.next_alignment(&mut aln) {
-//!     //println!("Hit fond in range: {}..{} (distance: {})", aln.ystart, aln.yend, aln.score);
-//!     //println!("{}", aln.pretty(pattern, text, 80));
+//!     println!(
+//!         "Hit found in range: {}..{} (distance: {})",
+//!         aln.ystart, aln.yend, aln.score
+//!     );
+//!     println!("{}", aln.pretty(pattern, text, 80));
 //! }
 //! # }
 //! ```
 //! **Output:**
 //!
 //! <pre>
-//! Hit fond in range: 3..10 (distance: 3)
+//! Hit found in range: 3..10 (distance: 3)
 //!    TCCTAGGGC
 //!    ||||+|\|+
 //! TCCTCCT-GAG-GGATTAGCAC
 //!
-//! Hit fond in range: 3..11 (distance: 3)
+//! Hit found in range: 3..11 (distance: 3)
 //!    TCCTAGGGC
 //!    ||||+|\|\
 //! TCCTCCT-GAGGGATTAGCAC
 //!
-//! Hit fond in range: 3..12 (distance: 2)
+//! Hit found in range: 3..12 (distance: 2)
 //!    TCCT-AGGGC
 //!    ||||x||||+
 //! TCCTCCTGAGGG-ATTAGCAC
 //!
-//! Hit fond in range: 3..13 (distance: 2)
+//! Hit found in range: 3..13 (distance: 2)
 //!    TCCT-AGGGC
 //!    ||||x||||\
 //! TCCTCCTGAGGGATTAGCAC
@@ -160,13 +182,13 @@
 //! # Finding the best hit
 //!
 //! In many cases, only the match with the smallest edit distance is actually of interest.
-//! Calculating an alignment for every hit is therefore not necessary.
+//! Therefore, calculating an alignment for every hit is not necessary.
 //! [`LazyMatches`](struct.LazyMatches.html) returned by `Myers::find_all_lazy()`
-//! provide an iterator over tuples of `(end, distance)` like `Myers::find_all_end()`, but
-//! additionally keep the data necessary for calculating the alignment path later at any desired
-//! position. Storing the data itself has a slight performance impact and requires more memory
-//! compared to `Myers::find_all_end()` [O(n) as opposed to O(m + k)]. Still the following code
-//! is faster than using `FullMatches`:
+//! provide an iterator over tuples of `(end, distance)` as `Myers::find_all_end()` does.
+//! However, the information needed to calculate the alignment path later on
+//! is also stored. This has a slight performance impact and requires O(n) memory,
+//! as opposed to O(m + k) for `Myers::find_all()`.
+//! Still, the following code is faster than using `Myers::find_all()`:
 //!
 //! ```
 //! # extern crate bio;
@@ -209,8 +231,8 @@
 //!
 //! # Dealing with ambiguities
 //!
-//! Matching multiple or all symbols at once can be achieved using `MyersBuilder`. This example
-//! allows `N` in the search pattern to match all four DNA bases in the text:
+//! Matching of multiple or all symbols at once can be configured through `MyersBuilder`.
+//! In the following example, `N` matches `A`, `C`, `G` or `T`:
 //!
 //! ```
 //! # extern crate bio;
@@ -225,7 +247,7 @@
 //! # }
 //! ```
 //!
-//! For more examples see the documentation of [`MyersBuilder`](struct.MyersBuilder.html).
+//! See the documentation of [`MyersBuilder`](struct.MyersBuilder.html) for more examples.
 
 #[macro_use]
 mod myers_impl;

--- a/src/pattern_matching/myers/mod.rs
+++ b/src/pattern_matching/myers/mod.rs
@@ -246,7 +246,7 @@ pub use self::simple::*;
 #[cfg(test)]
 mod tests {
     // from common_tests.rs
-    impl_tests!(super, u64, u8, build_64);
+    impl_common_tests!(false, super, u64, u8, build_64);
 
     use std::iter::repeat;
 

--- a/src/pattern_matching/myers/myers_impl.rs
+++ b/src/pattern_matching/myers/myers_impl.rs
@@ -147,6 +147,7 @@ use std::iter;
 
 impl<T: BitVec> $Myers {
     // Combining these two steps into one function seems beneficial for performance
+    #[inline]
     fn step_trace<'a>(
         &mut self,
         mut state: &mut $State,
@@ -280,6 +281,7 @@ where
 {
     type Item = (usize, $DistType);
 
+    #[inline]
     fn next(&mut self) -> Option<(usize, $DistType)> {
         for (i, a) in self.text.by_ref() {
             self.myers.step(&mut self.state, *a.borrow(), self.max_dist);
@@ -519,6 +521,7 @@ where
 {
     type Item = (usize, $DistType);
 
+    #[inline]
     fn next(&mut self) -> Option<(usize, $DistType)> {
         for (i, a) in self.text.by_ref() {
             self.myers.step_trace(

--- a/src/pattern_matching/myers/myers_impl.rs
+++ b/src/pattern_matching/myers/myers_impl.rs
@@ -281,7 +281,6 @@ where
 {
     type Item = (usize, $DistType);
 
-    #[inline]
     fn next(&mut self) -> Option<(usize, $DistType)> {
         for (i, a) in self.text.by_ref() {
             self.myers.step(&mut self.state, *a.borrow(), self.max_dist);

--- a/src/pattern_matching/myers/myers_impl.rs
+++ b/src/pattern_matching/myers/myers_impl.rs
@@ -118,7 +118,7 @@ where
 // rustfmt::skip prevents automatic indentation.
 // This is not optimal, as no checks are done at all..
 macro_rules! impl_myers {
-    ($DistType:ty, $Myers:ty, $State:ty, $TbHandler:ty) => {
+    ($DistType:ty, $max_dist:expr, $Myers:ty, $State:ty, $TbHandler:ty) => {
         mod myers_impl {
 // Macro implementing common methods in Myers object. Wrapped in a module
 // and then re-exported from there to avoid mixing of namespaces.
@@ -153,7 +153,7 @@ impl<T: BitVec> $Myers {
         C: Borrow<u8>,
         I: IntoIterator<Item = C>,
     {
-        let max_dist = <$DistType>::max_value();
+        let max_dist = $max_dist;
         let mut dist = max_dist;
         let m = self.m;
         let mut state = self.initial_state(m, max_dist);
@@ -179,7 +179,7 @@ impl<T: BitVec> $Myers {
         C: Borrow<u8>,
         I: IntoIterator<Item = C>,
     {
-        Matches::new(self, text.into_iter(), max_dist)
+        Matches::new(self, text.into_iter(), max_dist.min($max_dist))
     }
 
     /// Find the best match of the pattern in the given text.
@@ -189,7 +189,7 @@ impl<T: BitVec> $Myers {
         C: Borrow<u8>,
         I: IntoIterator<Item = C>,
     {
-        self.find_all_end(text, <$DistType>::max_value())
+        self.find_all_end(text, $max_dist)
             .min_by_key(|&(_, dist)| dist)
             .unwrap()
     }
@@ -209,7 +209,7 @@ impl<T: BitVec> $Myers {
         I: IntoIterator<Item = C>,
         I::IntoIter: ExactSizeIterator,
     {
-        FullMatches::new(self, text.into_iter(), max_dist)
+        FullMatches::new(self, text.into_iter(), max_dist.min($max_dist))
     }
 
     /// As `find_all_end`, this function returns an iterator over tuples of `(end, distance)`.
@@ -225,7 +225,7 @@ impl<T: BitVec> $Myers {
         I: IntoIterator<Item = C>,
         I::IntoIter: ExactSizeIterator,
     {
-        LazyMatches::new(self, text.into_iter(), max_dist)
+        LazyMatches::new(self, text.into_iter(), max_dist.min($max_dist))
     }
 }
 

--- a/src/pattern_matching/myers/simple.rs
+++ b/src/pattern_matching/myers/simple.rs
@@ -276,6 +276,7 @@ where
 
 impl_myers!(
     T::DistType,
+    T::DistType::max_value(),
     Myers<T>,
     crate::pattern_matching::myers::State<T, T::DistType>,
     crate::pattern_matching::myers::simple::ShortStatesHandler<'a>

--- a/src/pattern_matching/myers/simple.rs
+++ b/src/pattern_matching/myers/simple.rs
@@ -144,7 +144,7 @@ impl<'a, T: BitVec + 'a> StatesHandler<'a, T, T::DistType> for ShortStatesHandle
 
     #[inline]
     fn set_max_state(&self, pos: usize, states: &mut [State<T, T::DistType>]) {
-        states[pos] = State::max();
+        states[pos] = State::init_max_dist();
     }
 
     #[inline]
@@ -158,13 +158,18 @@ impl<'a, T: BitVec + 'a> StatesHandler<'a, T, T::DistType> for ShortStatesHandle
     }
 
     #[inline]
+    fn dist_at(&self, pos: usize, states: &[State<T, T::DistType>]) -> Option<T::DistType> {
+        states.get(pos).map(|s| s.dist)
+    }
+
+    #[inline]
     fn init_traceback(
         &self,
         m: T::DistType,
         pos: usize,
         states: &'a [State<T, T::DistType>],
-    ) -> Self::TracebackHandler {
-        ShortTracebackHandler::new(m, pos, states)
+    ) -> Option<Self::TracebackHandler> {
+        Some(ShortTracebackHandler::new(m, pos, states))
     }
 }
 

--- a/src/pattern_matching/myers/simple.rs
+++ b/src/pattern_matching/myers/simple.rs
@@ -4,7 +4,6 @@ use std::iter;
 use std::marker::PhantomData;
 use std::mem::{replace, size_of};
 use std::slice;
-use std::u64;
 
 use num_traits::{FromPrimitive, One, ToPrimitive, Zero};
 
@@ -219,18 +218,8 @@ where
     }
 
     #[inline]
-    fn block_mut(&mut self) -> &mut State<T, T::DistType> {
-        &mut self.state
-    }
-
-    #[inline]
     fn left_block(&self) -> &State<T, T::DistType> {
         &self.left_state
-    }
-
-    #[inline]
-    fn left_block_mut(&mut self) -> &mut State<T, T::DistType> {
-        &mut self.left_state
     }
 
     #[inline]

--- a/src/pattern_matching/myers/simple.rs
+++ b/src/pattern_matching/myers/simple.rs
@@ -8,7 +8,7 @@ use std::slice;
 use num_traits::{FromPrimitive, One, ToPrimitive, Zero};
 
 use crate::pattern_matching::myers::traceback::{StatesHandler, TracebackHandler};
-use crate::pattern_matching::myers::{BitVec, State};
+use crate::pattern_matching::myers::{word_size, BitVec, State};
 
 /// Myers algorithm.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -143,6 +143,11 @@ impl<'a, T: BitVec + 'a> StatesHandler<'a, T, T::DistType> for ShortStatesHandle
     }
 
     #[inline]
+    fn n_blocks(&self) -> usize {
+        1
+    }
+
+    #[inline]
     fn set_max_state(&self, pos: usize, states: &mut [State<T, T::DistType>]) {
         states[pos] = State::init_max_dist();
     }
@@ -177,22 +182,31 @@ type RevColIter<'a, T> = iter::Rev<slice::Iter<'a, State<T, <T as BitVec>::DistT
 
 pub(super) struct ShortTracebackHandler<'a, T: BitVec> {
     states_iter: iter::Chain<RevColIter<'a, T>, iter::Cycle<RevColIter<'a, T>>>,
-    state: State<T, T::DistType>,
-    left_state: State<T, T::DistType>,
+    // block representing the current TB matrix column
+    block: State<T, T::DistType>,
+    // block representing the TB matrix column to the left
+    left_block: State<T, T::DistType>,
+    // mask with one active bit indicating the position of the last letter
+    // TODO: not needed with padding
     max_mask: T,
-    pos_bitvec: T,
-    left_mask: T,
+    // mask with one active bit indicating the current position (row) in the current block
+    pos_mask: T,
+    // Bit mask that "covers" the range of positions *below* the left cell
+    // in the DP matrix. This is used used to initialize blocks
+    // (adjust the distance score) with `State::adjust_up_by(left_adj_mask)`.
+    left_adj_mask: T,
     _a: PhantomData<&'a ()>,
 }
 
 impl<'a, T: BitVec> ShortTracebackHandler<'a, T> {
     #[inline]
     fn new(m: T::DistType, pos: usize, states: &'a [State<T, T::DistType>]) -> Self {
-        let mask0 = T::one() << (m.to_usize().unwrap() - 1);
+        let pos_mask = T::one() << (m.to_usize().unwrap() - 1);
 
-        // Reverse iterator over states. If remembering all positions,
-        // the chain() and cycle() are not actually needed, but there seems
-        // to be almost no performance loss.
+        // reverse iterator over DP matrix columns
+        // chain + cycle is needed because `find_all` (`FullMatches` iterator)
+        // only stores m + max_dist states, and progressively cycles through the `states`.
+        // `LazyMatches` stores all states (cycle not actually needed, but performance loss small).
         let mut states_iter = states[..=pos]
             .iter()
             .rev()
@@ -201,15 +215,28 @@ impl<'a, T: BitVec> ShortTracebackHandler<'a, T> {
         // // Simpler alternative using skip() is slower in some cases:
         // let mut states = states.iter().rev().cycle().skip(states.len() - pos - 1);
 
+        let state = *states_iter.next().unwrap();
+
+        let mut left_state = *states_iter.next().unwrap();
+        left_state.adjust_one_up(pos_mask);
+        // *note*: this mask is initialized for the left state to be in the diagonal
+        let left_mask = pos_mask;
+
         ShortTracebackHandler {
-            state: *states_iter.next().unwrap(),
-            left_state: *states_iter.next().unwrap(),
+            block: state,
+            left_block: left_state,
             states_iter,
-            max_mask: mask0,
-            pos_bitvec: mask0,
-            left_mask: T::zero(),
+            max_mask: pos_mask,
+            pos_mask,
+            left_adj_mask: left_mask,
             _a: PhantomData,
         }
+    }
+
+    #[inline]
+    fn left_mask_up(&mut self) {
+        self.left_adj_mask = (self.left_adj_mask >> 1) | self.max_mask;
+        // println!("left {:064b}\nmax  {:064b}", self.left_mask, self.max_mask);
     }
 }
 
@@ -218,59 +245,73 @@ where
     T: BitVec + 'a,
 {
     #[inline]
-    fn block(&self) -> &State<T, T::DistType> {
-        &self.state
+    fn dist(&self) -> T::DistType {
+        self.block.dist
     }
 
     #[inline]
-    fn left_block(&self) -> &State<T, T::DistType> {
-        &self.left_state
+    fn left_dist(&self) -> T::DistType {
+        self.left_block.dist
     }
 
     #[inline]
-    fn pos_bitvec(&self) -> T {
-        self.pos_bitvec
-    }
-
-    #[inline]
-    fn move_up(&mut self, adjust_dist: bool) {
-        if adjust_dist {
-            self.state.adjust_dist(self.pos_bitvec);
-        }
-        self.pos_bitvec >>= 1;
-    }
-
-    #[inline]
-    fn move_up_left(&mut self, adjust_dist: bool) {
-        self.left_mask = (self.left_mask >> 1) | self.max_mask;
-        if adjust_dist {
-            self.left_state.adjust_dist(self.pos_bitvec);
-        }
-    }
-
-    #[inline]
-    fn move_to_left(&mut self) {
-        self.state = replace(&mut self.left_state, *self.states_iter.next().unwrap());
-        self.left_state.adjust_by_mask(self.left_mask);
-    }
-
-    #[inline]
-    fn move_left_down_if_better(&mut self) -> bool {
-        if self.left_state.mv & self.pos_bitvec != T::zero() {
-            self.left_state.dist -= T::DistType::one();
+    fn try_move_up(&mut self) -> bool {
+        if self.block.pv & self.pos_mask != T::zero() {
+            self.move_up();
             return true;
         }
         false
     }
 
     #[inline]
-    fn column_slice(&self) -> &[State<T, T::DistType>] {
-        std::slice::from_ref(&self.state)
+    fn move_up(&mut self) {
+        // (1) move up in current column
+        self.block.adjust_one_up(self.pos_mask);
+        self.pos_mask >>= 1;
+        // (2) move up in left column
+        self.left_mask_up();
+        self.left_block.adjust_one_up(self.pos_mask);
     }
 
     #[inline]
-    fn finished(&self) -> bool {
-        self.pos_bitvec == T::zero()
+    fn try_prepare_left(&mut self) -> bool {
+        if self.left_block.mv & self.pos_mask != T::zero() {
+            self.left_block.dist -= T::DistType::one();
+            return true;
+        }
+        false
+    }
+
+    #[inline]
+    fn prepare_diagonal(&mut self) {
+        self.left_mask_up();
+        self.pos_mask >>= 1;
+    }
+
+    #[inline]
+    fn finish_move_left(&mut self) {
+        self.block = replace(&mut self.left_block, *self.states_iter.next().unwrap());
+        self.left_block.adjust_up_by(self.left_adj_mask);
+    }
+
+    #[inline]
+    fn done(&self) -> bool {
+        self.pos_mask == T::zero()
+    }
+
+    fn print_state(&self) {
+        eprintln!(
+            "--- TB dist ({:?} <-> {:?})",
+            self.left_block.dist, self.block.dist
+        );
+        eprintln!(
+            " lm {:0width$b}\nleft {}\n  m {:0width$b}\ncurrent {}\n",
+            self.left_adj_mask,
+            self.left_block,
+            self.pos_mask,
+            self.block,
+            width = word_size::<T>()
+        );
     }
 }
 

--- a/src/pattern_matching/myers/traceback.rs
+++ b/src/pattern_matching/myers/traceback.rs
@@ -16,15 +16,18 @@ where
 {
     /// Object that helps obtaining a single traceback path
     type TracebackHandler: TracebackHandler<'a, T, D>;
-    /// Type that represents a column in the traceback matrix
+    /// Type that represents a column in the DP matrix
     type TracebackColumn: ?Sized;
 
     /// Prepare for a new search given n (maximum expected number of traceback columns) and
     /// m (pattern length).
     /// Returns the expected size of the vector storing the calculated blocks given this
-    /// information. The vector will then be initialized with the given number of 'empty'
+    /// information. The vector will then be initialized with the given number of
     /// State<T, D> objects and supplied to the other methods as slice.
     fn init(&mut self, n: usize, m: D) -> usize;
+
+    /// The max. number of blocks needed for a DP matrix column
+    fn n_blocks(&self) -> usize;
 
     /// Fill the column at `pos` with states initialized with the maximum distance
     /// (`State::init_max_dist()`). The leftmost column of the traceback matrix needs this.
@@ -50,130 +53,77 @@ where
     ) -> Option<Self::TracebackHandler>;
 }
 
-/// Objects implementing this trait should store states and have methods
-/// necessary for obtaining a single traceback path. This allows to use the
-/// same traceback code for the simple and the block-based Myers pattern
-/// matching approaches. It is designed to be as general as possible
-/// to allow different implementations.
+/// `TracebackHandler` objects assist with the computation of a traceback path.
+///  The trait is implemented both for the simple and the block-based algorithms.
 ///
-/// Implementors of `TracebackHandler` keep two `State<T, D>` instances,
-/// which store the information from two horizontally adjacent traceback
-/// columns, encoded in the PV / MV bit vectors. The columns are accessible
-/// using the methods `block()` (current / right column) and `left_block()`
-/// (left column). Moving horizontally to the next position can be achieved
-/// using `move_left()`.
+/// Implementors must keep track of two cells in the DP matrix:
+/// C = "current" cell
+/// L = "left" cell in the diagonal position
 ///
-/// Implementors also track the vertical cursor positions within the current
-/// traceback columns (two separate cursors for left and right column).
-/// `block()` and `left_block()` will always return the block that currently
-/// contain the cursors.
-/// `pos_bitvec()` returns a bit vector with a single activated bit at the current
-/// vertical position within the *right (current)* column.
-/// Moving to the next vertical position is achieved by `move_up()` and
-/// `move_up_left()`. With the block based implementation, this may involve
-/// switching to a new block.
+///   |————————————
+///   |   |   |   |
+///   |————————————
+///   |   | L |   |
+///   |————————————
+///   |   |   | C |
+///   |————————————
+///
+/// The idea behind this is, that diagonal moves in the DP matrix (= matches /
+/// substitutions) should be made as easy/fast as possible, while InDels
+/// are usually be less common (especially since there are no affine gap penalties)
+/// and upward/leftward moves can thus be more computationally intensive.
+///
+/// Implementors may store two `State<T, D>` blocks, whose `dist` field reflects
+/// the distance score of the current TB matrix cell, and along with that some auxiliary
+/// bit vectors indicating cursor position and assisting with adjustments to `dist` based
+/// deltas from the PV / MV bit vectors.
 pub(super) trait TracebackHandler<'a, T, D>
 where
     T: BitVec + 'a,
     D: DistType,
 {
-    /// Returns a reference to the current (right) block.
-    fn block(&self) -> &State<T, D>;
+    /// Returns the distance score of the current cell C(i, j).
+    fn dist(&self) -> D;
 
-    /// Returns a reference to the left block.
-    fn left_block(&self) -> &State<T, D>;
+    /// Returns the distance score of the left cell, which is in the diagonal
+    /// position, C(i-1, j-1).
+    fn left_dist(&self) -> D;
 
-    /// Bit vector representing the position in the traceback. Only the bit
-    /// at the current position should be on.
-    /// For a search pattern of length 4, the initial bit vector would be
-    /// `0b1000`. A call to `move_up_cursor()` will shift the vector, so another
-    /// call to `pos_bitvec()` results in `0b100`.
-    /// The bit vector has a width of `T`, meaning that it can store
-    /// the same number of positions as the PV and MV vectors. In the
-    /// case of the block based algorithm, the vector only stores the
-    /// position within the current block.
-    fn pos_bitvec(&self) -> T;
+    /// Checks if the cell to the left C(i, j-1) has a smaller distance score than
+    /// the current cell C(i, j). If so, it calls `move_up()`.
+    fn try_move_up(&mut self) -> bool;
 
-    /// Move up cursor by one position in traceback matrix.
-    ///
-    /// *Note concerning the block based Myers algorithm:*
-    /// The the active bit in bit vector returned by `pos_bitvec()`
-    /// is expected to jump back to the maximum (lowest) position
-    /// when reaching the uppermost position (like `rotate_right()` does).
-    ///
-    /// # Arguments
-    ///
-    /// * adjust_dist: If true, the distance score of the block is adjusted
-    ///   based on the current cursor position before moving it up.
-    fn move_up(&mut self, adjust_dist: bool);
+    /// Moves up by one position in the DP matrix, adjusting the
+    /// distance scores/blocks/bit masks for the current and left columns.
+    fn move_up(&mut self);
 
-    /// Move up left cursor by one position in traceback matrix.
-    ///
-    /// # Arguments
-    ///
-    /// * adjust_dist: If true, the distance score of the block is adjusted
-    ///   based on the current cursor position before moving it up.
-    ///   However, the current cursor position of the **right** block is used,
-    ///   **not** the one of the left block. This is an important oddity, which
-    ///   makes only sense because of the design of the traceback algorithm.
-    fn move_up_left(&mut self, adjust_dist: bool);
+    /// Checks if the cell to the left C(i-1, j) has a smaller distance score than
+    /// the cell in the diagonal C(i-1, j-1). If so, adjusts the score/block
+    /// for the left column and returns `true`.
+    /// The "current" block needs no adjustment, as it will be discarded in
+    /// `finish_move_left()`, which needs to be called afterwards to complete
+    /// the move.
+    fn try_prepare_left(&mut self) -> bool;
 
-    /// Shift the view by one traceback column / block to the left. The
-    /// block that was on the left position previously moves to the right /
-    /// current block without changes. The cursor positions have to be
-    /// adjusted indepentedently if necessary using `move_up(false)` /
-    /// `move_up_left(false)`.
-    /// `move_left()` adjusts distance score of the new left block to
-    /// be correct for the left vertical cursor position. It is therefore
-    /// important that the cursor is moved *before* calling `move_left()`.
-    fn move_to_left(&mut self);
+    /// Prepares for a diagonal move (which must be completed with `finish_move_left`).
+    /// Essentially, only bit masks and block indices need to be adjusted to
+    /// reflect the shift upwards by one position.
+    /// The blocks/distances themselves need no modification.
+    fn prepare_diagonal(&mut self);
 
-    /// Rather specialized method that allows having a simpler code in Traceback::_traceback_at()
-    /// Checks if the position below the left cursor has a smaller distance, and if so,
-    /// moves the cursor to this block and returns `true`.
-    ///
-    /// The problem is that the current implementation always keeps the left cursor in the
-    /// diagonal position for performance reasons. In this case, checking the actual left
-    /// distance score can be complicated with the block-based algorithm since the left cursor
-    /// may be at the lower block boundary. If so, the function thus has to check the topmost
-    /// position of the lower block and keep this block if the distance is better (lower).
-    fn move_left_down_if_better(&mut self) -> bool;
+    /// Complete a 'move' to the left by
+    /// (1) replacing the current column with the left one (same block and score)
+    /// (2) adding a new column to the left and adjusting the distance score
+    /// to reflect the diagonal position.
+    fn finish_move_left(&mut self);
 
-    /// Returns a slice containing all blocks of the current traceback column
-    /// from top to bottom. Used for debugging only.
-    fn column_slice(&self) -> &[State<T, D>];
-
-    /// Returns true if topmost position in the traceback matrix has been reached,
-    /// meaning that the traceback is complete.
-    /// Technically this means, that `move_up_cursor()` was called so many times
-    /// until the uppermost block was reached and the pos_bitvec() does not contain
-    /// any bit, since shifting has removed it from the vector.
-    fn finished(&self) -> bool;
+    /// Returns true if topmost DP matrix row has been reached,
+    /// meaning that the complete alignment path has been found.
+    fn done(&self) -> bool;
 
     /// For debugging only
     #[allow(dead_code)]
-    fn print_state(&self) {
-        println!(
-            "--- TB dist ({:?} <-> {:?})",
-            self.left_block().dist,
-            self.block().dist
-        );
-        println!(
-            "{:064b} m\n{:064b} + ({:?}) (left) d={:?}\n{:064b} - ({:?})\n \
-             {:064b} + ({:?}) (current) d={:?}\n{:064b} - ({:?})\n",
-            self.pos_bitvec(),
-            self.left_block().pv,
-            self.left_block().pv,
-            self.left_block().dist,
-            self.left_block().mv,
-            self.left_block().mv,
-            self.block().pv,
-            self.block().pv,
-            self.block().dist,
-            self.block().mv,
-            self.block().mv
-        );
-    }
+    fn print_state(&self);
 }
 
 #[derive(Clone, Debug)]
@@ -290,65 +240,75 @@ where
     ) -> Option<(D, D)> {
         use self::AlignmentOperation::*;
 
-        // Generic object that holds the necessary data and methods
-        let mut h = self.handler.init_traceback(self.m, pos, state_slice)?;
-
         // self.print_tb_matrix(pos, state_slice);
 
-        let ops = &mut ops;
+        // Generic object that holds the necessary data and methods
+        let mut h = self.handler.init_traceback(self.m, pos, state_slice)?;
 
         // horizontal column offset from starting point in traceback matrix (bottom right)
         let mut h_offset = D::zero();
 
         // distance of the match (will be returned)
-        let dist = h.block().dist;
-
-        // The cursor of the left state is always for diagonal position in the traceback matrix.
-        // This allows checking for a substitution by a simple comparison.
-        h.move_up_left(true);
+        let dist = h.dist();
 
         // Loop for finding the traceback path
-        // If there are several possible solutions, substitutions are preferred over InDels
-        // (Subst > Ins > Del)
-        while !h.finished() {
+        while !h.done() {
             let op;
-            // This loop is used to allow skipping `move_left()` using break (kind of similar
-            // to 'goto'). This was done to avoid having to inline move_left() three times,
+            // This loop is used to allow skipping `advance_left()` using break (kind of similar
+            // to 'goto'). This was done to avoid having to inline advance_left() three times,
             // which would use more space.
             #[allow(clippy::never_loop)]
             loop {
                 // h.print_state();
 
-                if h.left_block().dist.wrapping_add(&D::one()) == h.block().dist {
-                    // Diagonal (substitution)
+                // If there are several possible solutions, substitutions are preferred over InDels
+                // (Subst > Ins > Del)
+                if h.left_dist().wrapping_add(&D::one()) == h.dist() {
+                    // Diagonal (substitution), move up
                     // Since the left cursor is always in the upper diagonal position,
                     // a simple comparison of distances is enough to determine substitutions.
-                    h.move_up(false);
-                    h.move_up_left(false);
+                    h.prepare_diagonal();
                     op = Subst;
-                } else if h.block().pv & h.pos_bitvec() != T::zero() {
-                    // Up
-                    h.move_up(true);
-                    h.move_up_left(true);
+                    // then, move to left (below)
+                } else if h.try_move_up() {
+                    // Up (insertion to target = deletion in query pattern)
                     op = Ins;
                     break;
-                } else if h.move_left_down_if_better() {
-                    // Left
+                } else if h.try_prepare_left() {
+                    // Left (deletion in target text = insertion to query pattern)
                     op = Del;
+                    // then, move to left (below)
                 } else {
-                    // Diagonal (match)
-                    h.move_up(false);
-                    h.move_up_left(false);
+                    // Diagonal (match), move up
+                    debug_assert!(h.left_dist() == h.dist());
+                    h.prepare_diagonal();
                     op = Match;
+                    // then, move to left (below)
                 }
 
-                // Moving one position to the left, adjusting h_offset
+                // // This is (probably) equivalent to the Edlib strategy (Ins > Del > Subst)
+                // // Tests succeed with this strategy as well, and performance is similar.
+                // if h.try_move_up() {
+                //     op = Ins;
+                //     break;
+                // } else if h.left_dist() == h.dist() && h.try_prepare_left() {
+                //     op = Del;
+                // } else {
+                //     h.prepare_diagonal();
+                //     op = if h.left_dist().wrapping_add(&D::one()) == h.dist() {
+                //         Subst
+                //     } else {
+                //         Match
+                //     };
+                // }
+
+                // Moving one column to the left, adjusting h_offset
                 h_offset += D::one();
-                h.move_to_left();
+                h.finish_move_left();
                 break;
             }
 
-            // println!("{:?}", op);
+            // dbg!(op);
 
             if let Some(o) = ops.as_mut() {
                 o.push(op);
@@ -361,46 +321,55 @@ where
     // Useful for debugging
     #[allow(dead_code)]
     fn print_tb_matrix(&self, pos: usize, state_slice: &'a [State<T, D>]) {
-        let mut h = self
-            .handler
-            .init_traceback(self.m, pos, state_slice)
-            .unwrap();
+        let n_blocks = self.handler.n_blocks();
+        let pos = n_blocks * (pos + 1);
+        let states_iter = state_slice[..pos]
+            .chunks(n_blocks)
+            .rev()
+            .chain(state_slice.chunks(n_blocks).rev().cycle());
         let m = self.m.to_usize().unwrap();
         let mut out = vec![];
-        for _ in 0..state_slice.len() {
-            let mut col_out = vec![];
+        for col in states_iter {
+            let mut col_out = Vec::with_capacity(m);
             let mut empty = true;
-            for (i, state) in h.column_slice().iter().enumerate().rev() {
-                if !(state.is_new() || state.is_max()) {
+            for (i, block) in col.iter().enumerate().rev() {
+                if !(block.is_new() || block.is_max()) {
                     empty = false;
                 }
                 let w = word_size::<T>();
                 let end = (i + 1) * w;
-                let n = if end <= m { w } else { m % w };
-                state.write_dist_column(n, &mut col_out);
+                let _m = if end <= m { w } else { m % w };
+                let mut _block = *block;
+                let mut pos_mask = T::one() << (_m - 1);
+                col_out.push(_block.dist);
+                for _ in 0.._m {
+                    // println!("{}\n{:064b}", _block, pos_mask);
+                    _block.adjust_one_up(pos_mask);
+                    pos_mask >>= 1;
+                    col_out.push(_block.dist);
+                }
             }
             out.push(col_out);
-            h.move_to_left();
             if empty {
                 break;
             }
         }
 
         for j in (0..m).rev() {
-            print!("{:>4}: ", m - j + 1);
+            eprint!("{:>4}: ", m - j + 1);
             for col in out.iter().rev() {
                 if let Some(d) = col.get(j) {
                     if *d >= (D::max_value() >> 1) {
                         // missing value
-                        print!("    ");
+                        eprint!("    ");
                     } else {
-                        print!("{:>4?}", d);
+                        eprint!("{:>4?}", d);
                     }
                 } else {
-                    print!("   -");
+                    eprint!("   -");
                 }
             }
-            println!();
+            eprintln!();
         }
     }
 }

--- a/src/pattern_matching/myers/traceback.rs
+++ b/src/pattern_matching/myers/traceback.rs
@@ -222,15 +222,7 @@ where
         };
 
         // extend or truncate states vector
-        let curr_len = states.len();
-        if n_states > curr_len {
-            states.reserve(n_states);
-            states.extend((0..n_states - curr_len).map(|_| State::default()));
-        } else {
-            states.truncate(n_states);
-            states.shrink_to_fit();
-        }
-        debug_assert!(states.len() == n_states);
+        states.resize_with(n_states, Default::default);
 
         // first column is used to ensure a correct path if the text (target)
         // is shorter than the pattern (query)

--- a/src/pattern_matching/myers/traceback.rs
+++ b/src/pattern_matching/myers/traceback.rs
@@ -70,14 +70,8 @@ where
     /// Returns a reference to the current (right) block.
     fn block(&self) -> &State<T, D>;
 
-    /// Returns a mutable reference to the current (right) block.
-    fn block_mut(&mut self) -> &mut State<T, D>;
-
     /// Returns a reference to the left block.
     fn left_block(&self) -> &State<T, D>;
-
-    /// Returns a mutable reference to the left block.
-    fn left_block_mut(&mut self) -> &mut State<T, D>;
 
     /// Bit vector representing the position in the traceback. Only the bit
     /// at the current position should be on.
@@ -92,14 +86,15 @@ where
 
     /// Move up cursor by one position in traceback matrix.
     ///
+    /// *Note concerning the block based Myers algorithm:*
+    /// The the active bit in bit vector returned by `pos_bitvec()`
+    /// is expected to jump back to the maximum (lowest) position
+    /// when reaching the uppermost position (like `rotate_right()` does).
+    /// 
     /// # Arguments
     ///
     /// * adjust_dist: If true, the distance score of the block is adjusted
     ///   based on the current cursor position before moving it up.
-    ///  *Note concerning the block based Myers algorithm:*
-    ///  The the active bit in bit vector returned by `pos_bitvec()`
-    ///  is expected to jump back to the maximum (lowest) position
-    ///  when reaching the uppermost position (like `rotate_right()` does).
     fn move_up(&mut self, adjust_dist: bool);
 
     /// Move up left cursor by one position in traceback matrix.
@@ -146,6 +141,7 @@ where
     fn finished(&self) -> bool;
 
     /// For debugging only
+    #[allow(dead_code)]
     fn print_state(&self) {
         println!(
             "--- TB dist ({:?} <-> {:?})",

--- a/src/pattern_matching/ukkonen.rs
+++ b/src/pattern_matching/ukkonen.rs
@@ -67,7 +67,7 @@ where
         pattern: TextSlice<'a>,
         text: T,
         k: usize,
-    ) -> Matches<'_, F, C, T::IntoIter>
+    ) -> Matches<'a, F, C, T::IntoIter>
     where
         C: Borrow<u8>,
         T: IntoIterator<Item = C>,

--- a/src/pattern_matching/ukkonen.rs
+++ b/src/pattern_matching/ukkonen.rs
@@ -4,10 +4,10 @@
 // except according to those terms.
 
 //! Bounded version of Ukkonens DP algorithm for approximate pattern matching.
-//! Complexity: O(n * k) on random texts.
+//! Complexity: O(n * k) on random texts of length n.
 //!
 //! The algorithm finds all matches of a pattern in a text with up to k errors.
-//! Idea is to use dynamic programming to column-wise explore the edit matrix, but to omit
+//! The idea is to use dynamic programming to column-wise explore the edit matrix, but to omit
 //! parts of the matrix for which the error exceeds k. To achieve this, a value `lastk` is
 //! maintained that provides the lower feasible boundary of the matrix.
 //! Initially, lastk = min(k, m). In each iteration (over a column), lastk can increase by at most 1.


### PR DESCRIPTION
This PR includes some changes to the `bio::pattern_matching::myers` code. The initial motivation was to improve the [pattern matching feature](https://markschl.github.io/seqtool-docs/find/#approximate-matching) in [this](https://github.com/markschl/seqtool) sequence handling tool, but I ended up also including some code from refactoring efforts that I actually started some years ago already.

Summary:

* Added a `LazyMatches::dist_at()` method complementing the already existing `hit_at`, `path_at`, etc. (e318e4cb1b2e4223d969146ce78e8d24a1b8f688)
* Refactoring of code that computes the alignment path (traceback) with the aim to make it more understandable (f8d1f8969ad93338bce9f0ba077ab54d5e8a1775, 53d177b834bc560f85de28f2f9395125d17228b7, be1e35cd699b168fcde857b6bf395a5066aad576). The methods of the `TracebackHandler` trait were changed (code re-grouped), but the behaviour should not have changed (alignment paths found to be correct with fuzzing). In addition, there are many additional doc comments, and some more references to the Myers paper. A small deviation from the original implementation in `long.rs` (no padding with wildcards) is more clearly documented. I looked at this again, but I can't find any issues with it. The fact that the simple and block-based implementation yield the same results (with fuzzing, comparing single u64 or u128 with multi-u8 block version) further suggests there are no issues with this code.
* The fuzzing code was extended to also test ambiguities and wildcards and include a comparison to Edlib (commented out to avoid introducing another dependency) (f8d1f8969ad93338bce9f0ba077ab54d5e8a1775)
* Fixed two small bugs:
    1. Fix panic in `LazyMatches::...at()` methods if called with an end position for a match with distance > k (e318e4cb1b2e4223d969146ce78e8d24a1b8f688)
    2. fixed panics with very large `max_dist` (`...::long::Myers::distance()` did always panic) (5445989d491eff48d79e9e2d15b87d60f3c5aaed)
* Updated the documentation, also improving the module descriptions, which were partly outdated (not adapted to the block-based implementation) (1d39dec02652eed0ea1a9494e410e6d778970f0e). A small change to the `ukkonen` docs was also made (1a7432d5a800e0961fda07058c9b1b4aeeb93f4e)
* Some performance evaluations (thereby simplifying the benchmark code, 47f8fe6d2bb0f4b81ae7ae8b6f88c5cce2d6d7b9), added some `#[inline]` (b383561f7e4d0bf693b9d7a87398c7b7a675321c), although I had to remove one again due to some performance regression I don't fully understand (694f57333168db911ee79cf194a7732d4b0846c0). Bottom line: `Myers::find_all()` appears faster now, everything else is equally fast.
* Fixed some small warnings in other `pattern_matching` modules (298b1f97ed6ccdc1da3c959ed670280fe215e169). I checked that it compiles under Rust 1.65.0, although I had to downgrade to multimap 0.10.0 for this.
* Updated the copyright notice in mod.rs with my name (1d39dec02652eed0ea1a9494e410e6d778970f0e) (hopefully fine like this, otherwise I can adjust)

Possible remaining issues.
* The inlining of `fn next...()` is now a little inconsistent, unfortunately (due to 694f57333168db911ee79cf194a7732d4b0846c0)
* I'm not entirely sure if the term *linear-time* in `pattern_matching/mod.rs` still applies for the block-based algorithm, which is O(nk). Only if k does not change, then time scales linearly with pattern length (which would also qualify the Ukkonen algorithm as being linear-time).

Thanks for considering this PR!