### PR TITLE
refactor: Clippy warnings caused by legacy numeric constants

### DIFF
--- a/src/alignment/pairwise/banded.rs
+++ b/src/alignment/pairwise/banded.rs
@@ -82,8 +82,8 @@
 
 use crate::alignment::{Alignment, AlignmentOperation};
 use crate::utils::TextSlice;
-use std::cmp::{max, min, Ordering};
 use i32;
+use std::cmp::{max, min, Ordering};
 use std::ops::Range;
 
 use super::*;

--- a/src/alignment/pairwise/banded.rs
+++ b/src/alignment/pairwise/banded.rs
@@ -83,7 +83,7 @@
 use crate::alignment::{Alignment, AlignmentOperation};
 use crate::utils::TextSlice;
 use std::cmp::{max, min, Ordering};
-use std::i32;
+use i32;
 use std::ops::Range;
 
 use super::*;

--- a/src/alignment/pairwise/mod.rs
+++ b/src/alignment/pairwise/mod.rs
@@ -151,7 +151,7 @@
 //! ```
 
 use std::cmp::max;
-use std::i32;
+use i32;
 use std::iter::repeat;
 
 use crate::alignment::{Alignment, AlignmentMode, AlignmentOperation};

--- a/src/alignment/pairwise/mod.rs
+++ b/src/alignment/pairwise/mod.rs
@@ -150,8 +150,8 @@
 //! );
 //! ```
 
-use std::cmp::max;
 use i32;
+use std::cmp::max;
 use std::iter::repeat;
 
 use crate::alignment::{Alignment, AlignmentMode, AlignmentOperation};

--- a/src/data_structures/qgram_index.rs
+++ b/src/data_structures/qgram_index.rs
@@ -57,7 +57,7 @@ impl QGramIndex {
         I: Iterator<Item = &'a u8> + ExactSizeIterator + Clone,
         T: IntoIterator<Item = &'a u8, IntoIter = I> + Sized,
     {
-        QGramIndex::with_max_count(q, text, alphabet, std::usize::MAX)
+        QGramIndex::with_max_count(q, text, alphabet, usize::MAX)
     }
 
     /// Create a new q-gram index, only considering q-grams that occur at most `max_count` times.

--- a/src/data_structures/suffix_array.rs
+++ b/src/data_structures/suffix_array.rs
@@ -267,13 +267,13 @@ pub fn suffix_array(text: &[u8]) -> RawSuffixArray {
     let mut sais = Sais::new(n);
 
     match alphabet.len() + sentinel_count {
-        a if a <= std::u8::MAX as usize => {
+        a if a <= u8::MAX as usize => {
             sais.construct(&transform_text::<u8>(text, &alphabet, sentinel_count))
         }
-        a if a <= std::u16::MAX as usize => {
+        a if a <= u16::MAX as usize => {
             sais.construct(&transform_text::<u16>(text, &alphabet, sentinel_count))
         }
-        a if a <= std::u32::MAX as usize => {
+        a if a <= u32::MAX as usize => {
             sais.construct(&transform_text::<u32>(text, &alphabet, sentinel_count))
         }
         _ => sais.construct(&transform_text::<u64>(text, &alphabet, sentinel_count)),
@@ -626,11 +626,11 @@ impl Sais {
 
         let lms_substring_count = self.lms_pos.len();
 
-        if lms_substring_count <= std::u8::MAX as usize {
+        if lms_substring_count <= u8::MAX as usize {
             self.sort_lms_suffixes::<T, u8>(text, pos_types, lms_substring_count);
-        } else if lms_substring_count <= std::u16::MAX as usize {
+        } else if lms_substring_count <= u16::MAX as usize {
             self.sort_lms_suffixes::<T, u16>(text, pos_types, lms_substring_count);
-        } else if lms_substring_count <= std::u32::MAX as usize {
+        } else if lms_substring_count <= u32::MAX as usize {
             self.sort_lms_suffixes::<T, u32>(text, pos_types, lms_substring_count);
         } else {
             self.sort_lms_suffixes::<T, u64>(text, pos_types, lms_substring_count);

--- a/src/pattern_matching/myers/long.rs
+++ b/src/pattern_matching/myers/long.rs
@@ -14,7 +14,7 @@ use std::iter;
 use std::marker::PhantomData;
 use std::mem::replace;
 use std::slice;
-use std::u64;
+use u64;
 
 use itertools::Itertools;
 use num_traits::ToPrimitive;
@@ -69,7 +69,7 @@ impl<T: BitVec> Myers<T> {
         let pattern = pattern.into_iter();
         let m = pattern.len();
         assert!(m > 0, "Pattern is empty");
-        assert!(m <= usize::max_value() / 2, "Pattern too long");
+        assert!(m <= usize::MAX / 2, "Pattern too long");
 
         // build peq
         let mut peq = vec![];
@@ -304,7 +304,7 @@ where
             // we initialize the block below the last computed block with meaningful
             // defaults.
             states[pos + source.len()] = State {
-                dist: usize::max_value(),
+                dist: usize::MAX,
                 pv: T::zero(),
                 mv: T::zero(),
             };

--- a/src/pattern_matching/myers/simple.rs
+++ b/src/pattern_matching/myers/simple.rs
@@ -4,7 +4,7 @@ use std::iter;
 use std::marker::PhantomData;
 use std::mem::{replace, size_of};
 use std::slice;
-use std::u64;
+use u64;
 
 use num_traits::{FromPrimitive, One, ToPrimitive, Zero};
 

--- a/src/pattern_matching/pssm/dnamotif.rs
+++ b/src/pattern_matching/pssm/dnamotif.rs
@@ -5,8 +5,7 @@
 
 use super::*;
 use ndarray::prelude::Array2;
-use std::f32;
-use std::f32::{INFINITY, NEG_INFINITY};
+use f32;
 
 /// Position-specific scoring matrix for DNA sequences
 #[derive(Default, Clone, PartialEq, Debug)]
@@ -63,7 +62,7 @@ impl DNAMotif {
         self.min_score = 0.0;
         for i in 0..pssm_len {
             // can't use the regular min/max on f32, so we use f32::min
-            let min_sc = (0..4).map(|b| self.scores[[i, b]]).fold(INFINITY, f32::min);
+            let min_sc = (0..4).map(|b| self.scores[[i, b]]).fold(f32::INFINITY, f32::min);
             self.min_score += min_sc;
         }
 
@@ -72,7 +71,7 @@ impl DNAMotif {
         for i in 0..pssm_len {
             let max_sc = (0..4)
                 .map(|b| self.scores[[i, b]])
-                .fold(NEG_INFINITY, f32::max);
+                .fold(f32::NEG_INFINITY, f32::max);
             self.max_score += max_sc;
         }
     }

--- a/src/pattern_matching/pssm/dnamotif.rs
+++ b/src/pattern_matching/pssm/dnamotif.rs
@@ -4,8 +4,8 @@
 // except according to those terms.
 
 use super::*;
-use ndarray::prelude::Array2;
 use f32;
+use ndarray::prelude::Array2;
 
 /// Position-specific scoring matrix for DNA sequences
 #[derive(Default, Clone, PartialEq, Debug)]
@@ -62,7 +62,9 @@ impl DNAMotif {
         self.min_score = 0.0;
         for i in 0..pssm_len {
             // can't use the regular min/max on f32, so we use f32::min
-            let min_sc = (0..4).map(|b| self.scores[[i, b]]).fold(f32::INFINITY, f32::min);
+            let min_sc = (0..4)
+                .map(|b| self.scores[[i, b]])
+                .fold(f32::INFINITY, f32::min);
             self.min_score += min_sc;
         }
 

--- a/src/pattern_matching/pssm/mod.rs
+++ b/src/pattern_matching/pssm/mod.rs
@@ -33,7 +33,6 @@
 //!        ].as_ref(), None).unwrap();
 
 use std::borrow::Borrow;
-use std::f32::NEG_INFINITY;
 
 use itertools::Itertools;
 use ndarray::prelude::*;
@@ -65,7 +64,7 @@ impl Default for ScoredPos {
     fn default() -> ScoredPos {
         ScoredPos {
             loc: 0,
-            sum: NEG_INFINITY,
+            sum: f32::NEG_INFINITY,
             scores: Vec::new(),
         }
     }

--- a/src/pattern_matching/pssm/protmotif.rs
+++ b/src/pattern_matching/pssm/protmotif.rs
@@ -4,8 +4,8 @@
 // except according to those terms.
 
 use super::*;
-use ndarray::prelude::Array2;
 use f32;
+use ndarray::prelude::Array2;
 
 /// Position-specific scoring matrix for protein sequences
 #[derive(Default, Clone, PartialEq, Debug)]

--- a/src/pattern_matching/pssm/protmotif.rs
+++ b/src/pattern_matching/pssm/protmotif.rs
@@ -5,8 +5,7 @@
 
 use super::*;
 use ndarray::prelude::Array2;
-use std::f32;
-use std::f32::{INFINITY, NEG_INFINITY};
+use f32;
 
 /// Position-specific scoring matrix for protein sequences
 #[derive(Default, Clone, PartialEq, Debug)]
@@ -66,7 +65,7 @@ impl ProtMotif {
             // can't use the regular min/max on f32, so we use f32::min
             let min_sc = (0..20)
                 .map(|b| self.scores[[i, b]])
-                .fold(INFINITY, f32::min);
+                .fold(f32::INFINITY, f32::min);
             self.min_score += min_sc;
         }
 
@@ -75,7 +74,7 @@ impl ProtMotif {
         for i in 0..pssm_len {
             let max_sc = (0..20)
                 .map(|b| self.scores[[i, b]])
-                .fold(NEG_INFINITY, f32::max);
+                .fold(f32::NEG_INFINITY, f32::max);
             self.max_score += max_sc;
         }
     }

--- a/src/stats/pairhmm/homopolypairhmm.rs
+++ b/src/stats/pairhmm/homopolypairhmm.rs
@@ -69,7 +69,7 @@ use std::fmt::Debug;
 use std::iter::once;
 use std::mem;
 use std::ops::Shr;
-use std::usize;
+use usize;
 
 use enum_map::{Enum, EnumMap};
 use itertools::Itertools;

--- a/src/stats/pairhmm/pairhmm.rs
+++ b/src/stats/pairhmm/pairhmm.rs
@@ -14,7 +14,7 @@
 
 use std::cmp;
 use std::mem;
-use std::usize;
+use usize;
 
 pub use crate::stats::pairhmm::{EmissionParameters, GapParameters, StartEndGapParameters};
 use crate::stats::LogProb;


### PR DESCRIPTION
I noticed some Clippy warnings being caused by the use of legacy numeric constants. 

I wrote about this in an issue I opened here: https://github.com/rust-bio/rust-bio/issues/643

I think fixing these kinds of issues would be good in case some of the legacy constants and methods are deprecated in a future version of Rust.

More info about this Clippy: https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants

In short, I made these kinds of changes:

- Removing std from numeric constants. Ex: std::usize::MAX -> usize::MAX
- Removing std from imports of numeric constants. Ex: use std::u8 -> use u8

The only Clippy warnings left concerning legacy numeric methods are those found by the use of <$DistType>::max_value() in lines 149 and 185 in src/pattern_matching/myers/myers_impl.rs

Please let me know if any changes should be made to the branch, thanks!