### PR TITLE
docs(fmindex): document the mandatory terminal sentinel

### DIFF
--- a/src/data_structures/fmindex.rs
+++ b/src/data_structures/fmindex.rs
@@ -6,6 +6,17 @@
 //! The [Full-text index in Minute space index (FM-index)](https://doi.org/10.1109/SFCS.2000.892127) and
 //! the FMD-Index for finding suffix array intervals matching a given pattern in linear time.
 //!
+//! # Sentinel requirement
+//!
+//! The text that the underlying suffix array and BWT are built on **must end
+//! with a sentinel symbol** that is lexicographically smaller than every other
+//! symbol and does not occur anywhere else in the text. By convention this is
+//! the `$` character (see [`crate::data_structures::suffix_array::suffix_array`]).
+//! Searching an index built from a text without a trailing sentinel
+//! (e.g. a raw FASTA sequence) silently returns wrong results rather than
+//! erroring, so make sure to append the sentinel before constructing the index.
+//! Multiple sentinels are allowed when concatenating several sequences.
+//!
 //! # Examples
 //!
 //! ## Generate
@@ -109,6 +120,11 @@ pub trait FMIndexable {
     /// not exist.  If none of the pattern can be matched, the `BackwardSearchResult` is
     /// `Absent`.
     /// Complexity: O(m).
+    ///
+    /// Note: the index must have been built from a text ending with a sentinel
+    /// symbol (`$`, lexicographically smallest and not occurring elsewhere). An
+    /// index built from a text without a trailing sentinel yields wrong results
+    /// silently. See the [module-level documentation](self) for details.
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
Closes #495.

## Problem

As reported in #495, building an FM-index / suffix array / BWT requires the text to end with a sentinel symbol (`$`, lexicographically smallest, not occurring elsewhere in the text). Every example in the docs uses it, but it is never stated as a *requirement*. Worse, an index built from a text without a trailing sentinel (e.g. a raw FASTA sequence) returns **wrong results silently** rather than erroring — the reporter lost about an hour to this.

## Change

Documentation only, no behaviour change:

- Add a "Sentinel requirement" section to the `fmindex` module docs, explaining the requirement, the silent-failure mode, and that multiple sentinels are allowed for concatenated sequences.
- Add a note to `backward_search` (where the confusion actually surfaces), linking back to the module docs.

`suffix_array`'s `# Arguments` already documents the sentinel, so this fills the gap on the FM-index side where users actually hit it.

## Verification

- `cargo test --doc fmindex` → 5 passed, 0 failed
- `cargo fmt --check` clean; no new rustdoc warnings from these additions