### PR TITLE
docs(poa): document that the aligner uses linear gaps and ignores gap_extend

### DIFF
--- a/src/alignment/poa.rs
+++ b/src/alignment/poa.rs
@@ -16,6 +16,15 @@
 //! For a modern reference implementation, see poapy:
 //! <https://github.com/ljdursi/poapy>
 //!
+//! # Gap scoring
+//!
+//! This aligner uses a **linear** gap penalty: every gap column costs
+//! `Scoring::gap_open`, and `Scoring::gap_extend` is currently ignored. Although
+//! it takes the same [`Scoring`] type as the
+//! `pairwise` aligner (which implements affine gaps), passing a non-trivial
+//! `gap_extend` here has no effect on the result. See
+//! <https://github.com/rust-bio/rust-bio/issues/677>.
+//!
 //! # Example
 //!
 //! ```
@@ -281,6 +290,9 @@ pub struct Aligner<F: MatchFunc> {
 
 impl<F: MatchFunc> Aligner<F> {
     /// Create new instance.
+    ///
+    /// Note: only `scoring.gap_open` is used; gaps are scored linearly and
+    /// `scoring.gap_extend` is ignored (see the [module docs](self#gap-scoring)).
     pub fn new(scoring: Scoring<F>, reference: TextSlice) -> Self {
         Aligner {
             traceback: Traceback::new(),


### PR DESCRIPTION
Refs #677.

## Context

As reported in #677, `poa::Aligner` takes a `Scoring` (built with `Scoring::new(gap_open, gap_extend, match_fn)`) but never reads `gap_extend` — `grep gap_extend src/alignment/poa.rs` returns nothing. Every gap column costs `gap_open`, i.e. a **linear** gap penalty, so tuning `gap_extend` has no effect. This is surprising precisely because the `pairwise` aligner shares the same `Scoring` type and *does* implement affine gaps.

## This PR

Documentation only — it makes the current limitation explicit instead of silent:

- a "Gap scoring" section in the module docs,
- a note on `Aligner::new`,

both stating that only `gap_open` is used and `gap_extend` is ignored, and linking to #677.

## Why docs first

Implementing affine gaps in the POA dynamic program (a Gotoh-style extra state propagated across the graph) is a substantial change worth doing separately. Making the behaviour discoverable is a safe, immediately useful first step so users stop silently getting linear-gap results while passing an affine `gap_extend`. Happy to follow up with the affine implementation if you'd like — let me know your preference.

## Verification

- `cargo test --doc poa` → passes
- `cargo fmt --check` and `cargo doc` clean (no new warnings)