### PR TITLE
fix: cap ordered-float below 5.5 to preserve MSRV 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde_derive = "1.0"
 approx = ">=0.3, <0.6"
 custom_derive = "0.1"
 newtype_derive = "0.1"
-ordered-float = "5.0"
+ordered-float = ">=5.0, <5.5"
 regex = { version = "1.3", default-features = false, features = ["std", "perf"] }
 multimap = ">=0.6, <0.11"
 fxhash = "0.2"


### PR DESCRIPTION
ordered-float 5.5.0 (released recently) requires rustc 1.90, which breaks the MSRV job (pinned to 1.87.0) on any fresh resolution — master CI is currently red because of it, and #680 is blocked on the same failing check despite being approved.

This caps the requirement to `>=5.0, <5.5` so resolution picks 5.4.0 (rust-version 1.63), following the same convention already used for `statrs` and `enum-map`. Verified locally: resolution selects 5.4.0 and `cargo check --all` passes.

Alternative would be bumping MSRV to 1.90 — happy to do that instead if you prefer.